### PR TITLE
The second delta is in, and it roughly doubles the line estimate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+  // The Java language server is disabled here on purpose.
+  //
+  // These folders each contain a pinned *reference clone* of a large Java project: 2,489 .java
+  // files in gatk/, 1,181 in htsjdk/, 733 in picard/. The extension tries to index all of it,
+  // which is where the several hundred percent CPU and ~2.6 GB of resident memory came from.
+  //
+  // Nothing here is a Java project being edited. The Java is read as the source of truth for a
+  // Rust port, and reading it needs a text editor, not a language server. Disabling this is
+  // reversible: set "java.server.launchMode" back to "Standard" or remove this file.
+  "java.server.launchMode": "Disabled",
+  "java.import.gradle.enabled": false,
+  "java.import.maven.enabled": false,
+  "java.autobuild.enabled": false,
+
+  // Belt and braces: even in LightWeight mode, keep the reference clones out of any indexer.
+  "java.import.exclusions": [
+    "**/gatk/**",
+    "**/picard/**",
+    "**/htsjdk/**"
+  ],
+  "files.watcherExclude": {
+    "**/gatk/**": true,
+    "**/picard/**": true,
+    "**/htsjdk/**": true,
+    "**/target/**": true
+  },
+  "search.exclude": {
+    "**/target/**": true
+  }
+}

--- a/docs/sizing-from-the-measured-delta.md
+++ b/docs/sizing-from-the-measured-delta.md
@@ -7,8 +7,10 @@ number rather than from a story.
 
 ## What was measured
 
-`picard-rs/docs/decisions/0002` reports the first within-stratum delta. Two stratum-mates,
-ported over identical inputs so shared machinery is visible:
+Two within-stratum pairs, one at each end of the size distribution, each ported over identical
+inputs so that shared machinery is visible.
+
+**The small end** (`picard-rs/docs/decisions/0002`):
 
 | | Java ported | Rust written (non-test) | ratio |
 |---|---:|---:|---:|
@@ -16,8 +18,20 @@ ported over identical inputs so shared machinery is visible:
 | `MeanQualityByCycle` | 385 | 151 | **0.39** |
 | `CollectBaseDistributionByCycle` | 291 | 169 | **0.58** |
 
-The second member cost *more* per line than the first. The amortisation is real but it is
-**~18% of the second member's cost**, not the near-zero the plan's model implied.
+**The large end** (`picard-rs/docs/decisions/0003`), the measurement this document previously
+asked for:
+
+| | Java ported | Rust written (non-test) | ratio |
+|---|---:|---:|---:|
+| `CollectInsertSizeMetrics` | 526 | 399 | **0.76** |
+| `CollectAlignmentSummaryMetrics` | 1217 | 1030 | **0.85** |
+
+Counting the new shared machinery the second member forced into `htsjdk-rs` — alignment blocks,
+IUPAC base comparison, the FASTA reader, a histogram key-union fix, about 190 further lines —
+the second member cost **1.00 Rust lines per Java line**.
+
+In both pairs the second member cost **more** per Java line than the first. The archetype delta
+is negative at both ends of the one stratum where the hypothesis was most likely to hold.
 
 ## The corpus to be ported
 
@@ -30,15 +44,22 @@ Main source only, excluding tests, at the pinned tags:
 | GATK 4.6.2.0 | 1,589 | 292,297 |
 | **total** | **2,880** | **515,668** |
 
-## What that implies
+## What that implies, revised
 
-At the measured **0.39 to 0.58 Rust lines per Java line**, ported main source alone comes to
-roughly **200,000 to 300,000 lines of Rust**.
+The earlier revision of this document used the small-end pair's **0.39 to 0.58** and arrived at
+200,000 to 300,000 lines of Rust for the ported main source. That was too low, and the reason is
+now visible: the small-end pair's tools are small *because* they do little, and a tool that does
+little has a low ratio. The large-end pair, which is where most of the corpus's lines actually
+live, runs at **0.76 to 1.00**.
 
-The tests are not a rounding error on top of that. Across the four collectors ported so far,
+Weighting by where the lines are rather than by where the first measurement happened to land,
+the ported main source comes to roughly **390,000 to 515,000 lines of Rust**, not 200,000 to
+300,000. **The line estimate roughly doubles.**
+
+The tests are not a rounding error on top of that. Across the five collectors ported so far,
 test code has run between **50% and 95%** of the port's own size, and that is *before* the
 t-wise covering arrays and coverage-guided fuzzing the plan commits to. Taking the low end,
-total output is on the order of **300,000 to 500,000 lines**.
+total output is on the order of **600,000 to 900,000 lines**.
 
 Two things that number does **not** include, and both are large:
 
@@ -49,15 +70,44 @@ Two things that number does **not** include, and both are large:
   cost hours and changed almost no lines: the `EnumMap` iteration order is one line; the FPU's
   NaN sign is zero lines. Line counts measure typing, and typing is not where this work lives.
 
+## What replaces the archetype model
+
+The plan's model was "port the shape once, then pay a small delta per member". Two measurements
+now say something narrower and more useful:
+
+> **The per-member cost tracks the member's own Java footprint, at 0.76 to 1.00 Rust lines per
+> Java line. The stratum predicts almost nothing beyond that.**
+
+The stratum signals turn out to describe the plumbing — how records arrive (`single_pass`),
+whether the output has a histogram section (`histogram`), which base class the bean extends
+(`multi_level`) — and all of that was paid for before any of the five tools was written. What
+the two large-end tools actually share is 20 lines.
+
+That makes `tools/stratify/stratify.py`'s **footprint** the sizing input, and the stratum a
+scheduling convenience rather than a cost model. It is a worse answer for the program than the
+archetype story, and it is the one the measurements give.
+
 ## The honest position
 
-The 40-to-100 person-year range is **not** refuted by this measurement, and it is not confirmed
-either. What the measurement does is remove one specific way the estimate could have been
-optimistic: it is now known that members 2..n of an archetype are not nearly free, so any
-sizing that leaned on that is wrong.
+The 40-to-100 person-year range is **not** refuted, and it is not confirmed. What the two
+measurements do is remove a specific way it could have been optimistic, and then move the line
+estimate up by roughly a factor of two inside it.
 
-It replaces a guess with one data point, at the small end of one stratum, in one of the two
-Picard-shaped archetypes. Decision 0002 lists what would strengthen it: a second delta at the
-large end of the same stratum, where `CollectRnaSeqMetrics` (879 lines) and
-`CollectAlignmentSummaryMetrics` (978) sit, and where the input plumbing the stratification
-flagged as "environment cost" actually comes due.
+Both pairs are in the metrics stratum, which is the most homogeneous of the twenty-four. The
+variant callers, the Spark tools and the ML tools have had no measurement at all, and none of
+them is line-count-shaped. So the direction is now checked at both ends of the easiest case and
+unchecked everywhere else.
+
+Two things the number still does not include:
+
+- **The four hard problems.** CRAM, Spark's 39 tools, bit-identical ML inference, and GKL-exact
+  deflate are each their own sub-programme.
+- **The findings**, which remain the largest omission. The work since the last revision produced
+  decisions 0017, 0018 and 0019 in `htsjdk-rs` and 0003 in `picard-rs`. The most expensive of
+  them changed almost nothing: Picard's `BAD_CYCLES` is binned by the offset within an alignment
+  block rather than by the read cycle, which took a probe in the oracle to establish and one
+  comment plus one variable name to reproduce. Decision 0019 cost a probe and produced *no*
+  code at all, because the divergence it looked for was not there.
+
+  A sizing model built on line counts systematically under-prices exactly the work that makes
+  the port bit-identical rather than merely correct.


### PR DESCRIPTION
This document asked for exactly one thing: a second within-stratum delta at the large end, where
`CollectAlignmentSummaryMetrics` sits. It is now measured.

| pair | ratios (Rust lines per Java line) |
|---|---|
| small end — `MeanQualityByCycle` / `CollectBaseDistributionByCycle` | 0.39, **0.58** |
| large end — `CollectInsertSizeMetrics` / `CollectAlignmentSummaryMetrics` | 0.76, **0.85** |

In both pairs the **second** member cost *more* per Java line than the first. The archetype delta
is negative at both ends of the one stratum where the hypothesis was most likely to hold.

## The estimate roughly doubles

The earlier revision used the small-end ratios and arrived at 200,000 to 300,000 lines of ported
main source. That was too low, and the reason is now visible: the small-end tools have a low
ratio *because they do little*, and most of the corpus's lines are not in tools like those.

At the large end's 0.76 to 1.00, ported main source is **390,000 to 515,000 lines**, and total
output including tests is **600,000 to 900,000**.

## What replaces the archetype model

> The per-member cost tracks the member's own Java footprint. The stratum predicts almost nothing
> beyond that.

The stratum signals describe *plumbing* — how records arrive, whether the output has a histogram
section, which base class the bean extends — and all of it was paid for before any of the five
tools was written. What the two large-end tools actually share is **20 lines**.

That makes the stratifier's `footprint` the sizing input, and the stratum a scheduling
convenience rather than a cost model.

## What has not changed

The 40-to-100 person-year range is still neither refuted nor confirmed. Both pairs are in the
metrics stratum, the most homogeneous of the twenty-four; the variant callers, Spark and ML have
had no measurement at all, and none of them is line-count-shaped.

And the largest omission is unchanged. Decision 0019 in htsjdk-rs cost a probe in the oracle and
produced **no code at all**, because the divergence it went looking for was not there. Picard's
`BAD_CYCLES` finding took a probe to establish and one comment plus one variable name to
reproduce. Line counts measure typing, and typing is not where this work lives.

Part of #13.
