### PR TITLE
Print the argument coverage the ports measured

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -6,26 +6,26 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 | state | tools | share |
 |---|---:|---:|
-| oracle-backed | 31 | 10.0% |
+| oracle-backed | 32 | 10.3% |
 | golden-pending | 0 | 0.0% |
-| unchecked | 13 | 4.2% |
+| unchecked | 12 | 3.9% |
 | not started | 267 | 85.9% |
 | **total** | **311** | |
 
-`oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: the t-wise arrays (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) are generated but not yet run, so the argument-coverage column below is empty for every tool. That is the distance between where the programme is and what it claims to be heading for.
+`oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
 ## picard-origin tools (43 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
 | `AccumulateQualityYieldMetrics` | reporting-walker | unchecked | accumulatequalityyield | 1 | not measured |
-| `AddOATag` | record-transform | oracle-backed | addoatag, addoatag-bam | 2 | not measured |
+| `AddOATag` | record-transform | oracle-backed | addoatag, addoatag-bam | 2 | t=2, 0/9 rows (0%) |
 | `AddOrReplaceReadGroups` | record-transform | oracle-backed | addreplacerg | 1 | not measured |
 | `BamIndexStats` | reporting-walker | oracle-backed | bamindexstats | 1 | not measured |
 | `BedToIntervalList` | interval-utility | unchecked | bedtointervallist | 1 | not measured |
 | `CalculateReadGroupChecksum` | reporting-walker | oracle-backed | rgchecksum | 1 | not measured |
 | `CleanSam` | record-transform | oracle-backed | cleansam | 1 | not measured |
-| `CollectAlignmentSummaryMetrics` | reporting-walker | oracle-backed | metrics, rejections | 5 | not measured |
+| `CollectAlignmentSummaryMetrics` | reporting-walker | oracle-backed | metrics, rejections | 5 | t=2, 0/16 rows (0%) |
 | `CollectBaseDistributionByCycle` | reporting-walker | oracle-backed | metrics | 4 | not measured |
 | `CollectGcBiasMetrics` | reporting-walker | unchecked | gcbias | 1 | not measured |
 | `CollectInsertSizeMetrics` | reporting-walker | oracle-backed | metrics | 4 | not measured |
@@ -40,7 +40,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `FilterSamReads` | record-transform | oracle-backed | filtersamreads | 1 | not measured |
 | `FixMateInformation` | record-transform | oracle-backed | fixmate | 1 | not measured |
 | `IntervalListToBed` | interval-utility | unchecked | intervallisttobed | 1 | not measured |
-| `IntervalListTools` | interval-utility | unchecked | intervallisttools | 3 | not measured |
+| `IntervalListTools` | interval-utility | oracle-backed | intervallisttools, intervallisttoolspadbreak | 4 | not measured |
 | `LiftOverIntervalList` | interval-utility | unchecked | liftoverintervallist | 1 | not measured |
 | `MeanQualityByCycle` | reporting-walker | oracle-backed | metrics | 4 | not measured |
 | `MergeBamAlignment` | record-transform | unchecked | mergebamalignment, mergebamalignment-full | 2 | not measured |

--- a/tools/dashboard/generate.py
+++ b/tools/dashboard/generate.py
@@ -48,6 +48,14 @@ PORTS = [
     ("htsjdk-rs", REPO.parent / "htsjdk" / "tools" / "conformance" / "manifest.json"),
 ]
 
+# Each port's argument-coverage measurement, written by its own CI from the covering arrays. A
+# port with no such file has not run its arrays, and every tool it covers reports `not measured`
+# rather than nothing, so a reader cannot mistake silence for coverage.
+MEASURED = {
+    "picard-rs": REPO.parent / "Picard" / "tools" / "coverage" / "measured.json",
+    "htsjdk-rs": REPO.parent / "htsjdk" / "tools" / "coverage" / "measured.json",
+}
+
 
 def summarize(manifest):
     """The subset of a port's manifest the dashboard needs, and nothing else."""
@@ -75,6 +83,10 @@ def refresh():
         with open(path) as fh:
             summary = summarize(json.load(fh))
         summary["source"] = str(path)
+        measured = MEASURED.get(name)
+        if measured and measured.exists():
+            with open(measured) as fh:
+                summary["coverage"] = json.load(fh).get("tools", {})
         out = VENDORED / f"{name}.json"
         out.write_text(json.dumps(summary, indent=2) + "\n")
         written.append((name, len(summary["suites"])))
@@ -100,6 +112,30 @@ def load_manifests():
 RANK = {"oracle-backed": 3, "golden-pending": 2, "unchecked": 1, "not started": 0}
 
 
+def coverage_cell(entry, manifests):
+    """The argument-coverage column for one tool.
+
+    `not measured` is the honest answer for a tool whose arrays have never been run, and it is
+    also the answer for a tool that has an array but no port binary to run it against: an array
+    run against the reference alone measures the reference, not the port.
+
+    Where there is a measurement, the cell carries the strength, the fraction, and the number of
+    distinct outputs the accepted rows produced. The last one is not decoration: an array whose
+    accepted rows all produce the same output covers its argument pairs without observing them, so
+    a high fraction over one distinct output says nothing about the port.
+    """
+    measured = manifests.get(entry["port"], {}).get("coverage", {}).get(entry["tool"])
+    if not measured:
+        return "not measured"
+    cell = (
+        f"t={measured['t']}, {measured['matched']}/{measured['rows']} rows "
+        f"({measured['share']:.0%})"
+    )
+    if measured["distinct_outputs"] <= 1:
+        cell += ", **1 distinct output**"
+    return cell
+
+
 def tool_states(manifests):
     """Map tool name -> {'state', 'suites', 'port', 'cases'}."""
     states = {}
@@ -107,7 +143,8 @@ def tool_states(manifests):
         for suite in manifest["suites"]:
             for tool in suite.get("tools", []):
                 entry = states.setdefault(
-                    tool, {"state": "unchecked", "suites": [], "port": port, "cases": 0}
+                    tool,
+                    {"state": "unchecked", "suites": [], "port": port, "cases": 0, "tool": tool},
                 )
                 entry["suites"].append(suite["id"])
                 entry["cases"] += suite["cases"]
@@ -155,11 +192,12 @@ def render(inventory, manifests, missing):
     lines.append(
         "`oracle-backed` means CI re-derives the tool's goldens in the pinned container on every "
         "run and compares them. It does **not** mean the tool is byte-identical over its whole "
-        "argument surface: the t-wise arrays "
+        "argument surface: that is what the argument-coverage column is for. A t-wise array "
         "(`tools/coverage/covering.py`, sized in "
-        "[what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) are generated but not "
-        "yet run, so the argument-coverage column below is empty for every tool. That is the "
-        "distance between where the programme is and what it claims to be heading for."
+        "[what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the "
+        "reference and the port, and the column reports the fraction of its rows on which the two "
+        "answered identically, rejections included. `not measured` means the array has never been "
+        "run against a port binary, which is still true of most tools here."
     )
     lines.append("")
 
@@ -182,7 +220,7 @@ def render(inventory, manifests, missing):
                 suites = ", ".join(sorted(set(entry["suites"])))
                 lines.append(
                     f"| `{tool['name']}` | {tool['archetype']} | {state} | {suites} | "
-                    f"{entry['cases']} | not measured |"
+                    f"{entry['cases']} | {coverage_cell(entry, manifests)} |"
                 )
             lines.append("")
         not_started = [r[0]["name"] for r in subset if r[1] == "not started"]

--- a/tools/dashboard/ports/htsjdk-rs.json
+++ b/tools/dashboard/ports/htsjdk-rs.json
@@ -79,6 +79,18 @@
       "cases": 1
     },
     {
+      "id": "vcf-header-parse",
+      "status": "oracle-backed",
+      "tools": [],
+      "cases": 1
+    },
+    {
+      "id": "vcf-header-lines",
+      "status": "oracle-backed",
+      "tools": [],
+      "cases": 1
+    },
+    {
       "id": "vcf-record",
       "status": "oracle-backed",
       "tools": [],
@@ -86,6 +98,36 @@
     },
     {
       "id": "vcf-file",
+      "status": "oracle-backed",
+      "tools": [],
+      "cases": 1
+    },
+    {
+      "id": "vcf-record-parse",
+      "status": "oracle-backed",
+      "tools": [],
+      "cases": 1
+    },
+    {
+      "id": "vcf-genotype-parse",
+      "status": "oracle-backed",
+      "tools": [],
+      "cases": 1
+    },
+    {
+      "id": "vcf-genotype-likelihoods",
+      "status": "oracle-backed",
+      "tools": [],
+      "cases": 1
+    },
+    {
+      "id": "vcf-chromosome-counts",
+      "status": "oracle-backed",
+      "tools": [],
+      "cases": 1
+    },
+    {
+      "id": "vcf-genotype-type",
       "status": "oracle-backed",
       "tools": [],
       "cases": 1

--- a/tools/dashboard/ports/picard-rs.json
+++ b/tools/dashboard/ports/picard-rs.json
@@ -287,6 +287,14 @@
       "cases": 3
     },
     {
+      "id": "intervallisttoolspadbreak",
+      "status": "oracle-backed",
+      "tools": [
+        "IntervalListTools"
+      ],
+      "cases": 1
+    },
+    {
       "id": "liftoverintervallist",
       "status": "unchecked",
       "tools": [
@@ -351,5 +359,27 @@
       "cases": 1
     }
   ],
-  "source": "/Users/benjamin/Picard/tools/conformance/manifest.json"
+  "source": "/Users/benjamin/Picard/tools/conformance/manifest.json",
+  "coverage": {
+    "AddOATag": {
+      "rows": 9,
+      "accepted": 9,
+      "rejected": 0,
+      "distinct_outputs": 2,
+      "distinct_rejections": 0,
+      "matched": 0,
+      "t": 2,
+      "share": 0.0
+    },
+    "CollectAlignmentSummaryMetrics": {
+      "rows": 16,
+      "accepted": 16,
+      "rejected": 0,
+      "distinct_outputs": 11,
+      "distinct_rejections": 0,
+      "matched": 0,
+      "t": 2,
+      "share": 0.0
+    }
+  }
 }


### PR DESCRIPTION
Closes #80.

## What

The dashboard's argument-coverage column has been the string `not measured` for every tool since it existed, with a paragraph above the table explaining that the arrays were generated and never run. picard-rs now runs them (its PR #106), so this reads the measurement and prints it.

```text
| `AddOATag` | record-transform | oracle-backed | addoatag, addoatag-bam | 2 | t=2, 0/9 rows (0%) |
| `CollectAlignmentSummaryMetrics` | reporting-walker | oracle-backed | metrics, rejections | 5 | t=2, 0/16 rows (0%) |
```

Two tools marked `oracle-backed`, and **zero** of twenty-five array rows on which the port answers as the reference does. Both statements are true, and they measure different things: a suite re-derives the goldens it has, an array asks what happens when the arguments move. Putting them in the same row is the whole point of the column.

## What the cell says

`t=<strength>, <matched>/<rows> rows (<share>)`, plus a **1 distinct output** flag when the array's accepted rows all produced the same output. That case matters: such an array covers its argument pairs without observing them, so a high fraction over one distinct output would say nothing about the port, and a reader should not have to open the corpus to discover it.

`not measured` now means one specific thing rather than "we have not got there": the array has never been run against a port binary. Running an array against the reference alone measures the reference.

## How it stays honest

The measurement is vendored the same way the manifests are: `--refresh` copies each port's `tools/coverage/measured.json` into `tools/dashboard/ports/`, so the dashboard regenerates from committed data alone and CI's `--check` fails if the committed `STATUS.md` is stale. A port that has no such file reports `not measured` for every tool it covers, which is the current state of htsjdk-rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #83
