### PR TITLE
Plug the BED codec into -L, and retire the seam it was waiting for

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "gatk-corpus",
  "htsjdk-bam",
  "htsjdk-bgzf",
+ "htsjdk-tribble",
  "htsjdk-vcf",
  "noodles-bam",
  "noodles-fasta",
@@ -256,7 +257,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=868708e8b4ad3bc9479a14e1656dbda85df7fd93#868708e8b4ad3bc9479a14e1656dbda85df7fd93"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=695569c4000384db228c5050101c9bc12f05dd07#695569c4000384db228c5050101c9bc12f05dd07"
 dependencies = [
  "htsjdk-bgzf",
  "md-5",
@@ -265,16 +266,21 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=868708e8b4ad3bc9479a14e1656dbda85df7fd93#868708e8b4ad3bc9479a14e1656dbda85df7fd93"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=695569c4000384db228c5050101c9bc12f05dd07#695569c4000384db228c5050101c9bc12f05dd07"
 dependencies = [
  "flate2",
  "libz-sys",
 ]
 
 [[package]]
+name = "htsjdk-tribble"
+version = "0.1.0"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=695569c4000384db228c5050101c9bc12f05dd07#695569c4000384db228c5050101c9bc12f05dd07"
+
+[[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=868708e8b4ad3bc9479a14e1656dbda85df7fd93#868708e8b4ad3bc9479a14e1656dbda85df7fd93"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=695569c4000384db228c5050101c9bc12f05dd07#695569c4000384db228c5050101c9bc12f05dd07"
 dependencies = [
  "jmath",
 ]
@@ -292,7 +298,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=868708e8b4ad3bc9479a14e1656dbda85df7fd93#868708e8b4ad3bc9479a14e1656dbda85df7fd93"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=695569c4000384db228c5050101c9bc12f05dd07#695569c4000384db228c5050101c9bc12f05dd07"
 
 [[package]]
 name = "lexical-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,10 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # ["org.broadinstitute.hellbender", "picard"], which is why `gatk MarkDuplicates` runs Picard's
 # code, and why gatk-rs depends on picard-rs here.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "868708e8b4ad3bc9479a14e1656dbda85df7fd93" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "868708e8b4ad3bc9479a14e1656dbda85df7fd93" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "868708e8b4ad3bc9479a14e1656dbda85df7fd93" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "868708e8b4ad3bc9479a14e1656dbda85df7fd93" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "868708e8b4ad3bc9479a14e1656dbda85df7fd93" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "695569c4000384db228c5050101c9bc12f05dd07" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "695569c4000384db228c5050101c9bc12f05dd07" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "695569c4000384db228c5050101c9bc12f05dd07" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "695569c4000384db228c5050101c9bc12f05dd07" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "695569c4000384db228c5050101c9bc12f05dd07" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "695569c4000384db228c5050101c9bc12f05dd07" }
 picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "72a0ae70d0502d1c4f4cd05e883aad0a2e67f31c" }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,8 +73,9 @@ The single biggest unlock: 163 non-Spark GATK tools stand on it. This is the act
 - [~] `FeatureDataSource` and `FeatureContext`: the lookahead cache, the trim that preserves file
       order, and the window arithmetic are ported and oracle-backed (20 queries at two lookahead
       settings). The suite pins what a tool sees and does **not** distinguish the cache from a
-      fresh query per call, which the manifest states. Still missing: the codecs (VCF, BED,
-      interval_list) and the Tribble index, which are htsjdk's and belong in Milestone H
+      fresh query per call, which the manifest states. The **BED codec** is now ported and
+      oracle-backed in htsjdk-rs. Still missing: the VCF and interval_list codecs and the Tribble
+      index, which are htsjdk's and belong in Milestone H
 
 ### G1.4 Interval arguments
 
@@ -83,8 +84,10 @@ The single biggest unlock: 163 non-Spark GATK tools stand on it. This is the act
 - [x] interval **files**: `.list` and `.intervals` (lower-cased extension test, blank-line
       skipping, the empty-file refusal, and the order of the four tests in
       `parseIntervalArguments`), 13 arguments compared
-- [ ] the Feature-file path (`.interval_list`, `.bed`, VCF): the seam exists and is named
-      (`NoFeatureSources`), the codecs arrive with G1.3
+- [~] the Feature-file path: `.bed` is closed. The BED codec landed in htsjdk-rs (its own
+      oracle-backed suite, 90 rows) and is plugged into the seam, so 14 of the 15 measured `-L`
+      arguments now resolve identically and only `.interval_list` is pending. VCF arrives with
+      the Tribble index
 - [x] `-L unmapped` end to end, measured through `ReadWalker` (5 runs): the tail comes after
       every interval, `-L unmapped` alone is a bounded traversal of nothing else, and an unmapped
       read carrying its mate's position is not in the tail at all

--- a/crates/gatk-engine/Cargo.toml
+++ b/crates/gatk-engine/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 htsjdk-bam.workspace = true
 htsjdk-bgzf.workspace = true
 # The allele and sample axes of a likelihood matrix are defined over htsjdk alleles.
+htsjdk-tribble.workspace = true
 htsjdk-vcf.workspace = true
 # Pinned exactly, not by caret range: a byte-identity claim cannot float its dependencies.
 # noodles parses the .fai and the .bai; what those bytes mean to a GATK tool is ported.

--- a/crates/gatk-engine/src/feature_intervals.rs
+++ b/crates/gatk-engine/src/feature_intervals.rs
@@ -1,0 +1,101 @@
+//! The Feature-file branch of `-L`, ported from `IntervalUtils.featureFileToIntervals` and the
+//! codec resolution `FeatureManager.isFeatureFile` performs (GATK 4.6.2.0).
+//!
+//! This fills the seam [`crate::interval_args::NoFeatureSources`] was standing in for. The
+//! `interval-file` suite has measured the answer since it was written; what was missing was a
+//! codec to produce it.
+//!
+//! # A Feature file is recognised by codec, not by extension
+//!
+//! `FeatureManager` asks every registered codec's `canDecode`, and a codec answers on the path.
+//! `BEDCodec.canDecode` strips one block-compressed extension and then tests for `.bed`, so
+//! `regions.BED.gz` is a Feature file and `regions.bed.gz.gz` is not. Nothing looks inside the
+//! file, which is why a `.list` whose contents are BED is **not** a Feature file and reaches the
+//! interval reader instead, where it fails as a malformed locus. That row is in the golden.
+//!
+//! # The coordinates come from the codec, not from a conversion here
+//!
+//! ```text
+//! chr1  0  10        the BED line
+//! chr1:1-10          the interval -L produces
+//! ```
+//!
+//! The +1 is `BEDCodec`'s `StartOffset.ONE`, applied while decoding. This module does not shift
+//! anything: `createGenomeLoc(feature, true)` takes the feature's own start and end. A port that
+//! converted here as well would be off by one, and a port that converted here *instead* would
+//! agree until someone constructed the codec at `StartOffset.ZERO`.
+
+use std::path::Path;
+
+use htsjdk_bam::header::SamHeader;
+use htsjdk_tribble::bed::{self, StartOffset};
+
+use crate::interval::SimpleInterval;
+use crate::interval_args::{FeatureIntervals, IntervalArgumentError};
+
+/// The codecs this port registers, which is the subset of GATK's that reads intervals.
+///
+/// `.interval_list` is **not** here: htsjdk's `IntervalList` reader is its own thing and lands with
+/// its own slice. Until then this source answers `None` for one, which sends it down the
+/// interval-file branch exactly as an unregistered codec would, and the suite says so.
+pub struct BedFeatureSource;
+
+impl BedFeatureSource {
+    /// `IntervalUtils.featureFileToIntervals`: one interval per feature, in file order.
+    ///
+    /// A line the codec answers `null` for (blank, header, or fewer than two fields) contributes
+    /// nothing, because the reference's iterator skips nulls rather than stopping.
+    pub fn intervals(
+        &self,
+        text: &str,
+        header: &SamHeader,
+        path_hint: &str,
+    ) -> Result<Vec<SimpleInterval>, IntervalArgumentError> {
+        let mut intervals = Vec::new();
+        for line in text.lines() {
+            let feature = match bed::decode(line, StartOffset::One) {
+                Ok(Some(feature)) => feature,
+                Ok(None) => continue,
+                // A malformed BED line reaches the caller as a file that could not be read, which
+                // is the shape the reference's Tribble layer wraps a codec failure in. The exact
+                // exception is not measured yet: the golden has no malformed-BED case, so this is
+                // named as the nearest existing refusal rather than invented.
+                Err(_) => {
+                    return Err(IntervalArgumentError::IntervalFileMissing(
+                        path_hint.to_string(),
+                    ))
+                }
+            };
+            // `createGenomeLoc(feature, true)` validates against the dictionary, so a contig the
+            // header does not hold is refused here and not silently kept.
+            intervals.push(crate::interval::parse_interval(
+                &format!("{}:{}-{}", feature.contig, feature.start, feature.end),
+                header,
+            )?);
+        }
+        Ok(intervals)
+    }
+}
+
+impl FeatureIntervals for BedFeatureSource {
+    fn intervals_from_feature_file(
+        &self,
+        path: &Path,
+        header: &SamHeader,
+    ) -> Option<Result<Vec<SimpleInterval>, IntervalArgumentError>> {
+        // `canDecode` is asked before the file is opened, exactly as `FeatureManager` asks it, so
+        // a path no codec claims never becomes a read attempt.
+        if !bed::can_decode(&path.to_string_lossy()) {
+            return None;
+        }
+        let text = match std::fs::read_to_string(path) {
+            Ok(text) => text,
+            Err(_) => {
+                return Some(Err(IntervalArgumentError::IntervalFileMissing(
+                    path.to_string_lossy().to_string(),
+                )))
+            }
+        };
+        Some(self.intervals(&text, header, &path.to_string_lossy()))
+    }
+}

--- a/crates/gatk-engine/src/lib.rs
+++ b/crates/gatk-engine/src/lib.rs
@@ -18,6 +18,7 @@ pub mod clipping;
 pub mod context;
 pub mod context_iterator;
 pub mod downsampling;
+pub mod feature_intervals;
 pub mod features;
 pub mod interval;
 pub mod interval_args;

--- a/crates/gatk-engine/tests/interval_file.rs
+++ b/crates/gatk-engine/tests/interval_file.rs
@@ -21,7 +21,9 @@ const CONTIG_LENGTH: i32 = 200;
 
 /// The cases whose answer needs Feature codecs. Both are files whose names look like intervals
 /// and whose contents are decoded by a codec instead.
-const PENDING_FEATURE_SOURCES: [&str; 2] = ["picard-interval-list", "bed"];
+/// `.interval_list` is still pending: it is a Feature file to the reference, and htsjdk's
+/// IntervalList reader is its own slice. `bed` left this list when the BED codec landed.
+const PENDING_FEATURE_SOURCES: [&str; 1] = ["picard-interval-list"];
 
 fn golden() -> String {
     corpus::read_golden(
@@ -138,7 +140,7 @@ fn every_argument_resolves_the_way_the_reference_resolves_it() {
         let result = interval_args::parse_interval_arguments(
             &argument(label, &dir),
             &header,
-            &interval_args::NoFeatureSources,
+            &gatk_engine::feature_intervals::BedFeatureSource,
         );
 
         if PENDING_FEATURE_SOURCES.contains(&label) {


### PR DESCRIPTION
Closes #9.

Closes #60.

## What

`IntervalUtils.featureFileToIntervals` and the codec resolution behind it, filling the `NoFeatureSources` seam with the BED codec that landed in htsjdk-rs (#54 there, its own oracle-backed suite over 90 rows).

The `interval-file` suite has measured the answer since it was written:

```text
case  bed  ok  2  chr1:1-10|chr2:5-6
```

from `chr1\t0\t10` and `chr2\t4\t6`. What was missing was a codec to produce it, and the test said so in as many words:

> Named, not skipped: the reference reads these through a codec, and the port has no codecs yet. When G1.3 lands, this assertion fails and goes away with the seam.

It has, and it does. **14 of the 15** measured `-L` arguments now resolve identically; only `.interval_list` is still pending, because htsjdk's `IntervalList` reader is its own slice.

## Two things this module deliberately does not do

**It does not shift coordinates.** The `+1` that turns a BED 0-based start into `chr1:1-10` is `BEDCodec`'s `StartOffset.ONE`, applied while decoding; `featureFileToIntervals` takes the feature's own start and end. A port that shifted here *as well* would be off by one, and one that shifted here *instead* would agree until someone constructed the codec at `StartOffset.ZERO`.

**It does not look inside the file.** `FeatureManager` asks `canDecode`, which answers on the path, so a `.list` whose contents are BED is **not** a Feature file: it reaches the interval reader and fails as a malformed locus. That row is in the golden too, and it stays green.

## One refusal is named, not measured

A malformed BED line inside a `.bed` argument comes back as the nearest existing refusal, because the golden has no such case. It is marked as such in the code rather than presented as reproduced.

## Verification

- `cargo test -p gatk-engine --test interval_file`: 14 arguments identical, 1 pending, against the unchanged golden
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `provenance.py`: clean
- pin moved to htsjdk-rs `695569c`, which carries the new `htsjdk-tribble` crate
- ROADMAP G1.3 and G1.4 updated to say `.bed` is closed and what remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #60

