### PR TITLE
A commenting standard, a way to measure it, and the first three files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
         # in all three repositories now, not just the one where it was learned.
         run: python3 tools/audit/provenance.py crates
 
+      - name: A file already explained does not lose its explanations
+        # docs/COMMENTING.md. The guard is a ratchet, not a floor for the whole tree: it fails only
+        # when a file on tools/audit/commented.txt drops below the density it was recorded at, so
+        # the remaining files are a measured list rather than a feeling.
+        run: python3 tools/audit/comment_density.py --check
+
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --release

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -185,6 +185,18 @@ The single biggest unlock: 163 non-Spark GATK tools stand on it. This is the act
     belongs to **G3** with `HaplotypeCaller` rather than to G1. Listing it here would be counting
     the assembler as an annotation
 
+### Explaining the code as it is written
+
+- [~] `docs/COMMENTING.md`: every item that is not self-evident answers what it computes, how, and
+      **why it is written this way rather than the obvious way**, and Rust idioms are explained
+      where they are not guessable from Java. The third question is the point: in a byte-identity
+      port the obvious way is usually wrong, and a reader who can check the Java should not have to
+      learn Rust to check the port. `tools/audit/comment_density.py --check` is a ratchet, not a
+      floor: it fails only when a file already on the list loses its explanations
+- [ ] the tranches, in the order a reader needs them: the engine's numeric primitives, then the
+      likelihood matrix, then the annotations, then the readers and writers. **3 of 122 files** in
+      this repository, 332 across the three
+
 ### G1.8 The argument layer
 
 - [ ] Barclay's argument model and validation at library level, so covering-array vectors are

--- a/crates/gatk-engine/src/fragment.rs
+++ b/crates/gatk-engine/src/fragment.rs
@@ -25,7 +25,7 @@
 //! `Collectors.groupingBy` builds a `HashMap`, so the new evidence order is hash order over the
 //! grouping key, which for these annotations is the read name. The order **within** each group is
 //! the stream's, so the reads of a pair keep the sample's order and "the first read of each
-//! fragment" is well defined. [`gatk_engine::java_hash::hash_map_order`] reproduces the outer one.
+//! fragment" is well defined. [`crate::java_hash::hash_map_order`] reproduces the outer one.
 //!
 //! # More than two reads with one name is a warning, not an error
 //!
@@ -33,21 +33,45 @@
 //! more than two survive it logs "Using two reads randomly to combine as a fragment" and takes the
 //! **first two**, which is not random but is the sublist. If none survive it takes the first read of
 //! the original list, supplementary or not.
+//!
+//! # Reading this file without reading Rust
+//!
+//! - `Vec<T>` is a growable array, Java's `ArrayList<T>`, but without boxing: a `Vec<usize>` holds
+//!   the integers themselves;
+//! - `Result<T, E>` is "a value or an error". `Ok(v)` is the value, `Err(e)` the error. It is how
+//!   this codebase models a reference exception, and the compiler forces the caller to handle both;
+//! - `&BamRecord` is a borrowed read: the function may look at it but does not own or free it;
+//! - `read.flags & 0x10` is a bitwise test on the SAM flags word, exactly as in Java.
 
 use crate::java_hash::{hash_map_order, string_hash_code};
 use htsjdk_bam::record::BamRecord;
 
 /// `Fragment`: one read or a pair, with the interval spanning them.
+///
+/// **What**: the coordinates the fragment covers, plus the reads it was built from.
+///
+/// **Why the reads are kept rather than summarised**: `OrientationBiasReadCounts` reads the
+/// **first** read's strand, mapping quality and base quality, so the annotation needs the reads
+/// themselves and needs them in the sample's original order.
+///
+/// `#[derive(...)]` asks the compiler to write three implementations: `Debug` for printing in
+/// tests, `Clone` for copying, `PartialEq` for `==`. Java would write them by hand or inherit them.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Fragment {
+    /// Index into the BAM header's sequence dictionary; `getAssignedContig` in the reference.
     pub contig_index: i32,
+    /// First reference position covered, one-based as everywhere in this codebase.
     pub start: i32,
+    /// Last reference position covered, inclusive.
     pub end: i32,
     /// One or two reads, in the order they appeared in the sample.
     pub reads: Vec<BamRecord>,
 }
 
 /// What fragment construction refuses.
+///
+/// **Why an enum rather than a string**: each variant is one `Utils.validateArg` in the reference,
+/// and naming them separately lets a test assert which one fired rather than matching on a message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FragmentError {
     /// `Utils.validateArg(!reads.isEmpty(), "Need one or two reads to construct a fragment")`.
@@ -58,6 +82,9 @@ pub enum FragmentError {
 }
 
 /// `GATKRead.getEnd()` for an aligned read: the last reference position the cigar covers.
+///
+/// **Why it is a one-line wrapper**: so that the two call sites below read as the reference reads,
+/// and so a future change to how an end is computed has one place to happen.
 fn read_end(read: &BamRecord) -> i32 {
     read.alignment_end()
 }
@@ -65,10 +92,18 @@ fn read_end(read: &BamRecord) -> i32 {
 impl Fragment {
     /// `Fragment.create(List<GATKRead>)`.
     ///
-    /// The interval takes `min` and `max` of the two reads' starts and ends and then `min`/`max`
-    /// again, because a read whose end precedes its start (an unmapped one) would otherwise build an
-    /// interval the constructor rejects.
+    /// **What**: build a fragment from one or two reads.
+    ///
+    /// **How**: the interval is the smallest one covering both reads.
+    ///
+    /// **Why the `min` and `max` are applied twice**: the reference computes a start and an end and
+    /// then wraps them in another `Math.min` / `Math.max` pair. That is not redundant: a read whose
+    /// end precedes its start (an unmapped one carrying a position) would otherwise build an
+    /// interval whose constructor rejects it. The port keeps both applications so the same inputs
+    /// survive.
     pub fn create(reads: &[BamRecord]) -> Result<Fragment, FragmentError> {
+        // `match` on the length, which is Java's `switch` but required to cover every case. The
+        // final arm binds the length to `found` and so covers three and above.
         match reads.len() {
             0 => Err(FragmentError::NoReads),
             1 => {
@@ -76,16 +111,23 @@ impl Fragment {
                 let end = read_end(read);
                 Ok(Fragment {
                     contig_index: read.reference_index,
+                    // The double clamp described above, for the single-read case.
                     start: read.alignment_start.min(end),
                     end: read.alignment_start.max(end),
+                    // `.to_vec()` copies the borrowed slice into an owned list, because the
+                    // fragment outlives the caller's array.
                     reads: reads.to_vec(),
                 })
             }
             2 => {
+                // Destructuring: one line binds both reads instead of two indexed lookups.
                 let (left, right) = (&reads[0], &reads[1]);
                 let start = left.alignment_start.min(right.alignment_start);
                 let end = read_end(left).max(read_end(right));
                 Ok(Fragment {
+                    // The contig comes from the **left** read only. A pair whose mates map to
+                    // different contigs therefore reports the first one's, silently, exactly as
+                    // the reference does.
                     contig_index: left.reference_index,
                     start: start.min(end),
                     end: start.max(end),
@@ -97,24 +139,40 @@ impl Fragment {
     }
 
     /// `Fragment.createAndAvoidFailure`.
+    ///
+    /// **What**: build a fragment from any number of reads sharing a name, without throwing.
+    ///
+    /// **How**: drop the alignments that are not the primary record, then take at most two.
+    ///
+    /// **Why it matters that this trims the evidence and not the arithmetic**: `groupEvidence` has
+    /// already summed the likelihoods of the **whole** group by the time this runs. A group of three
+    /// reads therefore yields a two-read fragment carrying a three-read likelihood. The conformance
+    /// golden carries that pair of rows, and no reading of either source alone establishes it.
     pub fn create_and_avoid_failure(reads: &[BamRecord]) -> Result<Fragment, FragmentError> {
         if reads.len() <= 2 {
             return Fragment::create(reads);
         }
+        // `.filter(...)` keeps the reads for which the closure is true; `.cloned()` copies each one
+        // out of the borrow; `.collect()` gathers them. The type annotation on the binding tells
+        // `collect` what to build.
         let primary: Vec<BamRecord> = reads
             .iter()
             .filter(|read| {
                 let flags = read.flags;
-                // Duplicate, secondary and supplementary respectively.
+                // Bit 0x400 marks a PCR or optical duplicate, 0x100 a secondary alignment, 0x800 a
+                // supplementary one. A read is primary when it has none of the three.
                 flags & 0x400 == 0 && flags & 0x100 == 0 && flags & 0x800 == 0
             })
             .cloned()
             .collect();
         if primary.len() > 2 {
             // "Using two reads randomly to combine as a fragment", which takes the first two.
+            // `&primary[..2]` is a borrowed view of the first two elements, not a copy.
             return Fragment::create(&primary[..2]);
         }
         if primary.is_empty() {
+            // Nothing primary survived, so the reference falls back to the first read of the
+            // original list, supplementary or duplicate though it may be. It does not fail.
             return Fragment::create(&reads[..1]);
         }
         Fragment::create(&primary)
@@ -122,11 +180,18 @@ impl Fragment {
 
     /// `ReadUtils.isF2R1`: reverse-strand and first-of-pair agree.
     ///
-    /// A read that is not paired at all has `isFirstOfPair()` false, so a **forward** unpaired read
-    /// is `F2R1` (false equals false) and a reverse one is `F1R2`. The orientation is defined
-    /// whether or not there is a mate, and for an unpaired read it is the opposite of what the
-    /// names suggest.
+    /// **What**: which of the two read-pair orientations this read belongs to. The orientation is
+    /// what `OrientationBiasReadCounts` splits its counts on, because oxidative damage during
+    /// library preparation shows up in one orientation and not the other.
+    ///
+    /// **How**: one equality between two flag tests.
+    ///
+    /// **Why the names mislead**: a read that is not paired at all has `isFirstOfPair()` false, so
+    /// a **forward** unpaired read satisfies `false == false` and is classified `F2R1`, while a
+    /// reverse one is `F1R2`. That is the opposite of what the names suggest, and the golden's
+    /// `unpaired-forward` row is `F1R2=[0, 0];F2R1=[1, 1]` because of it.
     pub fn is_f2r1(read: &BamRecord) -> bool {
+        // 0x10 is "this read is reverse-strand", 0x40 is "this read is the first of its pair".
         let reverse = read.flags & 0x10 != 0;
         let first_of_pair = read.flags & 0x40 != 0;
         reverse == first_of_pair
@@ -135,25 +200,42 @@ impl Fragment {
 
 /// The grouping key and the resulting order of `AlleleLikelihoods.groupEvidence` by read name.
 ///
-/// Returns, per sample, the groups in the order the reference's `HashMap` iteration produces, each
-/// group holding the indices of its reads within that sample in the sample's own order.
+/// **What**: for one sample's reads, the groups that share a name, in the order the reference's
+/// `HashMap` iteration produces, each group holding the **positions** of its reads within that
+/// sample.
+///
+/// **How**: collect the groups in first-appearance order, then reorder them by Java's `HashMap`
+/// iteration rule over the hash of each name.
+///
+/// **Why positions rather than the reads themselves**: the caller needs to index the likelihood
+/// matrix by the same positions to sum the right columns, so returning indices keeps the two in
+/// step. Returning reads would force the caller to search for each one.
 pub fn group_by_read_name(reads: &[BamRecord]) -> Vec<Vec<usize>> {
-    // Insertion order first, as `groupingBy` fills the map.
+    // Insertion order first, as `groupingBy` fills the map. `names` and `groups` are kept parallel:
+    // `names[k]` is the read name of `groups[k]`.
     let mut names: Vec<String> = Vec::new();
     let mut groups: Vec<Vec<usize>> = Vec::new();
     for (index, read) in reads.iter().enumerate() {
+        // `.position(...)` returns `Some(k)` for the first match or `None` for no match, which is
+        // Java's `indexOf` with the absence made explicit. A linear scan is right here: a sample's
+        // reads at one site number in the tens.
         match names.iter().position(|name| *name == read.read_name) {
             Some(position) => groups[position].push(index),
             None => {
                 names.push(read.read_name.clone());
+                // `vec![index]` builds a one-element list, the first member of a new group.
                 groups.push(vec![index]);
             }
         }
     }
+    // Java's `String.hashCode` is specified exactly, so the hash of a read name is portable. That
+    // is what makes reproducing `HashMap` order possible at all.
     let entries: Vec<(usize, i32)> = (0..names.len())
         .map(|index| (index, string_hash_code(&names[index])))
         .collect();
     match hash_map_order(&entries) {
+        // The reordering: `order` holds the group positions in hash order, and this rebuilds the
+        // list of groups to match.
         Ok(order) => order
             .into_iter()
             .map(|index| groups[index].clone())
@@ -168,6 +250,7 @@ pub fn group_by_read_name(reads: &[BamRecord]) -> Vec<Vec<usize>> {
 mod tests {
     use super::*;
 
+    /// A read at a given position with a 10-base match, which is all these tests need.
     fn read(name: &str, flags: u16, start: i32) -> BamRecord {
         BamRecord {
             read_name: name.to_string(),
@@ -178,12 +261,16 @@ mod tests {
             cigar: htsjdk_bam::text_parse::parse_cigar("10M").expect("a cigar"),
             read_bases: vec![b'A'; 10],
             base_qualities: vec![30; 10],
+            // `..Default::default()` fills every field not named above with its default, so the
+            // test says only what it cares about.
             ..Default::default()
         }
     }
 
     #[test]
     fn a_pair_spans_both_reads() {
+        // 0x41 is paired and first-of-pair; 0x81 is paired and second. The second read starts at
+        // 200 and covers ten bases, so the pair ends at 209.
         let fragment =
             Fragment::create(&[read("r", 0x41, 100), read("r", 0x81, 200)]).expect("a fragment");
         assert_eq!((fragment.start, fragment.end), (100, 209));
@@ -206,6 +293,8 @@ mod tests {
             read("a", 0x81, 200),
         ]);
         assert_eq!(groups.len(), 2);
+        // Positions 0 and 2 share the name "a". The assertion is on membership rather than on
+        // position because the outer order is the HashMap's, which this test does not pin.
         assert!(groups.contains(&vec![0, 2]));
         assert!(groups.contains(&vec![1]));
     }

--- a/crates/gatk-engine/src/histogram.rs
+++ b/crates/gatk-engine/src/histogram.rs
@@ -49,7 +49,9 @@ const BIN_EPSILON: f64 = 0.01;
 /// What the reference raises as `GATKException`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HistogramError {
-    /// A bin index outside `int` range: "Histogram values are suspiciously extreme".
+    /// A bin index outside `int` range: "Histogram values are suspiciously extreme". Reachable
+    /// from a value near the limits of a `double`, since the bin index is the value divided by the
+    /// bin size.
     ValueTooExtreme,
     /// `add(value, count)` with a count below one.
     NonPositiveCount,
@@ -69,10 +71,14 @@ pub struct CompressedDataList {
 }
 
 impl CompressedDataList {
+    /// An empty list. `Self` means "the type this block is for", so `Self::default()` is the
+    /// derived empty value: an empty map.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Whether anything has been added. Note that a value added with a count of zero still makes
+    /// the list non-empty, because the key exists.
     pub fn is_empty(&self) -> bool {
         self.value_counts.is_empty()
     }
@@ -89,6 +95,11 @@ impl CompressedDataList {
 
     /// `add(val, count)`, which has **no** guard against a non-positive count. The guard is in
     /// `Histogram`, one level up, so a negative count reaching this class is stored.
+    ///
+    /// **How the one line works**: `.entry(value)` looks the key up once and hands back a handle to
+    /// its slot, present or not; `.or_insert(0)` fills the slot with zero if it was absent and
+    /// returns a writable reference either way; the leading `*` writes through that reference. Java
+    /// would need a `get`, a null test and a `put`, and would look the key up twice.
     pub fn add_count(&mut self, value: i32, count: i32) {
         *self.value_counts.entry(value).or_insert(0) += count;
     }
@@ -101,6 +112,20 @@ impl CompressedDataList {
     }
 
     /// The iteration order: each value repeated its count of times, values ascending.
+    ///
+    /// **What**: the run-length encoding expanded back out. A list holding `{2: 3, 5: 2}` yields
+    /// `2, 2, 2, 5, 5`.
+    ///
+    /// **How**: `.flat_map(...)` turns each `(value, count)` pair into a small sequence and then
+    /// flattens all of them into one. `repeat_n(v, n)` is that small sequence.
+    ///
+    /// **Why `.max(0)`**: a negative count could have been stored, since this class has no guard.
+    /// Converting a negative number to an unsigned length would be a program error, so it is
+    /// clamped and the entry simply yields nothing.
+    ///
+    /// `impl Iterator<Item = i32> + '_` is the return type: "some sequence of integers whose
+    /// lifetime is tied to this list". The `'_` is what stops the sequence outliving the data it
+    /// reads.
     pub fn iter(&self) -> impl Iterator<Item = i32> + '_ {
         self.value_counts
             .iter()
@@ -110,10 +135,17 @@ impl CompressedDataList {
 
 impl std::fmt::Display for CompressedDataList {
     /// `toString`: `value,count` pairs joined by commas, values ascending.
+    ///
+    /// **Why the separator is written before each entry but the first**, rather than after each
+    /// and trimmed: that is what the reference does, and the difference shows on the empty list,
+    /// where this produces the empty string and a trim-based version would too, but on a list with
+    /// one entry only this one is guaranteed to emit no comma at all.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut first = true;
         for (value, count) in &self.value_counts {
             if !first {
+                // `write!` appends to the formatter and can fail if the destination does; the `?`
+                // hands that failure to the caller.
                 write!(f, ",")?;
             }
             write!(f, "{value},{count}")?;
@@ -171,6 +203,18 @@ impl Histogram {
     }
 
     /// `getBinnedValue`: the epsilon goes in **before** the division, not after.
+    ///
+    /// **What**: which bin a value falls in, as a signed index that may be negative.
+    ///
+    /// **How**: shift by a hundredth of a bin, divide by the bin size, take the floor, then round.
+    /// The rounding after a floor is redundant arithmetically and is kept because the reference has
+    /// it: `Math.round` of an already-integral double is that double, but it also converts to a
+    /// `long`, which is what the reference wants.
+    ///
+    /// **Why the floor and not a truncation**: the floor goes **down** for negative numbers, so a
+    /// value of -1.23 with a tenth-wide bin lands in bin -13 and is reported as -1.3, away from
+    /// zero. The binning is therefore not symmetric about zero, and the allele-specific rank sums,
+    /// which store their Z scores through this, inherit that asymmetry.
     fn binned_value(&self, d: f64) -> i64 {
         jmath::math::round(((d + BIN_EPSILON * self.bin_size) / self.bin_size).floor())
     }
@@ -226,12 +270,26 @@ impl Histogram {
     }
 
     /// `median()`, walking the bins in ascending order. `None` for an empty histogram.
+    ///
+    /// **What**: the middle value, or the average of the two middle values when the count is even.
+    ///
+    /// **How**: accumulate the counts in key order until the running total reaches the middle
+    /// position, then read off the bin.
+    ///
+    /// **Why the arithmetic looks off by one**: `medianIndex` is `(n + 1) / 2` in **integer**
+    /// division, so for an even count it is the **lower** of the two middle positions. The walk
+    /// then remembers that bin and averages it with the next one. For an odd count it returns
+    /// immediately. The reference is written this way and the port follows it rather than a
+    /// textbook median, because the two differ on which bin is reported when a bin spans the
+    /// middle.
     pub fn median(&self) -> Option<f64> {
         let num_items: i32 = self.data.value_counts().values().sum();
         let odd = num_items % 2 != 0;
         // Integer division: for an even count this is the lower of the two middle positions.
         let median_index = (num_items + 1) / 2;
 
+        // `counter` is the running total; `first_median` remembers the lower of the two middle
+        // bins once it has been passed, and stays `None` for an odd count.
         let mut counter = 0i32;
         let mut first_median: Option<f64> = None;
         for (key, count) in self.data.value_counts() {

--- a/crates/gatk-engine/src/math_utils.rs
+++ b/crates/gatk-engine/src/math_utils.rs
@@ -24,30 +24,73 @@
 //! `Math.pow` is a HotSpot intrinsic that decision 0007 (in `htsjdk-rs`) records as unported. The
 //! conformance golden is what decides whether the two agree on the inputs these annotations
 //! produce, rather than an assumption made here.
+//!
+//! # Reading this file without reading Rust
+//!
+//! Every function below is commented to the standard in `docs/COMMENTING.md`. Three pieces of
+//! syntax recur and are worth learning once:
+//!
+//! - `&[f64]` is a **borrowed view** of a list of 64-bit floating-point numbers. "Borrowed" means
+//!   the function may read it but does not own it and will not free it; the caller keeps the list.
+//!   Java would write `double[]`, with the difference that Java's array could be modified through
+//!   the reference and this one cannot, because it is not marked `mut` (mutable);
+//! - `f64` is Java's `double`, `i32` is Java's `int`, `i64` is Java's `long`, `usize` is an
+//!   unsigned integer wide enough to index memory (Java has no equivalent and uses `int`);
+//! - a function's last expression is its return value; `return` is only written for early exits.
 
 /// `MathUtils.maxElementIndex(array, start, endIndex)`.
 ///
-/// Strictly greater, so the **first** maximum wins when two entries tie. That tie is reachable:
-/// a genotype with PLs `[0, 0, X]` normalises to two equal likelihoods.
+/// **What**: the index of the largest value in `array[start..end]`.
+///
+/// **How**: walk once from `start + 1`, keeping the index of the best seen so far.
+///
+/// **Why it is written out rather than using a library maximum**: the comparison is strictly
+/// greater-than, so the **first** of two equal maxima wins. A library routine is free to return
+/// either. That tie is reachable: a genotype with PLs `[0, 0, X]` normalises to two equal
+/// likelihoods, and which index is reported decides which pair of columns
+/// `computeDiploidGenotypeCounts` reads.
 pub fn max_element_index(array: &[f64], start: usize, end: usize) -> usize {
+    // `let mut` declares a variable that may be reassigned. Without `mut` a Rust binding is
+    // constant, which is the opposite default from Java's.
     let mut max_i = start;
+    // `(a..b)` is a half-open range: it yields a, a+1, ... b-1, never b. Java's
+    // `for (int i = a; i < b; i++)`.
     for i in (start + 1)..end {
+        // Strictly greater, never `>=`. See the note above: this is the tie-breaking rule.
         if array[i] > array[max_i] {
             max_i = i;
         }
     }
+    // No `return` keyword: the last expression of the function body is what it evaluates to.
     max_i
 }
 
 /// `Math.pow(10.0, x)`. See the module note: the deferred intrinsic, measured rather than assumed.
+///
+/// **What**: ten raised to the power `x`.
+///
+/// **How**: the platform's own `powf`. `10.0f64` writes the literal ten as a 64-bit float so that
+/// the method call resolves to the 64-bit version rather than the 32-bit one.
+///
+/// **Why it is a named function rather than inlined at each call site**: so that there is exactly
+/// one place to change if decision 0007 is ever closed by porting `Math.pow`, and so that a reader
+/// grepping for the deferred function finds every use of it.
 pub fn pow10(x: f64) -> f64 {
     10.0f64.powf(x)
 }
 
 /// `MathUtils.log10SumLog10(array)`, with a **capital S**.
 ///
-/// `MathUtils` has two log-sums whose names differ by that one letter, and they are not the same
-/// function:
+/// **What**: given an array of base-ten logarithms, the logarithm of the sum of the numbers they
+/// represent, computed without ever forming those numbers (which would overflow or underflow).
+///
+/// **How**: factor out the largest element. If `m` is the largest, then
+/// `log10(sum of 10^a_i) = m + log10(sum of 10^(a_i - m))`, and every term of that inner sum is at
+/// most one, so nothing overflows. The term for `m` itself is exactly one, which is why the
+/// accumulator starts at `1.0` rather than at zero.
+///
+/// **Why the capital S matters**: `MathUtils` has two log-sums whose names differ by that one
+/// letter, and they are not the same function:
 ///
 /// | | accumulation | `-Infinity` entries | one element |
 /// |---|---|---|---|
@@ -55,35 +98,65 @@ pub fn pow10(x: f64) -> f64 {
 /// | `log10SumLog10` | `sum = 1.0` then `sum += term` | **skipped**, no addition at all | still summed |
 ///
 /// The accumulation order is observable. For PLs of `[60, 0, 60]` the terms are `1e-6` twice, and
-/// `(1.0 + 1e-6) + 1e-6` is two ulp away from `1.0 + (1e-6 + 1e-6)`. `normalizeLog10`, and so every
-/// genotype count `ExcessHet` and `InbreedingCoeff` rest on, calls the capital-S one. The golden
-/// caught the port calling the other, on the `equilibrium` cohort's het count and nowhere else.
+/// `(1.0 + 1e-6) + 1e-6` is two ulp away from `1.0 + (1e-6 + 1e-6)`. ("ulp" is one unit in the last
+/// place: the distance between a floating-point number and the next one representable.)
+/// `normalizeLog10`, and so every genotype count `ExcessHet` and `InbreedingCoeff` rest on, calls
+/// the capital-S one. The golden caught the port calling the other, on the `equilibrium` cohort's
+/// het count and nowhere else.
 ///
 /// The last line is the third difference: a sum still exactly `1.0` skips `Math.log10` rather than
 /// taking the logarithm of one, so a single-element array never reaches the logarithm at all.
 pub fn log10_sum_log10(log10_values: &[f64]) -> f64 {
+    // `.len()` is the number of elements, so this asks for the whole array.
     log10_sum_log10_range(log10_values, 0, log10_values.len())
 }
 
 /// `MathUtils.log10SumLog10(array, start, finish)`.
+///
+/// **What**: as [`log10_sum_log10`], but over the half-open slice `[start, finish)` only.
+///
+/// **How and why**: see [`log10_sum_log10`]. The three early exits below are each a branch of the
+/// reference, reproduced in its order because the order decides which one fires first.
 pub fn log10_sum_log10_range(log10_values: &[f64], start: usize, finish: usize) -> f64 {
+    // An empty or inverted range. The reference answers negative infinity, which is the logarithm
+    // of a sum of nothing, and it does this test **before** looking at the array, so an
+    // out-of-bounds `start` never causes an index error on this path.
     if start >= finish {
         return f64::NEG_INFINITY;
     }
     let max_index = max_element_index(log10_values, start, finish);
     let max_value = log10_values[max_index];
+    // If the largest entry is negative infinity then every entry is, so every number is zero and
+    // the sum is zero, whose logarithm is negative infinity. Returning `max_value` rather than the
+    // constant is the reference's own wording and gives the same bits.
     if max_value == f64::NEG_INFINITY {
         return max_value;
     }
+    // Starts at one, not zero: the largest element's own term is `10^(m - m)`, which is one, and
+    // the loop below skips it rather than adding it.
     let mut sum = 1.0f64;
+    // `.iter()` walks the array by reference; `.enumerate()` pairs each item with its position;
+    // `.take(finish)` stops after position `finish - 1`; `.skip(start)` discards the first `start`
+    // pairs. Together they are Java's `for (int i = start; i < finish; i++)`, and the positions
+    // reported by `enumerate` are absolute because `skip` comes after it.
     for (i, value) in log10_values.iter().enumerate().take(finish).skip(start) {
+        // Two skips, not one. The maximum's term is omitted because it was folded into the
+        // starting `1.0`; a negative-infinity term is omitted because the reference omits it, and
+        // that is **not** the same as adding the zero it would have produced. Adding zero is an
+        // operation and can change nothing here, but the count of additions changes which
+        // intermediate sums exist, and this is the file where that matters.
         if i == max_index || *value == f64::NEG_INFINITY {
             continue;
         }
+        // `*value` reads through the borrow: `value` is a reference to an `f64`, `*value` is the
+        // `f64` itself. Java has no equivalent because Java's `double` is never a reference.
         sum += pow10(value - max_value);
     }
     // `throw new IllegalArgumentException("log10 p: Values must be non-infinite and non-NAN")`,
     // which no ported caller can reach because the inputs are PLs.
+    //
+    // The `if` is an expression here, not a statement: it evaluates to one of the two branches and
+    // that value is added to `max_value`. Java would need a ternary.
     max_value
         + if sum != 1.0 {
             jmath::math::log10(sum)
@@ -93,19 +166,48 @@ pub fn log10_sum_log10_range(log10_values: &[f64], start: usize, finish: usize) 
 }
 
 /// `MathUtils.normalizeFromLog10ToLinearSpace`.
+///
+/// **What**: turn an array of base-ten logarithms into the numbers themselves, scaled so they sum
+/// to (approximately) one.
+///
+/// **How**: subtract the log-sum from every entry, then raise ten to each. Subtracting a logarithm
+/// is dividing, so this divides every number by their total.
+///
+/// **Why "approximately"**: each element goes through its own `pow`, and a sum of separately
+/// rounded quotients need not be exactly one. Callers that test two entries for equality are
+/// comparing two `pow` results, not two exact fractions.
 pub fn normalize_from_log10_to_linear_space(array: &[f64]) -> Vec<f64> {
     let log10_sum = log10_sum_log10(array);
+    // `.map(...)` applies the closure to each element and `.collect()` gathers the results into a
+    // new `Vec<f64>`, which is Java's `ArrayList<Double>` without the boxing. The closure
+    // `|x| ...` takes one argument; `x` here is a reference, and `x - log10_sum` reads through it
+    // automatically because subtraction is defined on references to numbers.
     array.iter().map(|x| pow10(x - log10_sum)).collect()
 }
 
 /// `MathUtils.normalizeSumToOne`, which divides by the sum whatever the sum is.
 ///
-/// There is no guard for a zero sum, so an all-zero input yields `NaN` rather than zeros. The
-/// negative-sum check is an `IllegalArgumentException`, modelled here as `None`.
+/// **What**: scale an array so its entries sum to one.
+///
+/// **How**: add everything up, then divide each entry by that total.
+///
+/// **Why there is no guard for a zero sum**: because the reference has none. An all-zero input
+/// divides zero by zero and yields `NaN` ("not a number", the floating-point result of an
+/// undefined operation) rather than zeros. A site with no informative reads gets an allele fraction
+/// of `NaN`, and a consumer reading it as a number has to survive that.
+///
+/// **Why the return type is `Option`**: the reference's negative-sum check throws
+/// `IllegalArgumentException`. `Option<T>` is Rust's "a value or nothing", checked by the compiler,
+/// which is how this codebase models a reference exception that a caller might legitimately hit.
+/// `None` here means "the reference would have thrown".
 pub fn normalize_sum_to_one(array: &[f64]) -> Option<Vec<f64>> {
     if array.is_empty() {
+        // `Some(x)` wraps a real value; `Vec::new()` is an empty list. The reference returns the
+        // input array unchanged for an empty input, which is the same thing observed from outside.
         return Some(Vec::new());
     }
+    // `.sum()` needs to know what type it is accumulating into, which the `: f64` annotation
+    // supplies. It adds left to right, which is the order the reference's own loop uses.
     let sum: f64 = array.iter().sum();
     if sum < 0.0 {
         return None;
@@ -119,14 +221,26 @@ pub fn normalize_sum_to_one(array: &[f64]) -> Option<Vec<f64>> {
 /// return (d > 0.0) ? (int) (d + 0.5d) : (int) (d - 0.5d);
 /// ```
 ///
-/// Half-away-from-zero for ordinary input, but the cast truncates towards zero, so it rounds twice
-/// on a value whose sum with a half is not representable, exactly the way `Math.round` stopped
-/// doing in Java 7. Java's `(int)` narrowing clamps rather than wrapping and answers zero for NaN.
+/// **What**: round a number to the nearest integer, halves going away from zero.
+///
+/// **How**: add or subtract a half depending on the sign, then throw away the fractional part.
+///
+/// **Why that is not the same as rounding**: the addition happens first and is itself rounded. On a
+/// value whose sum with a half is not exactly representable, the sum rounds **up** to the next
+/// integer and the truncation then keeps it, so the function rounds twice. `0.49999999999999994` is
+/// the largest double below a half; adding a half gives exactly `1.0`, and this function answers
+/// one where half-up answers zero. `Math.round` stopped doing this in Java 7; `fastRound` never
+/// did.
+///
+/// **Why the three guards**: Java's `(int)` narrowing clamps to the extremes rather than wrapping
+/// around, and answers zero for `NaN`. Rust's `as` conversion has had exactly those semantics since
+/// 1.45, so the guards are belt and braces and document the intent.
 pub fn fast_round(d: f64) -> i32 {
     let shifted = if d > 0.0 { d + 0.5 } else { d - 0.5 };
     if shifted.is_nan() {
         return 0;
     }
+    // `i32::MAX as f64` converts the largest 32-bit integer to a float so the two can be compared.
     if shifted >= i32::MAX as f64 {
         return i32::MAX;
     }
@@ -138,13 +252,24 @@ pub fn fast_round(d: f64) -> i32 {
 
 /// `Math.min(double, double)`, which is **not** `f64::min`.
 ///
-/// Rust's `min` returns the non-NaN argument; Java's propagates the NaN. It also distinguishes the
-/// two zeros, which `f64::min` explicitly leaves unspecified. Both differences are reachable from
-/// `Math.max(0., Math.min(1., pval))` in `ExcessHet`, where a NaN p-value would silently become 1.
+/// **What**: the smaller of two numbers, with Java's exact treatment of the two odd cases.
+///
+/// **How**: test for `NaN` first, then for the two zeros, then compare.
+///
+/// **Why it cannot be the built-in**: Rust's `min` returns the **non**-`NaN` argument, so
+/// `min(1.0, NaN)` is `1.0`; Java's propagates the `NaN`. Rust's also leaves the choice between
+/// `0.0` and `-0.0` explicitly unspecified; Java's prefers the negative zero. Both differences are
+/// reachable from `Math.max(0., Math.min(1., pval))` in `ExcessHet`, where a `NaN` p-value would
+/// silently become one under the built-in and stay `NaN` under this.
 pub fn java_min(a: f64, b: f64) -> f64 {
+    // `a != a` is Java's own idiom for "a is NaN", since NaN is the only value unequal to itself.
+    // Rust spells it `is_nan()`, which is the same test.
     if a.is_nan() {
         return a;
     }
+    // Both are zero **and** the second is the negative one: Java returns the negative zero. The two
+    // zeros compare equal, so `a <= b` below could not distinguish them and this case must come
+    // first.
     if a == 0.0 && b == 0.0 && b.is_sign_negative() {
         return b;
     }
@@ -155,11 +280,13 @@ pub fn java_min(a: f64, b: f64) -> f64 {
     }
 }
 
-/// `Math.max(double, double)`. See [`java_min`].
+/// `Math.max(double, double)`. See [`java_min`]: same three cases, mirrored.
 pub fn java_max(a: f64, b: f64) -> f64 {
     if a.is_nan() {
         return a;
     }
+    // Mirrored from `java_min`: here it is the **first** argument being the negative zero that
+    // makes the reference return the other one.
     if a == 0.0 && b == 0.0 && a.is_sign_negative() {
         return b;
     }
@@ -172,18 +299,31 @@ pub fn java_max(a: f64, b: f64) -> f64 {
 
 /// `QualityUtils.qualToProb(double)`: `1 - pow(10, qual / -10)`.
 ///
-/// The `double` overload, not the cached `byte` one: an `int` GQ widens to `double` at the call
-/// site in `GenotypeUtils`, so the cache is bypassed and the `Math.pow` is real.
+/// **What**: turn a Phred-scaled quality score into the probability that the call it describes is
+/// correct. Phred 30 means one error in a thousand, so the answer is 0.999.
+///
+/// **How**: `10^(-q/10)` is the error probability by definition of the scale; one minus it is the
+/// probability of being right.
+///
+/// **Why the argument is `f64` and not a byte**: `QualityUtils` has two overloads. The byte one
+/// reads a precomputed cache; the double one calls `Math.pow` for real. An `int` genotype quality
+/// widens to `double` at the call site in `GenotypeUtils`, so Java picks the double overload, the
+/// cache is bypassed, and the `pow` is the deferred intrinsic. Binding to the cached one here would
+/// be a different function.
 pub fn qual_to_prob(qual: f64) -> f64 {
     1.0 - pow10(qual / -10.0)
 }
 
+// `#[cfg(test)]` compiles this module only when running tests, so none of it ships.
 #[cfg(test)]
 mod tests {
+    // Brings everything from the parent module into scope, so the tests can call the functions
+    // above by their bare names.
     use super::*;
 
     #[test]
     fn the_first_maximum_wins_a_tie() {
+        // Two equal maxima at positions 0 and 1. The strictly-greater comparison keeps the first.
         assert_eq!(max_element_index(&[1.0, 1.0, 0.0], 0, 3), 0);
     }
 
@@ -193,13 +333,16 @@ mod tests {
         assert_eq!(fast_round(-2.5), -3);
         assert_eq!(fast_round(0.4), 0);
         // The truncating cast is what makes this not `Math.round`: the double below a half plus a
-        // half is exactly one, so it rounds twice and answers one where half-up answers zero.
+        // half is exactly one, so it rounds twice and answers one where half-up answers zero. The
+        // underscores in the literal are digit separators and have no effect on the value.
         assert_eq!(fast_round(0.499_999_999_999_999_94), 1);
     }
 
     #[test]
     fn an_all_zero_vector_normalises_to_nan() {
         let out = normalize_sum_to_one(&[0.0, 0.0]).expect("a non-negative sum");
+        // `.all(...)` is true when the closure holds for every element. Zero divided by zero is
+        // NaN, so both entries are.
         assert!(out.iter().all(|value| value.is_nan()));
     }
 }

--- a/docs/COMMENTING.md
+++ b/docs/COMMENTING.md
@@ -1,0 +1,99 @@
+# Commenting standard
+
+This programme reimplements GATK, Picard and htsjdk in Rust and claims **byte-identical** output.
+A reader who wants to check that claim has to compare two things: what the Java does and what the
+Rust does. Most of them can read the Java. Not all of them can read the Rust, and none of them
+should have to read it twice to find out *why* a line is written the way it is.
+
+So the code is commented for someone who does not know Rust.
+
+## The three questions
+
+Every item that is not self-evident answers three questions, in this order:
+
+- **What** it computes, in the domain's own words. "The index of the largest value", not "the loop
+  variable after the loop".
+- **How** it computes it, when the method is not obvious from the name. One or two sentences.
+- **Why** it is written *this way and not the obvious way*. This is the one that carries the value
+  of the whole exercise, because in a byte-identity port the obvious way is usually wrong.
+
+The **why** is the point. A comment that says `// add one to i` is worse than no comment. A comment
+that says `// strictly greater, so the first of two equal maxima wins, and that tie is reachable`
+is why the file exists.
+
+## Levels
+
+**Module** (`//!` at the top of the file). Which reference class this is, which version, and the
+handful of things about it that would surprise a careful reader. This level already exists across
+the codebase and is not changed by this standard.
+
+**Item** (`///` above a function, type or constant). The three questions. Always name the reference
+symbol it ports, so a reader can put the two side by side.
+
+**Inline** (`//` inside a body). Two kinds, both wanted:
+
+- *Intent*: what this step is for, and what the reference does at the same point.
+- *Mechanics*: what a piece of Rust syntax means, **where the idiom is not guessable from Java**.
+  `.iter().enumerate().skip(n)` deserves a sentence. `let x = 1;` does not.
+
+## Mechanics worth explaining, once per file at most
+
+These are the constructs a Java reader trips on. Explain them the first time a file uses one, and
+not again:
+
+| Rust | What it means to a Java reader |
+|---|---|
+| `&[T]` | a borrowed, read-only view of an array; the caller keeps ownership |
+| `&mut T` | a borrowed, writable reference; only one may exist at a time |
+| `Option<T>` | "a value or nothing", checked by the compiler; Java's `null` without the crash |
+| `Result<T, E>` | "a value or an error"; how this codebase models a reference exception |
+| `let Some(x) = y else { ... }` | unwrap or take the early exit; there is no Java equivalent |
+| `.iter().map(..).collect()` | Java's stream, map, collect |
+| `?` | propagate the error to the caller; Java's `throws` at a single call site |
+| final expression, no `return` | the last expression of a body is its value |
+| `f64`, `i32`, `i64`, `usize` | `double`, `int`, `long`, and an unsigned index type Java lacks |
+
+## What not to write
+
+- Do not restate the type. The compiler already checked it and the comment will rot.
+- Do not narrate control flow that reads plainly. `// loop over the samples` above
+  `for sample in samples` is noise.
+- Do not explain the same idiom twice in one file.
+- Do not write a comment you cannot defend from the reference. If the reason is "I think this is
+  faster", say that; if the reason is a line of Java, quote the line.
+
+## Quoting the reference
+
+Where a comment turns on what the Java does, quote the Java, in a fenced block for an item comment
+and inline for a one-liner. The quote is the evidence. A paraphrase invites a reader to trust the
+port's reading of the reference, which is exactly what the port is not entitled to ask.
+
+## Density, and why it is measured rather than mandated
+
+`tools/audit/comment_density.py` reports, per file, the ratio of comment lines to code lines. It
+does **not** fail a file for being below the bar: a generated table of five thousand constants
+should not be commented line by line, and a mechanical accessor needs nothing.
+
+What it does fail is **regression**. A file listed in `tools/audit/commented.txt` has been brought
+to this standard deliberately, and the guard fails if its density drops. That way the work is
+ratchet-shaped: nothing already done can quietly come undone, and the remaining files are a
+measured list rather than a feeling.
+
+Run it with no arguments for the full table:
+
+```
+python3 tools/audit/comment_density.py
+```
+
+## Order of work
+
+The list in `tools/audit/commented.txt` grows one tranche at a time. The order is by how much a
+reader needs the file to understand anything else:
+
+1. the engine's numeric primitives (`math_utils`, `histogram`, `java_hash`, `fragment`)
+2. the likelihood matrix and its allele and sample axes
+3. the annotations, which are the widest surface and the least surprising individually
+4. the readers and writers, where the surprises are about file formats rather than arithmetic
+5. everything else
+
+`htsjdk-rs` and `picard-rs` carry their own copies of this file and their own lists.

--- a/tools/audit/comment_density.py
+++ b/tools/audit/comment_density.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Measure how well the Rust sources explain themselves, and stop finished files from regressing.
+
+The programme claims byte-identical output, and a reader checking that claim has to compare the
+Java with the Rust. Not all of them read Rust. `docs/COMMENTING.md` is the standard that follows
+from that; this script is the part of it that can be automated.
+
+It reports a ratio per file: comment lines over code lines. It does NOT fail a file for being low,
+because a generated table of constants should not be commented line by line and a mechanical
+accessor needs nothing. What it fails is regression: a file listed in `commented.txt` was brought
+to the standard deliberately, and its recorded floor may not drop.
+
+Usage:
+    comment_density.py            report every file, sorted by ratio
+    comment_density.py --check    fail if any listed file fell below its recorded floor
+    comment_density.py --record   rewrite the floors from the current tree (review the diff)
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CRATES = ROOT / "crates"
+LISTED = pathlib.Path(__file__).resolve().parent / "commented.txt"
+
+
+def measure(path: pathlib.Path) -> tuple[int, int]:
+    """Return (comment lines, code lines) for one Rust source.
+
+    A comment line is one whose first non-whitespace characters are `//` (which covers `///` and
+    `//!`). A code line is any other non-blank line. Block comments are not counted, because this
+    codebase does not use them and pretending otherwise would invite a way to game the number.
+
+    String literals containing `//` would be miscounted, which is accepted: the ratio is a
+    reporting aid, not a proof, and the only file where it decides anything is one a human has
+    already read.
+    """
+    comments = 0
+    code = 0
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("//"):
+            comments += 1
+        else:
+            code += 1
+    return comments, code
+
+
+def sources() -> list[pathlib.Path]:
+    """Every Rust source under `crates/`, excluding build output, sorted for a stable report."""
+    return sorted(
+        p
+        for p in CRATES.rglob("*.rs")
+        if "target" not in p.parts
+    )
+
+
+def ratio(comments: int, code: int) -> float:
+    """Comments per line of code. A file with no code at all counts as fully commented."""
+    return comments / code if code else float("inf")
+
+
+def load_floors() -> dict[str, float]:
+    """The recorded floor for each file that has been brought to the standard.
+
+    Format is one `<path> <ratio>` pair per line, `#` starting a comment. Paths are relative to the
+    repository root so the file reads as a checklist.
+    """
+    floors: dict[str, float] = {}
+    if not LISTED.exists():
+        return floors
+    for raw in LISTED.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        name, _, value = line.partition(" ")
+        floors[name.strip()] = float(value.strip())
+    return floors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail on regression")
+    parser.add_argument("--record", action="store_true", help="rewrite the floors")
+    args = parser.parse_args()
+
+    measured: dict[str, tuple[int, int, float]] = {}
+    for path in sources():
+        comments, code = measure(path)
+        name = str(path.relative_to(ROOT))
+        measured[name] = (comments, code, ratio(comments, code))
+
+    floors = load_floors()
+
+    if args.record:
+        lines = [
+            "# Files brought to the standard in docs/COMMENTING.md, with the comment-to-code",
+            "# ratio each had when it was done. tools/audit/comment_density.py --check fails if",
+            "# one of them drops below its recorded floor, so the work is a ratchet: nothing",
+            "# already explained can quietly come undone.",
+            "#",
+            "# Regenerate with: python3 tools/audit/comment_density.py --record",
+            "",
+        ]
+        for name in sorted(floors):
+            if name not in measured:
+                print(f"listed file no longer exists: {name}", file=sys.stderr)
+                return 1
+            lines.append(f"{name} {measured[name][2]:.3f}")
+        LISTED.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        print(f"recorded {len(floors)} floors")
+        return 0
+
+    if args.check:
+        failed = False
+        for name, floor in sorted(floors.items()):
+            if name not in measured:
+                print(f"listed file no longer exists: {name}")
+                failed = True
+                continue
+            comments, code, current = measured[name]
+            # A hair of tolerance, so that adding a line of code to a well-commented file does not
+            # fail the build. Deleting the comments will still fail it.
+            if current < floor - 0.02:
+                print(
+                    f"{name}: {current:.3f} comments per line, recorded floor {floor:.3f} "
+                    f"({comments} comment lines, {code} code lines)"
+                )
+                failed = True
+        if failed:
+            print()
+            print("see docs/COMMENTING.md; a file on the list may not lose its explanations")
+            return 1
+        print(f"{len(floors)} files at or above their recorded comment density")
+        return 0
+
+    total_comments = sum(c for c, _, _ in measured.values())
+    total_code = sum(k for _, k, _ in measured.values())
+    print(f"{len(measured)} files, {total_comments} comment lines, {total_code} code lines")
+    print(f"overall {ratio(total_comments, total_code):.3f} comments per line of code")
+    print(f"{len(floors)} of {len(measured)} files brought to the standard")
+    print()
+    print(f"{'ratio':>7}  {'cmt':>6}  {'code':>6}  file")
+    for name, (comments, code, current) in sorted(
+        measured.items(), key=lambda item: item[1][2]
+    ):
+        mark = "*" if name in floors else " "
+        print(f"{current:7.3f}  {comments:6d}  {code:6d} {mark}{name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit/commented.txt
+++ b/tools/audit/commented.txt
@@ -1,0 +1,9 @@
+# Files brought to the standard in docs/COMMENTING.md, with the comment-to-code
+# ratio each had when it was done. tools/audit/comment_density.py --check fails if
+# one of them drops below its recorded floor, so the work is a ratchet: nothing
+# already explained can quietly come undone.
+#
+# Regenerate with: python3 tools/audit/comment_density.py --record
+
+crates/gatk-engine/src/fragment.rs 1.149
+crates/gatk-engine/src/math_utils.rs 1.930

--- a/tools/audit/commented.txt
+++ b/tools/audit/commented.txt
@@ -6,4 +6,5 @@
 # Regenerate with: python3 tools/audit/comment_density.py --record
 
 crates/gatk-engine/src/fragment.rs 1.149
+crates/gatk-engine/src/histogram.rs 0.609
 crates/gatk-engine/src/math_utils.rs 1.930

--- a/tools/conformance/ci.template.yml
+++ b/tools/conformance/ci.template.yml
@@ -54,6 +54,12 @@ jobs:
         # in all three repositories now, not just the one where it was learned.
         run: python3 tools/audit/provenance.py crates
 
+      - name: A file already explained does not lose its explanations
+        # docs/COMMENTING.md. The guard is a ratchet, not a floor for the whole tree: it fails only
+        # when a file on tools/audit/commented.txt drops below the density it was recorded at, so
+        # the remaining files are a measured list rather than a feeling.
+        run: python3 tools/audit/comment_density.py --check
+
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --release


### PR DESCRIPTION
Closes #9.

Closes #9.

Closes #63.

The programme claims byte-identical output, and a reader checking that claim compares the Java with
the Rust. Most of them can read the Java. Not all of them can read the Rust, and none of them should
have to read it twice to find out *why* a line is written the way it is.

## The standard

`docs/COMMENTING.md`. Every item that is not self-evident answers three questions in order:

- **What** it computes, in the domain's own words;
- **How**, when the method is not obvious from the name;
- **Why it is written this way rather than the obvious way.**

The third is the point. In a byte-identity port the obvious way is usually wrong, and that is
exactly the knowledge a comment can carry and a type signature cannot. `// add one to i` is worse
than no comment; `// strictly greater, so the first of two equal maxima wins, and that tie is
reachable` is why the file exists.

Rust idioms are explained where they are not guessable from Java, once per file, with a table of the
constructs a Java reader trips on (`&[T]`, `Option`, `Result`, `let ... else`, `?`, the missing
`return`). The standard also says what **not** to write: do not restate the type, do not narrate
control flow that reads plainly, and do not write a comment you cannot defend from the reference.

## The measurement

`tools/audit/comment_density.py` reports comments per line of code, per file. It does **not** fail a
file for being low: a generated table of five thousand constants should not be commented line by
line, and a mechanical accessor needs nothing.

What it fails is **regression**. A file on `tools/audit/commented.txt` was brought to the standard
deliberately, and the guard fails if it drops below the density it was recorded at. The work is
therefore a ratchet: nothing already explained can quietly come undone, and what remains is a
measured list rather than a feeling. Wired into the generated CI.

## The first tranche

    crates/gatk-engine/src/math_utils.rs   1.930 comments per line of code
    crates/gatk-engine/src/fragment.rs     1.149
    crates/gatk-engine/src/histogram.rs    0.609

Three of 122 files in this repository, 332 across the three repositories, 91k lines. **This is the
first tranche and not the whole job**, and the roadmap now carries the count so the remainder is
visible. The order is by how much a reader needs the file to understand anything else: the engine's
numeric primitives first, then the likelihood matrix, then the annotations, then the readers and
writers. `htsjdk-rs` and `picard-rs` get their own copies of the standard and their own lists.

CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #9


