### PR TITLE
Two of the four divergences were ours, not Java's

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -293,6 +293,20 @@ The goldens are byte-identical to the same container on Apple Silicon, so nothin
 depends on the host — which is a stronger statement than the suite needed to make and is worth
 having on the record for a chain built on an unported `exp` and an unported `pow`.
 
+**Below 2^53 the formatter reproduces the reference exactly**, on 903,121 measured values. It did
+not at first: two of the four divergences were this port's fault rather than Java's, an equidistant
+pair of shortest forms that the specification resolves toward the even digit and Rust's formatter
+does not. That is fixed, in both repos (htsjdk-rs #74).
+
+What is left is above the line, and it is not a rule. On a sweep of 493 such values Java gave the
+shortest form 472 times, the double's exact value 9 times, and neither 12 times — `2^60` comes out
+as its exact value rounded to eighteen significant digits. Those are branches inside Java 17's
+pre-Schubfach `FloatingDecimal`, so closing them would mean transcribing GPL2 source or fitting an
+implementation to measurements, and both are refused. The remaining route is decision 0013's
+option 3: pin a **JDK 19+** oracle, where `Double.toString` is Schubfach and the question
+disappears. That is a change to what "the reference" means, not a porting task, and it is not one
+to make quietly.
+
 **Not in scope:** reproducing `Math.exp` bit-for-bit. It has no specification to implement
 against — beyond "within 1 ulp and semi-monotone", its only definition is its own code — so
 recovering its bits from black-box measurement would be reverse-engineering toward a functional

--- a/crates/gatk-annotation/src/decimal_format.rs
+++ b/crates/gatk-annotation/src/decimal_format.rs
@@ -51,22 +51,20 @@
 //!
 //! # Where this stops being the reference, measured
 //!
-//! 278,486 values formatted through both patterns by the pinned oracle and by this module agree on
-//! every one, under two conditions. Outside them they do not, and both boundaries are in Java's
-//! digit generation rather than in the rounding:
+//! **Below 2^53 there is no divergence at all**, on 903,121 values formatted through both patterns
+//! by the pinned oracle and by this module. That covers everything `AllelePseudoDepth` can produce
+//! by a wide margin: a pseudo-fraction lies in `[0, 1]` and a pseudo-depth is a sum of posterior
+//! counts over the reads at one site.
 //!
-//!  * **at most fifteen significant digits.** At sixteen the two disagree on which shortest form to
-//!    produce. `6.985838094673373e14` is exactly `698583809467337.25`, so the sixteen-digit forms
-//!    `…337.2` and `…337.3` are equidistant, and Java picks the even one where Rust picks the
-//!    larger. Both round-trip; only one is what the reference prints;
-//!  * **below 2^53.** Above it Java stops printing the shortest form and starts printing digits
-//!    from the value itself, so `-2.0097114521676883e17` comes out as `-200971145216768832` where
-//!    the shortest form padded with zeros would give `-200971145216768830`.
+//! Above 2^53 the reference stops printing the shortest form, and what it prints instead is not one
+//! thing. On a sweep of 493 such values it gave the shortest form 472 times, the double's exact
+//! value 9 times, and neither 12 times — `2^60` comes out as its exact value rounded to eighteen
+//! significant digits. Those are branches inside Java 17's pre-Schubfach `FloatingDecimal`, not a
+//! rule, and reproducing them would mean transcribing GPL2 source or fitting an implementation to
+//! measurements. Both are refused; see `docs/licence-compatibility-risk.md`.
 //!
-//! Neither is reachable from `AllelePseudoDepth`: a pseudo-fraction lies in `[0, 1]` and shows four
-//! digits, and a pseudo-depth is a sum of posterior counts over the reads at one site. Both are
-//! many orders of magnitude short of fifteen significant digits. The limits are recorded because a
-//! later caller may not be.
+//! There used to be a second limit here, at sixteen significant digits, and it was this port's
+//! fault rather than Java's. See [`closest_of_that_length`].
 //!
 //! # What is not modelled
 //!
@@ -271,7 +269,78 @@ fn shortest_decimal(value: f64) -> (String, i32) {
     let digits = digits.trim_end_matches('0');
     let digits = if digits.is_empty() { "0" } else { digits };
     // `{:e}` writes one digit before the point, so `0.<digits>` needs one more.
-    (digits.to_string(), exponent + 1)
+    closest_of_that_length(digits, exponent + 1, value)
+}
+
+/// Among the decimals of the length Rust chose, the one nearest the double, ties to even.
+///
+/// "Shortest, then nearest, then even" is the specification every modern shortest-representation
+/// algorithm implements — Ryu, Schubfach, and therefore Java 19 and later. Rust's formatter gets
+/// the length right and does not always get the last digit right: `6.985838094673373e14` is
+/// exactly `698583809467337.25`, so the two sixteen-digit forms `…337.2` and `…337.3` are
+/// **equidistant** and both round-trip. Java prints the even one; Rust prints the other.
+///
+/// Fixing it here is implementing to the specification, not to Java 17: the reference agrees with
+/// the rule, and where it stops agreeing — above 2^53, where its digit generation predates
+/// Schubfach — no rule of this kind reaches it anyway.
+///
+/// The cost is two string parses per call. The exact expansion, which is the expensive part, is
+/// computed only when a neighbour also round-trips, which needs the double to be a short decimal
+/// and is rare.
+fn closest_of_that_length(digits: &str, exp10: i32, value: f64) -> (String, i32) {
+    let length = digits.len();
+    let Ok(number) = digits.parse::<u128>() else {
+        // Beyond what a u128 holds there is no neighbour to consider: the length is already past
+        // anything a double can distinguish.
+        return (digits.to_string(), exp10);
+    };
+    // The scale that turns the digit string back into the value it names.
+    let scale = exp10 - length as i32;
+    let magnitude = value.abs();
+
+    // Reaching the exact expansion needs the double to sit exactly on a midpoint, which needs it
+    // to *be* a short decimal. Testing that first is what keeps this affordable: without the gate
+    // the expansion ran on nearly every value, because at seventeen digits some twenty neighbouring
+    // decimals round-trip. Reading a midpoint back as a double does not help either — it sits
+    // inside the same rounding interval and parses to the same double.
+    if !may_be_a_short_decimal(magnitude) {
+        return (digits.to_string(), exp10);
+    }
+
+    for lower in [number.wrapping_sub(1), number] {
+        let upper = lower + 1;
+        let (lower_text, upper_text) = (lower.to_string(), upper.to_string());
+        // Only a neighbour of the *same* length competes. A shorter one would have been chosen
+        // already, since Rust's answer is the shortest that round-trips.
+        if lower_text.len() != length || upper_text.len() != length {
+            continue;
+        }
+        let both_round_trip = [&lower_text, &upper_text].iter().all(|candidate| {
+            format!("{candidate}e{scale}")
+                .parse::<f64>()
+                .is_ok_and(|parsed| parsed == magnitude)
+        });
+        if !both_round_trip {
+            continue;
+        }
+        // The midpoint of two consecutive n-digit decimals is that pair's lower half with a 5
+        // appended, so the exact comparison this crate already does answers which side the double
+        // falls on.
+        let chosen = match compare_to_exact(&format!("{lower_text}5"), exp10, magnitude) {
+            Ordering::Less => lower_text,
+            Ordering::Greater => upper_text,
+            // Equidistant, and this is the case Rust gets wrong.
+            Ordering::Equal => {
+                if lower % 2 == 0 {
+                    lower_text
+                } else {
+                    upper_text
+                }
+            }
+        };
+        return (chosen, exp10);
+    }
+    (digits.to_string(), exp10)
 }
 
 /// Where the double's exact value sits relative to its own shortest decimal form.
@@ -301,6 +370,38 @@ fn compare_to_exact(digits: &str, exp10: i32, magnitude: f64) -> Ordering {
         }
     }
     Ordering::Equal
+}
+
+/// Whether the double could be a decimal short enough for an equidistant pair to exist at all.
+///
+/// A necessary condition, and a cheap one. Write the value as `odd * 2^power` with `odd` odd. When
+/// `power` is negative the exact decimal is `odd * 5^-power` over `10^-power`, and `5^-power` is
+/// odd too, so nothing cancels: the expansion has at least `digits(odd) + floor(0.699 * -power)`
+/// significant digits. When `power` is positive the value is `odd * 2^power`, at least
+/// `digits(odd) + floor(0.301 * power)` digits by the same argument. A tie between two forms of at
+/// most eighteen digits cannot happen once either exceeds nineteen.
+///
+/// False positives are harmless — the exact comparison then runs and finds no tie. False negatives
+/// would be a bug, which is why the bound is the pessimistic one.
+fn may_be_a_short_decimal(value: f64) -> bool {
+    let bits = value.to_bits();
+    let biased = ((bits >> 52) & 0x7ff) as i32;
+    let fraction = bits & ((1u64 << 52) - 1);
+    let (mantissa, exponent) = if biased == 0 {
+        (fraction, -1074)
+    } else {
+        (fraction | (1u64 << 52), biased - 1075)
+    };
+    if mantissa == 0 {
+        return true;
+    }
+    let shift = mantissa.trailing_zeros() as i32;
+    let power = exponent + shift;
+    let odd_digits = (mantissa >> shift).to_string().len() as u32;
+    if power >= 0 {
+        return odd_digits * 1000 + power as u32 * 301 <= 19_000;
+    }
+    odd_digits * 1000 + (-power) as u32 * 699 <= 19_000
 }
 
 /// The double's exact decimal expansion, as `(digits, exp10)` with the value `0.<digits> * 10^exp10`.
@@ -436,18 +537,28 @@ mod tests {
         assert_eq!(FRACTION_FORMAT.format(2.0 / 3.0), "0.6667");
     }
 
-    /// The measured edge of the agreement, kept as a test so it is a recorded limit rather than a
-    /// surprise. Both boundaries are in Java's digit generation, not in the rounding rule.
+    /// An equidistant pair of shortest forms, which Rust resolves one way and the specification the
+    /// other. This used to be a recorded divergence and is now a passing case.
     #[test]
-    fn sixteen_significant_digits_is_past_the_edge() {
-        // 698583809467337.25 exactly, so the two sixteen-digit forms are equidistant. Java prints
-        // the even one, `698583809467337.2`; the shortest form Rust produces ends in 3.
+    fn an_equidistant_shortest_form_goes_to_the_even_digit() {
+        // 698583809467337.25 exactly, so `…337.2` and `…337.3` are equidistant and both
+        // round-trip. Rust's formatter gives the odd one; the reference and the specification give
+        // the even one.
         assert_eq!(
             DEPTH_FORMAT.format(6.985_838_094_673_373e14),
-            "698583809467337.3"
+            "698583809467337.2"
         );
-        // Above 2^53 Java prints digits the shortest form does not have. It gives
-        // `-200971145216768832`, the value itself.
+        assert_eq!(
+            DEPTH_FORMAT.format(5.936_134_122_025_243e14),
+            "593613412202524.2"
+        );
+    }
+
+    /// The one limit that is left, and it is Java's rather than this port's.
+    #[test]
+    fn above_two_to_the_fifty_three_the_reference_leaves_the_shortest_form() {
+        // The reference prints `-200971145216768832`, the double's exact value. This gives the
+        // shortest form padded with zeros, and no rule of the kind above reaches the difference.
         assert_eq!(
             FRACTION_FORMAT.format(-2.009_711_452_167_688_3e17),
             "-200971145216768830"

--- a/crates/gatk-annotation/tests/decimal_format.rs
+++ b/crates/gatk-annotation/tests/decimal_format.rs
@@ -7,22 +7,17 @@
 //!
 //! # The suite declares its own domain, and the corpus goes past it
 //!
-//! The port reproduces the reference exactly for values below 2^53 whose shortest decimal form
-//! needs at most fifteen significant digits, which is the whole of what `AllelePseudoDepth` can
-//! produce. Past that the divergence is in Java's *digit generation* rather than in its rounding,
-//! and it has two shapes, both deliberately present in the corpus:
-//!
-//!  * **sixteen significant digits.** `6.985838094673373e14` is exactly `698583809467337.25`, so
-//!    the two sixteen-digit forms are equidistant; Java picks the even one, Rust the larger;
-//!  * **above 2^53.** Java stops printing the shortest form and starts printing digits from the
-//!    value itself.
+//! **Below 2^53 the port reproduces the reference exactly**, which covers everything
+//! `AllelePseudoDepth` can produce by a wide margin. Above it the reference stops printing the
+//! shortest decimal form, and what it prints instead is not one thing: sometimes the double's exact
+//! value, sometimes that value rounded to eighteen significant digits, mostly the shortest form
+//! after all. Those are branches inside Java 17's pre-Schubfach `FloatingDecimal`.
 //!
 //! Every row is compared, including those. What the test asserts is not that the divergences are
-//! few but that they are all of that **shape**: a divergence below 2^53 with fewer than sixteen
-//! significant digits would mean a rounding rule is wrong, which is a different failure and the one
-//! this suite exists to catch. A corpus trimmed to what already passes would report a hundred per
-//! cent and mean nothing, and a quarantine listed value by value would keep passing after the rule
-//! behind it stopped being true.
+//! few but that they are all of that **shape**: a divergence below 2^53 would mean a rounding rule
+//! is wrong, which is a different failure and the one this suite exists to catch. A corpus trimmed
+//! to what already passes would report a hundred per cent and mean nothing, and a quarantine listed
+//! value by value would keep passing after the rule behind it stopped being true.
 
 use std::io::Read;
 
@@ -44,20 +39,7 @@ fn golden() -> String {
 /// Computed from the value, not looked up: a list of bit patterns would keep passing after the
 /// rule behind it stopped being true.
 fn past_the_declared_domain(value: f64) -> bool {
-    if !value.is_finite() {
-        return false;
-    }
-    if value.abs() >= 9_007_199_254_740_992.0 {
-        return true;
-    }
-    let significant = format!("{value:e}")
-        .split('e')
-        .next()
-        .expect("mantissa")
-        .chars()
-        .filter(char::is_ascii_digit)
-        .count();
-    significant >= 16
+    value.is_finite() && value.abs() >= 9_007_199_254_740_992.0
 }
 
 #[test]

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -1044,7 +1044,7 @@
         {
           "dump": "DecimalFormatDump",
           "golden": "crates/gatk-annotation/tests/data/decimal_format.txt.gz",
-          "why": "From the pinned container on a real x86-64 runner, published as the golden-pending artefact of the run that added this suite. 315 rows, no corrections, and byte-identical to the same container on Apple Silicon: nothing the formatter does here depends on the host. 630 strings compared and four values diverge, all of them Java emitting digits the shortest form does not have."
+          "why": "From the pinned container on a real x86-64 runner, published as the golden-pending artefact of the run that added this suite. 315 rows, no corrections, and byte-identical to the same container on Apple Silicon: nothing the formatter does here depends on the host. 630 strings compared and two values diverge, both above 2^53, where Java 17's pre-Schubfach digit generation stops producing the shortest decimal form. Below that line there is no divergence at all, measured on 903,121 values."
         }
       ]
     },


### PR DESCRIPTION
Follow-up to #103. The `decimal-format` suite reported four divergences and blamed all four on Java 17's digit generation. **Two were this port's fault.**

`6.985838094673373e14` is exactly `698583809467337.25`, so the two sixteen-digit forms `…337.2` and `…337.3` are **equidistant** and both round-trip. "Shortest, then nearest, then **even**" is the specification Ryu and Schubfach implement, so it is what Java 19+ does — and what Java 17 does here too. Rust's formatter gets the length right and picks the odd form.

`shortest_decimal` now corrects it. That is implementing to the specification rather than to Java 17, which matters because Java 17 stops following the specification above 2^53 and this correction does not follow it there.

## The cost had to be managed

At seventeen digits some twenty neighbouring decimals round-trip, so a naive check runs the exact expansion on nearly every value — measured at **0.12s → 6s** in htsjdk-rs, where the corpus is large enough to notice. Reading a midpoint back as a double does not help: it sits inside the same rounding interval and parses to the same double.

What does help is that a tie needs the double to *be* a short decimal, and that is testable without expanding it. Written as `odd * 2^power`, the exact decimal has at least `digits(odd) + floor(0.699 * -power)` significant digits when `power` is negative, and `digits(odd) + floor(0.301 * power)` when positive. A tie between forms of at most eighteen digits cannot happen once either exceeds nineteen. **Back to 0.15s.**

## Result

**Four divergences to two, and below 2^53 there is no divergence at all** — 903,121 measured values. The suite now asserts that single line in place of the two-shape rule.

## What is left, and why it is not a porting task

Above the line Java 17 produces no one thing. On a sweep of 493 such values:

| what Java printed | count |
|---|---|
| the shortest decimal form | 472 |
| the double's exact value | 9 |
| neither | 12 |

`2^60` comes out as its exact value rounded to eighteen significant digits. Those are branches inside pre-Schubfach `FloatingDecimal`, so closing them would mean transcribing GPL2 source or fitting an implementation to measurements. Both are refused — the second by htsjdk-rs decision 0011's own rule, which already rejected a fitted rule that scored *better* on its corpus.

The remaining route is decision 0013's **option 3**: pin a JDK 19+ oracle, where `Double.toString` is Schubfach and the question disappears. That changes what "the reference" means for the whole programme, so it is a decision to take deliberately rather than a task to schedule.

Paired with IPNP-BIPN/htsjdk-rs#75, which does the same there: 68 → 66, likewise leaving only values above 2^53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Part of #12.
