### PR TITLE
Pick up htsjdk-rs's corrected number formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=01468fe9276fcdc9dde8db992c22afe2749ef25c#01468fe9276fcdc9dde8db992c22afe2749ef25c"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb#6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb"
 dependencies = [
  "htsjdk-bgzf",
  "md-5",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=01468fe9276fcdc9dde8db992c22afe2749ef25c#01468fe9276fcdc9dde8db992c22afe2749ef25c"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb#6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb"
 dependencies = [
  "flate2",
  "libz-sys",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=01468fe9276fcdc9dde8db992c22afe2749ef25c#01468fe9276fcdc9dde8db992c22afe2749ef25c"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb#6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb"
 dependencies = [
  "flate2",
  "htsjdk-bam",
@@ -293,7 +293,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=01468fe9276fcdc9dde8db992c22afe2749ef25c#01468fe9276fcdc9dde8db992c22afe2749ef25c"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb#6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb"
 dependencies = [
  "jmath",
 ]
@@ -311,7 +311,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=01468fe9276fcdc9dde8db992c22afe2749ef25c#01468fe9276fcdc9dde8db992c22afe2749ef25c"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb#6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb"
 
 [[package]]
 name = "lexical-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # ["org.broadinstitute.hellbender", "picard"], which is why `gatk MarkDuplicates` runs Picard's
 # code, and why gatk-rs depends on picard-rs here.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "01468fe9276fcdc9dde8db992c22afe2749ef25c" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "01468fe9276fcdc9dde8db992c22afe2749ef25c" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "01468fe9276fcdc9dde8db992c22afe2749ef25c" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "01468fe9276fcdc9dde8db992c22afe2749ef25c" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "01468fe9276fcdc9dde8db992c22afe2749ef25c" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "01468fe9276fcdc9dde8db992c22afe2749ef25c" }
-picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "01468fe9276fcdc9dde8db992c22afe2749ef25c" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
+picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }


### PR DESCRIPTION
The pin moves from `01468fe` to `6ab766b`, which carries three changes to `htsjdk-metrics`'s `format_double` and the record behind them:

- **the tie rule**, which used to round up whenever the digit string was not the double's exact value, and so was wrong on about half the cases it decided (IPNP-BIPN/htsjdk-rs#72). 112 divergences → 68;
- **the equidistant shortest form**, resolved toward the even digit as the specification requires (IPNP-BIPN/htsjdk-rs#74). 68 → 66, and every one left is above 2^53;
- **decision 0013's options 2 and 3**, corrected and closed by measurement (IPNP-BIPN/htsjdk-rs#76).

`FormatUtil` is what every Picard metrics file and every GATK report is written through, so this is not a cosmetic bump: any gatk-rs output going through it now agrees with the reference on 46 values where it did not.

Nothing in the workspace moved locally. The oracle suites in CI are what says so on the platform the goldens come from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Part of #12.
