### PR TITLE
pow now has a bound, and measuring what it buys said keep the libm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb#6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=67fb5d16713c9e04166414742d038cfc98169b60#67fb5d16713c9e04166414742d038cfc98169b60"
 dependencies = [
  "htsjdk-bgzf",
  "md-5",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb#6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=67fb5d16713c9e04166414742d038cfc98169b60#67fb5d16713c9e04166414742d038cfc98169b60"
 dependencies = [
  "flate2",
  "libz-sys",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb#6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=67fb5d16713c9e04166414742d038cfc98169b60#67fb5d16713c9e04166414742d038cfc98169b60"
 dependencies = [
  "flate2",
  "htsjdk-bam",
@@ -293,7 +293,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb#6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=67fb5d16713c9e04166414742d038cfc98169b60#67fb5d16713c9e04166414742d038cfc98169b60"
 dependencies = [
  "jmath",
 ]
@@ -311,7 +311,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb#6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=67fb5d16713c9e04166414742d038cfc98169b60#67fb5d16713c9e04166414742d038cfc98169b60"
 
 [[package]]
 name = "lexical-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # ["org.broadinstitute.hellbender", "picard"], which is why `gatk MarkDuplicates` runs Picard's
 # code, and why gatk-rs depends on picard-rs here.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
-picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "6ab766bc7737334c12ce5ce50dc2d4b1338c6bcb" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
+picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }

--- a/crates/gatk-annotation/src/allele_pseudo_depth.rs
+++ b/crates/gatk-annotation/src/allele_pseudo_depth.rs
@@ -21,10 +21,25 @@
 //! # `Math.pow` enters here, and it carries no bound
 //!
 //! [`Self::calculate_weights`] ends on `Math.pow(10, secondAdjusted)`. That is a **second**
-//! unported intrinsic, and unlike `exp` nobody has measured a bound for it: the jmath table puts
-//! the host's `powf` at 99.9378% agreement with the JVM, against `exp`'s 99.9711%, and 0025's
-//! 1-ulp result is about `exp` alone. Three settings of `weightDecay` reach three different sets
-//! of intrinsics, so the conformance suite has to carry all three:
+//! unported intrinsic. It now has a bound — htsjdk-rs decision 0027 measured fdlibm's `pow` at
+//! **1 ulp** from `Math.pow` over 404,964 points, the same figure 0025 got for `exp` — but this
+//! port does not use fdlibm here, and the reason is measured rather than assumed.
+//!
+//! Switching all three of gatk-rs's `pow` call sites to [`jmath::strict_math::pow`] was tried. It
+//! **broke a passing byte-identity claim**: `heterozygosity_and_mq` moved from `3.3333333333333335`
+//! to `3.3333333333333344`, two ulp on the emitted value, from one ulp in `pow` amplified by the
+//! arithmetic above it. The host's `powf` agrees with `Math.pow` on 99.9378% of the corpus where
+//! fdlibm agrees on 98.5317%, so on the points these suites reach, the libm is simply closer.
+//!
+//! What that trade buys and costs is worth stating plainly, because it is the opposite of the one
+//! `NaturalLogUtils` makes for `exp`. fdlibm is fixed and the host libm is whatever the machine
+//! ships, so fdlibm would make the port host-independent — at the price of a suite that passes
+//! today. The evidence that the libm is safe here is not an assumption: these suites pass on
+//! aarch64 locally and on x86-64 in CI, which is two platforms agreeing. If a third ever disagrees,
+//! the bounded alternative now exists and this is the note that says so.
+//!
+//! Three settings of `weightDecay` reach three different sets of intrinsics, so the conformance
+//! suite has to carry all three:
 //!
 //! | `weightDecay` | what runs |
 //! |---|---|


### PR DESCRIPTION
Picks up IPNP-BIPN/htsjdk-rs#77, which ported fdlibm's `pow` and measured it: **exact** against `StrictMath.pow` on 404,964 points, and within **1 ulp** of `Math.pow` — the same figure decision 0025 got for `exp`.

That made an obvious-looking change available, and it was **tried rather than argued**.

## The change that looked right

gatk-rs reaches the host's `powf` at three sites: `calculateWeights` in `AllelePseudoDepth`, and `pow10` in both `fisher_exact` and `math_utils`. fdlibm is fixed where the host libm is whatever the machine ships, so switching would make the port host-independent.

## It broke a passing byte-identity claim

```
heterozygosity_and_mq:  3.3333333333333335  ->  3.3333333333333344
```

Two ulp on the emitted value, from one ulp in `pow` amplified by the arithmetic above it.

The reason is in the rates, and it is the same lesson as decision 0027's: the libm agrees with `Math.pow` on **99.9378%** of the corpus where fdlibm agrees on **98.5317%**. On the points these suites actually reach, the libm is simply closer.

## So the switch is reverted, and the finding is written into the module

The trade here is the **opposite** of the one `NaturalLogUtils` makes for `exp`, and saying why is the point of the note:

- fdlibm buys host-independence and costs a suite that passes today;
- the evidence that the libm is safe here is not an assumption — these suites pass on aarch64 locally and on x86-64 in CI, which is two platforms agreeing;
- if a third ever disagrees, the bounded alternative now exists, and the module says where to find it.

The pin moves to `67fb5d1` regardless, because `jmath::strict_math::pow` being available is what makes that alternative real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Part of #33.
