### PR TITLE
H.1 was finished, and the roadmap said it was not

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -475,14 +475,20 @@ copy, which is a worse position than reading the source rather than a better one
 
 Everything downstream inherits these, so they are front-loaded.
 
-- [~] BAM/SAM/tags/index read and write (core done; write-side BAI, CRAI and corner cases remain)
+- [x] BAM/SAM/tags/index read and write. **Measured before working, and the entry was stale.** The
+      write-side BAI is oracle-backed over nine shapes (`empty`, `unmapped` with both a placed and
+      an unplaced read, `window_boundary`, `all_levels`, and the rest); the read-side index has its
+      own six, with the dump recording why the two forms differ — a chunk ending on a BGZF block
+      boundary is `(nextBlockAddress, 0)` to the reader and `(blockAddress, blockLength)` to the
+      writer. Tags cover every writable type, `B` arrays and the empty one included. **CRAI moved
+      to CRAM**, where it belongs: it is the CRAM index and cannot precede CRAM
 - [~] VCF and Tribble (allele, variant, header, encoder exist; full read, write, index and all
       field types remain). Two named consumers wait here rather than in G1: the **Tribble index**,
       which is what turns a Feature file into a random-access source rather than a linear read
       (G1.3), and the pair `VCFUtils.smartMergeHeaders` plus `VariantContextComparator`, which is
       what `MultiVariantDataSource` merges several VCFs with (G1.6's multi-input half)
-- [ ] **CRAM** (container model, all encodings, codec negotiation, reference-based compression):
-      a sub-project on its own
+- [ ] **CRAM** (container model, all encodings, codec negotiation, reference-based compression),
+      **and CRAI with it**: a sub-project on its own
 - [ ] **GKL-exact deflate** (ISA-L / igzip byte-exact), the default non-JDK path. Until it
       exists, every byte claim over BGZF must name the deflater it is a claim about
 - [~] **jmath**: bit-exact Java `Math` / `StrictMath` / commons-math3 `FastMath`, plus `Gamma`,


### PR DESCRIPTION
Following the board's order put Milestone H first. Its first leaf said *"core done; write-side BAI, CRAI and corner cases remain"*. Measured before working:

| | state |
|---|---|
| **write-side BAI** | **oracle-backed**, 9 shapes: `empty`, `one_read`, `same_window`, `sparse_windows`, `all_levels`, `multi_reference_with_gap`, `unmapped` (placed *and* unplaced), `many_blocks`, `window_boundary` |
| **read-side index** | **oracle-backed**, 6 cases, with the dump recording *why* the two forms differ — a chunk ending on a BGZF block boundary is `(nextBlockAddress, 0)` to the reader and `(blockAddress, blockLength)` to the writer |
| **tags** | every writable type: `c/C/s/S/i/I`, `A`, `f`, `Z`, and `B` of byte, short, int and float, empty array included. `H` is read-only in htsjdk itself, which the port records at the type rather than leaving as a gap |
| **SAM text** | its own suite |

So "write-side BAI remains" had been false for a while.

What genuinely remained is **CRAI**, and CRAI is the CRAM index: it cannot land before CRAM. It moves to the CRAM entry — not bookkeeping, because leaving it in H.1 made a finished item look blocked and made CRAM look smaller than it is.

IPNP-BIPN/htsjdk-rs#64 is closed with the measurement attached, and its board row is Done. A corner case that turns up later gets its own issue with the case that found it, which is a better record than an open box labelled "corner cases".

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Part of #9.
