### PR TITLE
The Tribble index is in, and H.2 owes nobody a named consumer

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,7 +88,7 @@ Three of the four remain open, none of them G1 work.
 - [x] `ReferenceContext` and `ReadsContext` (352 window answers)
 - [~] `FeatureDataSource` and `FeatureContext`: the lookahead cache, the trim that preserves file
       order, and the window arithmetic are ported and oracle-backed (20 queries at two lookahead
-      settings). The suite pins what a tool sees and does **not** distinguish the cache from a
+      settings), and the **Tribble index it needed is now in** (htsjdk-rs #83). The suite pins what a tool sees and does **not** distinguish the cache from a
       fresh query per call, which the manifest states. All three codecs `-L` reaches are ported
       and oracle-backed in htsjdk-rs (**BED**, **IntervalList**, and **VCF**'s `canDecode`, the one
       that decides by content). Still missing: the **Tribble index**, which is what turns a
@@ -482,9 +482,18 @@ Everything downstream inherits these, so they are front-loaded.
       boundary is `(nextBlockAddress, 0)` to the reader and `(blockAddress, blockLength)` to the
       writer. Tags cover every writable type, `B` arrays and the empty one included. **CRAI moved
       to CRAM**, where it belongs: it is the CRAM index and cannot precede CRAM
-- [~] VCF and Tribble (allele, variant, header, encoder exist; full read, write, index and all
-      field types remain). One named consumer still waits here: the **Tribble index**, which is
-      what turns a Feature file into a random-access source rather than a linear read (G1.3).
+- [~] VCF and Tribble (allele, variant, header, encoder exist; full read, write and all field
+      types remain). **Both named consumers are now done**, so nothing in G1 waits on this entry.
+
+      The **Tribble index** landed with htsjdk-rs #83: the linear `.idx` is read byte for byte and
+      the interval-tree one is *refused* rather than mis-parsed. The dump was written before the
+      port and earned that order three times. The type identifiers cannot be read out of the Java
+      at all — `LinearIndex.INDEX_TYPE` reads a field of the `IndexType` enum whose own constructor
+      is handed `LinearIndex.INDEX_TYPE` — so `1` and `2` are measured rather than cited. The bin
+      width is **per contig**, 16000 and 8000 in one file, so a reader assuming the creator's
+      default would answer every query wrongly and never fail. And the header carries the source
+      file's modification time, so the raw bytes differ on every run: the golden masks those eight
+      bytes and reports the offset rather than being quietly unstable.
 
       **The other is done.** `VariantContextComparator` and `VCFUtils.smartMergeHeaders` are ported
       and oracle-backed (htsjdk-rs #81 and #82, 67 and 16 rows), so `MultiVariantDataSource` has


### PR DESCRIPTION
IPNP-BIPN/htsjdk-rs#83 lands the linear `.idx` reader.

| | |
|---|---|
| linear indexes parsed byte for byte | 2 |
| interval-tree | **refused**, not mis-parsed |
| queries | 12 — 3 refused for an unknown contig, 2 empty |

That was **the last named consumer H.2 owed anyone**. `FeatureDataSource` can now be a random-access source rather than a linear read, which is what G1.3 named when it closed. The other two — `smartMergeHeaders` and `VariantContextComparator` — landed in htsjdk-rs#81 and #82.

## The dump was written before the port, and earned that three times

Two of the three would not have failed loudly.

- **the type identifiers cannot be read out of the Java at all.** `LinearIndex.INDEX_TYPE` reads a field of the `IndexType` enum whose own constructor is handed `LinearIndex.INDEX_TYPE`. Measured: `1` and `2`, under magic `1480870228` = `TIDX`;
- **the bin width is per contig** — 16000 and 8000 in one file. A reader assuming the creator's default would answer every query wrongly and **never fail**;
- **the header carries the source file's modification time**, so the raw bytes differ on every run. Measured by running the dump twice and diffing, not reasoned about. The golden masks those eight bytes and reports the offset, which keeps the rest of the layout under test instead of leaving the file quietly unstable — the failure mode where a suite "flakes" and gets repaired by regeneration.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Part of #13.
