### PR TITLE
The list decision 0023 promised, built by walking the call sites

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -512,12 +512,23 @@ Everything downstream inherits these, so they are front-loaded.
       **and CRAI with it**: a sub-project on its own
 - [ ] **GKL-exact deflate** (ISA-L / igzip byte-exact), the default non-JDK path. Until it
       exists, every byte claim over BGZF must name the deflater it is a claim about
-- [~] **jmath**: bit-exact Java `Math` / `StrictMath` / commons-math3 `FastMath`, plus `Gamma`,
-      `BinomialDistribution`, SVD. `Percentile` and `Median` are ported and oracle-backed. The
-      target is **not** "the corpus reaches 100%": its columns are `java.lang.Math`, whose
-      remaining divergent functions can only be made exact by transcribing GPL2 source, so that
-      is unreachable by construction. htsjdk-rs decision 0023 replaced it with "every function a
-      ported call site reaches is exact, and every one that cannot be is named at the call site" 
+- [~] **jmath**. The target is **not** "the corpus reaches 100%": its columns are `java.lang.Math`,
+      whose remaining divergent functions can only be made exact by transcribing GPL2 source, so
+      that is unreachable by construction. htsjdk-rs decision 0023 replaced it with "every function
+      a ported call site reaches is exact, and every one that cannot be is named at the call site".
+
+      **The rule was written down and the list was not.** It is now, in
+      `docs/numeric-functions-a-ported-call-site-reaches.md`, built by walking the call sites rather
+      than the library. Eight functions are reached through jmath and every one is exact or
+      bounded; **six call sites reach the host libm directly**, and those are the whole of the gap:
+      four `powf`, one `exp` in the activity profile that should be `strict_math::exp`, and
+      `log1mexp`'s `ln_1p`/`expm1` pair, which nothing in G1 reaches. `StrictMath.exp` and
+      `StrictMath.pow` are exact and `Math.exp`/`Math.pow` are each bounded at **1 ulp**
+      (decisions 0025 and 0027).
+
+      `BinomialDistribution` and SVD, the other two names this entry used to carry, are **not
+      reached by anything ported**: both are Mutect2-family and therefore Milestone G3. The honest
+      entry for them is "waits for G3" rather than "remaining" 
 - [ ] BGZF GKL/igzip surface cross-checked on real x86-64 hardware, not under emulation
 
 ---

--- a/docs/numeric-functions-a-ported-call-site-reaches.md
+++ b/docs/numeric-functions-a-ported-call-site-reaches.md
@@ -1,0 +1,50 @@
+# Which numeric functions a ported call site reaches, and what each one is worth
+
+htsjdk-rs decision 0023 replaced "the jmath corpus reaches 100%" — unreachable by construction,
+because its columns are `java.lang.Math` and the remaining divergent functions can only be made
+exact by transcribing GPL2 source — with a rule:
+
+> every function a ported call site reaches is exact, and every one that cannot be is named at the
+> call site.
+
+The rule was written down and the list was not. This is the list, produced by walking the call
+sites rather than the library: what a ported path actually reaches, and what is known about each.
+
+## Reached through `jmath`
+
+| function | call sites | status |
+|---|---|---|
+| `math::log` | 14 | **exact**. Correctly rounded in the reference, so rounding the true result suffices (decision 0006) |
+| `math::sqrt` | 2 | **exact**. IEEE 754 mandates the rounding, so every implementation already agrees |
+| `math::round`, `fast_math::round` | 4 | **exact**, oracle-backed |
+| `strict_math::exp` | 1, in `NaturalLogUtils` | **exact** against `StrictMath.exp`; the call site's own reference is `Math.exp`, which is **1 ulp** away (decision 0025) |
+| `gamma::*` | 1 | **exact**, oracle-backed (`gamma-erf-normal`) |
+| `normal::*` | 1 | **exact**, oracle-backed |
+| `percentile::*` | 1 | **exact**, oracle-backed |
+| `saddle_point::hypergeometric_log_probability` | 1 | **exact**, oracle-backed |
+
+## Reached through the host libm, bypassing `jmath`
+
+These are the ones the rule exists for. Each is a place where a ported output depends on whatever
+libm the machine ships.
+
+| call site | function | status |
+|---|---|---|
+| `gatk-engine/src/math_utils.rs:79` — `pow10` | `powf` | **99.9378% against `Math.pow`**, unbounded per call. A bounded alternative now exists (`strict_math::pow`, 1 ulp, decision 0027) and was **measured to be worse here**: switching broke a passing byte-identity claim, because on the points these suites reach the libm is simply closer |
+| `gatk-engine/src/fisher_exact.rs:109` — `pow10` | `powf` | as above |
+| `gatk-annotation/src/allele_pseudo_depth.rs:339,341` — `calculateWeights` | `powf` ×2 | as above. Which of the two runs depends on `weightDecay`, so the exposure varies with an argument |
+| `gatk-engine/src/natural_log_utils.rs:172,174` — `log1mexp` | `ln_1p`, `exp_m1` | **not exact**, and the module says so at the call site. Neither has a ported equivalent, and nothing in G1 reaches this branch |
+| `gatk-engine/src/activity_profile.rs:98` | `exp` | the **host** `exp`, not `strict_math::exp`. 99.9711% against `Math.exp`. Worth revisiting when the activity profile gets its byte claim |
+| `gatk-engine/src/mann_whitney.rs:167` | `powi(3)` | **exact**: an integer power of a `f64` is repeated multiplication, and the reference computes it the same way |
+
+## What this changes
+
+Nothing in the code, and two things in what is claimed.
+
+**The gap is six call sites, not "the corpus".** Every one is named above with the number attached,
+so a future byte claim over any of them knows what it is standing on.
+
+**`BinomialDistribution` and SVD, the other two names in H.5, are not reached by anything ported.**
+Both are Mutect2-family — read orientation, panel of normals, the somatic filters — which is
+Milestone G3. Porting them now would be work ahead of its consumer, and the honest entry for them
+is "waits for G3" rather than "remaining".


### PR DESCRIPTION
Decision 0023 replaced an unreachable target — *"the jmath corpus reaches 100%"*, impossible because its columns are `java.lang.Math` and the divergent remainder can only be made exact by transcribing GPL2 source — with a rule:

> every function a ported call site reaches is exact, and every one that cannot be is named at the call site.

**The rule was written down and the list was not.** This is the list, produced by walking the call sites rather than the library.

## Eight functions reached through jmath, all exact or bounded

`log` (14 sites, correctly rounded), `sqrt` (IEEE-mandated), `round`, `gamma`, `normal`, `percentile`, `saddle_point`, and `strict_math::exp` — exact against `StrictMath.exp`, and **1 ulp** from the `Math.exp` its call site is really about.

## Six call sites reach the host libm directly, and those are the whole gap

| call site | function | status |
|---|---|---|
| `math_utils::pow10`, `fisher_exact::pow10` | `powf` ×2 | 99.9378% against `Math.pow`, unbounded per call |
| `allele_pseudo_depth::calculate_weights` | `powf` ×2 | as above; which of the two runs depends on `weightDecay` |
| `activity_profile.rs:98` | `exp` | the **host's**, not `strict_math::exp`. Worth revisiting when that path gets a byte claim |
| `natural_log_utils::log1mexp` | `ln_1p`, `expm1` | no ported equivalent; nothing in G1 reaches this branch |

A bounded alternative to `powf` now exists (decision 0027, 1 ulp) and was **measured to be worse here**: switching broke a passing byte-identity claim, because on the points these suites reach the libm is simply closer.

`powi(3)` in `mann_whitney` is on the list and is **exact** — an integer power is repeated multiplication and the reference computes it the same way.

## The entry loses two names it should not have carried

`BinomialDistribution` and SVD are reached by **nothing ported**: both are Mutect2-family, so Milestone G3. Porting them now would be work ahead of its consumer, and *"waits for G3"* is the honest status rather than *"remaining"*.

Documentation only. Full list in `docs/numeric-functions-a-ported-call-site-reaches.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Part of #13.
