### PR TITLE
Name a candidate-golden artefact after its suites, not its job index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,39 +113,51 @@ jobs:
         include:
           - group: oracle-backed
             index: "1/12"
+            slug: "annotation-original-alignment-annotation-per-allele-variant-getters-annotation-likelihood-counts-genotyper-allele-likelihoods"
             suites: "annotation-original-alignment annotation-per-allele variant-getters annotation-likelihood-counts genotyper-allele-likelihoods"
           - group: oracle-backed
             index: "2/12"
+            slug: "genotyper-allele-list-annotation-counting-readfilters-readsdatasource-referencecontext"
             suites: "genotyper-allele-list annotation-counting readfilters readsdatasource referencecontext"
           - group: oracle-backed
             index: "3/12"
+            slug: "readwalker-printreads-record-transform-fix-misencoded-intervalwalker"
             suites: "readwalker printreads record-transform fix-misencoded intervalwalker"
           - group: oracle-backed
             index: "4/12"
+            slug: "alignmentstate-pileupelement-intervalfile-jexlfilter-featurecache"
             suites: "alignmentstate pileupelement intervalfile jexlfilter featurecache"
           - group: oracle-backed
             index: "5/12"
+            slug: "readpileup-readstates-locusiterator-acbuilder-locuswalker"
             suites: "readpileup readstates locusiterator acbuilder locuswalker"
           - group: oracle-backed
             index: "6/12"
+            slug: "javarandom-reservoir-well19937c-leveling-variantwalker"
             suites: "javarandom reservoir well19937c leveling variantwalker"
           - group: oracle-backed
             index: "7/12"
+            slug: "activityprofile-assemblyregion-intervaliterators-assemblyregioniterator-assemblyregionwalker"
             suites: "activityprofile assemblyregion intervaliterators assemblyregioniterator assemblyregionwalker"
           - group: oracle-backed
             index: "8/12"
+            slug: "mann-whitney-annotation-rank-sum-annotation-strand-bias-annotation-read-grouping-annotation-depth-per-allele"
             suites: "mann-whitney annotation-rank-sum annotation-strand-bias annotation-read-grouping annotation-depth-per-allele"
           - group: oracle-backed
             index: "9/12"
+            slug: "annotation-flow-annotation-site-statistics-annotation-heterozygosity-and-mq-annotation-allele-specific-rank-sum-annotation-allele-specific-strand-bias"
             suites: "annotation-flow annotation-site-statistics annotation-heterozygosity-and-mq annotation-allele-specific-rank-sum annotation-allele-specific-strand-bias"
           - group: oracle-backed
             index: "10/12"
+            slug: "annotation-allele-specific-site-statistics-annotation-pedigree-annotation-fragment-counts-annotation-haplotype-filtering-multipasswalker"
             suites: "annotation-allele-specific-site-statistics annotation-pedigree annotation-fragment-counts annotation-haplotype-filtering multipasswalker"
           - group: oracle-backed
             index: "11/12"
+            slug: "barclay-value-model-barclay-tagged-arguments-barclay-argument-collections-barclay-arguments-file-barclay-plugin-descriptors"
             suites: "barclay-value-model barclay-tagged-arguments barclay-argument-collections barclay-arguments-file barclay-plugin-descriptors"
           - group: oracle-backed
             index: "12/12"
+            slug: "natural-log-utils-somatic-likelihoods-decimal-format-allele-pseudo-depth"
             suites: "natural-log-utils somatic-likelihoods decimal-format allele-pseudo-depth"
     steps:
       - uses: actions/checkout@v4
@@ -174,7 +186,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: candidate-goldens-${{ matrix.group }}-${{ strategy.job-index }}
+          name: candidate-goldens-${{ matrix.slug }}
           path: tools/conformance/pending/
           if-no-files-found: ignore
 

--- a/tools/conformance/generate_ci.py
+++ b/tools/conformance/generate_ci.py
@@ -90,9 +90,13 @@ def oracle_jobs(manifest):
         chunks = [group[i : i + per_job] for i in range(0, len(group), per_job)]
         for n, chunk in enumerate(chunks, 1):
             ids = " ".join(s["id"] for s in chunk)
+            # The artefact is named after the suites in the job, not the job's position in the
+            # matrix. Adding a suite renumbers the matrix, and a golden that took the previous
+            # slice's name is a golden published under the wrong claim.
             rows.append(
                 f"          - group: {status}\n"
                 f"            index: \"{n}/{len(chunks)}\"\n"
+                f"            slug: \"{'-'.join(s['id'] for s in chunk)}\"\n"
                 f"            suites: \"{ids}\""
             )
     matrix = "\n".join(rows)
@@ -136,7 +140,7 @@ def oracle_jobs(manifest):
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: candidate-goldens-${{{{ matrix.group }}}}-${{{{ strategy.job-index }}}}
+          name: candidate-goldens-${{{{ matrix.slug }}}}
           path: tools/conformance/pending/
           if-no-files-found: ignore
 """


### PR DESCRIPTION
The artefact carried `strategy.job-index`, so it was named after the job's **position in the matrix**. Adding a suite renumbers the matrix, which means a slice's golden can be published under the name the previous slice's had, and **a golden published under the wrong claim is worse than no golden**.

htsjdk-rs had the same defect and it was fixed there; this is the same fix. The name is now the suite ids of the job joined by hyphens, which is stable under insertion because it does not depend on anything but the job's own contents. The longest is 150 characters, well inside the limit.

Found while taking the golden for `fix-misencoded`, whose artefact was `candidate-goldens-golden-pending-12`.

Closes #148.