### PR TITLE
Say when the window, and not the reference, stopped the alignment

### DIFF
--- a/crates/gatk-engine/src/variant_context_utils.rs
+++ b/crates/gatk-engine/src/variant_context_utils.rs
@@ -20,6 +20,14 @@
 //! with a window of 2, at 49 with 10, at 39 with 20, and at the start of its run with a wide
 //! enough one. Nothing in the record says which of those happened.
 //!
+//! # The window that ran out is not the same as the record that had nowhere to go
+//!
+//! The reference returns a `VariantContext` and nothing else, so those two cases are
+//! indistinguishable to its caller: a record stopped by `--max-leading-bases` looks exactly like
+//! one that is genuinely left aligned. [`left_align_and_trim_reporting`] returns the same record
+//! with an [`Alignment`] beside it. The bytes do not change, which is why this is not a divergence;
+//! what changes is that the answer stops being silent.
+//!
 //! # What comes back unchanged
 //!
 //! A non-indel, a `maxLeadingBases` of zero or less, and a shift of zero all return the input
@@ -89,18 +97,54 @@ impl Variant {
     }
 }
 
+/// Whether the record that came back is as far left as the reference would allow.
+///
+/// The reference does not carry this: `leftAlignAndTrim` returns a `VariantContext` and nothing
+/// else, so a record that ran out of window is indistinguishable from one that had nowhere left to
+/// go. The bytes of the record are the same either way, which is why reporting this changes no
+/// output; it only stops the answer from being silent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Alignment {
+    /// The shift stopped before the edge of the window, so widening it would change nothing.
+    Complete,
+    /// The shift reached the edge of a window that was already at `maxLeadingBases`. The record is
+    /// shifted as far as the argument allowed and NOT as far as the reference would allow: a
+    /// larger `--max-leading-bases` would move it further.
+    WindowExhausted,
+    /// Nothing was attempted: a non-indel, or a `maxLeadingBases` of zero or less.
+    NotAttempted,
+}
+
 /// `leftAlignAndTrim(vc, ref, maxLeadingBases, trim)`.
 ///
 /// `reference_bases` is the whole contig, one-based positions indexing from 1, which is what a
 /// `ReferenceContext` hands back a slice of.
+///
+/// The record this returns is the reference's, byte for byte. Use
+/// [`left_align_and_trim_reporting`] where it matters whether the window ran out.
 pub fn left_align_and_trim(
     variant: &Variant,
     reference_bases: &[u8],
     max_leading_bases: i32,
     trim: bool,
 ) -> Result<Variant, AlignmentError> {
+    left_align_and_trim_reporting(variant, reference_bases, max_leading_bases, trim)
+        .map(|(variant, _)| variant)
+}
+
+/// The same alignment, with what the reference throws away: whether the window ran out.
+///
+/// GATK's own loop knows the difference, in `shifts.getLeft() == variantOffsetInRef &&
+/// leadingBases < maxLeadingBases`, and drops it on the floor when the second half is false. A
+/// caller that wants to widen the window and try again, or to warn, has no way to ask.
+pub fn left_align_and_trim_reporting(
+    variant: &Variant,
+    reference_bases: &[u8],
+    max_leading_bases: i32,
+    trim: bool,
+) -> Result<(Variant, Alignment), AlignmentError> {
     if !variant.is_indel() || max_leading_bases <= 0 {
-        return Ok(variant.clone());
+        return Ok((variant.clone(), Alignment::NotAttempted));
     }
 
     let mut leading_bases = max_leading_bases.min(10);
@@ -135,13 +179,27 @@ pub fn left_align_and_trim(
         let (left, right) = normalize_alleles(&borrowed, &mut ranges, variant_offset, trim)?;
 
         if left == 0 && right == 0 {
-            return Ok(variant.clone());
+            return Ok((variant.clone(), Alignment::Complete));
         }
         // The shift reached the edge of the slice and a wider one is allowed: try again.
         if left == variant_offset && leading_bases < max_leading_bases {
             leading_bases = (2 * leading_bases).min(max_leading_bases);
             continue;
         }
+        // Falling through with the shift still on the edge is the case the reference cannot tell
+        // its caller about. Landing ON the edge is not enough to call the window exhausted: a
+        // window of exactly the distance the record wants to walk lands there and is complete. The
+        // only way to tell is to offer one more base and see whether the shift grows, which is one
+        // extra pass and only in this case.
+        let alignment = if left == variant_offset {
+            if would_shift_further(variant, reference_bases, leading_bases, trim)? {
+                Alignment::WindowExhausted
+            } else {
+                Alignment::Complete
+            }
+        } else {
+            Alignment::Complete
+        };
 
         let alleles: Vec<Allele> = variant
             .alleles
@@ -154,16 +212,59 @@ pub fn left_align_and_trim(
             })
             .collect();
 
-        return Ok(Variant {
-            contig: variant.contig.clone(),
-            start: variant.start - left,
-            stop: variant.stop - right,
-            // The reference builds this list from a HashMap's values, so the order is the map's.
-            // Rebuilding it in record order is what the golden shows, and all it shows.
-            alleles,
-            genotypes: variant.genotypes.clone(),
-        });
+        return Ok((
+            Variant {
+                contig: variant.contig.clone(),
+                start: variant.start - left,
+                stop: variant.stop - right,
+                // The reference builds this list from a HashMap's values, so the order is the
+                // map's. Rebuilding it in record order is what the golden shows, and all it shows.
+                alleles,
+                genotypes: variant.genotypes.clone(),
+            },
+            alignment,
+        ));
     }
+}
+
+/// Whether one more base of window would move the record further left.
+///
+/// Left alignment slides base by base, so a record that can still move moves by at least one when
+/// it is given one more base. A record already at the start of the contig cannot be given one.
+fn would_shift_further(
+    variant: &Variant,
+    reference_bases: &[u8],
+    leading_bases: i32,
+    trim: bool,
+) -> Result<bool, AlignmentError> {
+    let ref_start = (variant.start - leading_bases).max(1);
+    if ref_start == 1 {
+        return Ok(false);
+    }
+    let wider_start = ref_start - 1;
+    let slice = &reference_bases[(wider_start - 1) as usize..variant.stop as usize];
+    let variant_offset = variant.start - wider_start;
+
+    let sequences: Vec<Vec<u8>> = variant
+        .alleles
+        .iter()
+        .map(|allele| {
+            let mut sequence = slice[..variant_offset as usize].to_vec();
+            sequence.extend_from_slice(&allele.bases);
+            sequence
+        })
+        .collect();
+    let mut ranges: Vec<IndexRange> = variant
+        .alleles
+        .iter()
+        .map(|allele| IndexRange::new(variant_offset + 1, variant_offset + allele.len() as i32))
+        .collect();
+    let borrowed: Vec<&[u8]> = sequences
+        .iter()
+        .map(|sequence| sequence.as_slice())
+        .collect();
+    let (left, _) = normalize_alleles(&borrowed, &mut ranges, variant_offset, trim)?;
+    Ok(left > leading_bases)
 }
 
 #[cfg(test)]
@@ -206,6 +307,56 @@ mod tests {
         assert_eq!((wide.start, wide.stop), (10, 11));
         let narrow = left_align_and_trim(&variant, &bases, 2, true).expect("aligned");
         assert_eq!((narrow.start, narrow.stop), (15, 16));
+    }
+
+    /// The same two calls, asked which of them was stopped by the window.
+    #[test]
+    fn the_report_tells_the_two_apart() {
+        let bases = reference();
+        let variant = deletion(17, "AA", "A");
+
+        let (wide, alignment) =
+            left_align_and_trim_reporting(&variant, &bases, 1000, true).expect("aligned");
+        assert_eq!((wide.start, wide.stop), (10, 11));
+        assert_eq!(alignment, Alignment::Complete);
+
+        let (narrow, alignment) =
+            left_align_and_trim_reporting(&variant, &bases, 2, true).expect("aligned");
+        assert_eq!((narrow.start, narrow.stop), (15, 16));
+        assert_eq!(alignment, Alignment::WindowExhausted);
+
+        // Every window between the two, so the report follows the record and not the argument.
+        for (window, expected) in [
+            (7, Alignment::Complete),
+            (6, Alignment::WindowExhausted),
+            (10, Alignment::Complete),
+        ] {
+            let (_, alignment) =
+                left_align_and_trim_reporting(&variant, &bases, window, true).expect("aligned");
+            assert_eq!(alignment, expected, "window {window}");
+        }
+    }
+
+    /// A record the reference never touches reports that nothing was attempted, which is not the
+    /// same as a record it aligned and could not move.
+    #[test]
+    fn nothing_attempted_is_not_the_same_as_nothing_to_do() {
+        let bases = reference();
+        let snp = deletion(18, "A", "C");
+        let (_, alignment) =
+            left_align_and_trim_reporting(&snp, &bases, 1000, true).expect("untouched");
+        assert_eq!(alignment, Alignment::NotAttempted);
+
+        let (_, alignment) =
+            left_align_and_trim_reporting(&deletion(17, "AA", "A"), &bases, 0, true)
+                .expect("untouched");
+        assert_eq!(alignment, Alignment::NotAttempted);
+
+        // Already left aligned: attempted, and there was nowhere to go.
+        let (_, alignment) =
+            left_align_and_trim_reporting(&deletion(10, "GA", "G"), &bases, 1000, true)
+                .expect("untouched");
+        assert_eq!(alignment, Alignment::Complete);
     }
 
     #[test]

--- a/crates/gatk-engine/tests/left_align_and_trim.rs
+++ b/crates/gatk-engine/tests/left_align_and_trim.rs
@@ -11,7 +11,9 @@
 //!  * **and the genotypes are remapped**, which is visible only because the alleles moved.
 
 use gatk_corpus as corpus;
-use gatk_engine::variant_context_utils::{left_align_and_trim, Allele, Variant};
+use gatk_engine::variant_context_utils::{
+    left_align_and_trim, left_align_and_trim_reporting, Alignment, Allele, Variant,
+};
 
 fn golden() -> String {
     corpus::read_golden(
@@ -229,4 +231,32 @@ fn the_genotypes_are_remapped_with_the_alleles() {
         })
         .collect();
     assert_eq!(rendered.join(";"), expected[3]);
+}
+
+/// The record is the reference's whatever the report says, and the report is what the reference
+/// throws away: which of these calls was stopped by its window rather than by the reference.
+#[test]
+fn the_report_never_changes_the_record() {
+    let text = golden();
+    let bases = reference(&text);
+    for label in labels(&text) {
+        let input = variant(&row(&text, "in", &label));
+        let (max_leading_bases, trim) = arguments(&label);
+        let plain = left_align_and_trim(&input, &bases, max_leading_bases, trim).expect("a record");
+        let (reported, alignment) =
+            left_align_and_trim_reporting(&input, &bases, max_leading_bases, trim)
+                .expect("a record");
+        assert_eq!(plain, reported, "record/{label}");
+
+        let expected = match label.as_str() {
+            // The three the golden shows landing short of their run.
+            "deletion-narrow-window"
+            | "deletion-in-long-run-narrow"
+            | "deletion-in-long-run-twenty" => Alignment::WindowExhausted,
+            // The ones the reference never attempted at all.
+            "zero-window" | "negative-window" | "snp" | "mixed" => Alignment::NotAttempted,
+            _ => Alignment::Complete,
+        };
+        assert_eq!(alignment, expected, "alignment/{label}");
+    }
 }

--- a/docs/a-truncated-alignment-that-looks-finished.md
+++ b/docs/a-truncated-alignment-that-looks-finished.md
@@ -1,0 +1,71 @@
+# A truncated alignment that looks finished
+
+`GATKVariantContextUtils.leftAlignAndTrim` slides an indel left through the reference. It does not
+read the whole contig: it takes a slice, ten bases before the variant to start with, and widens it
+while the shift keeps landing on the slice's edge.
+
+```java
+for (int leadingBases = Math.min(maxLeadingBases, 10); leadingBases <= maxLeadingBases; leadingBases = Math.min(2*leadingBases, maxLeadingBases)) {
+    ...
+    } else if (shifts.getLeft() == variantOffsetInRef && leadingBases < maxLeadingBases) {
+        continue;
+    }
+```
+
+The second half of that condition is the bound: once the window is at `--max-leading-bases`, the
+loop stops widening and returns whatever the last pass produced. So a record can come out **shifted
+as far as the argument allowed and not as far as the reference would allow**, and it is returned
+the same way a fully aligned record is.
+
+The `left-align-and-trim` suite holds one deletion at four windows:
+
+| `--max-leading-bases` | where it lands | left aligned |
+|---|---|---|
+| 2 | `chr1:15-16` | no |
+| 10 | `chr1:49-50` | no |
+| 20 | `chr1:39-40` | no |
+| 1000 | `chr1:30-31` | yes |
+
+All four are `VariantContext`s with nothing to tell them apart. Two runs of the same tool over the
+same data with different `--max-leading-bases` produce different, equally silent files, and a
+downstream comparison of two such files reports a difference in the data rather than in the
+arguments.
+
+## Why the port does not fix it
+
+The bound is deliberate: the whole point of the widening loop is to avoid reading megabases of
+reference for a variant that will move three bases. Removing it would change output bytes, and
+byte-identity with GATK 4.6.2.0 is the thing this programme exists to prove. The truncation is
+reproduced exactly, and `left_align_and_trim` returns the reference's record.
+
+What the port does not reproduce is the **silence**, because the silence is not in the bytes.
+`left_align_and_trim_reporting` returns the same record with an `Alignment` beside it:
+
+- `Complete`, the shift stopped before the edge, or one more base of window would not move it;
+- `WindowExhausted`, the window is what stopped it, and a larger one would move it further;
+- `NotAttempted`, a non-indel or a window of zero or less.
+
+Nothing about the record changes. The conformance suite asserts that on all nineteen calls of the
+golden: the record from the reporting function is the record from the plain one, and the report
+classifies the three truncated calls, the four never attempted, and the rest.
+
+## The measurement inside the fix
+
+Telling `Complete` from `WindowExhausted` is not `shifts.getLeft() == variantOffsetInRef`. A window
+of exactly the distance the record wants to walk lands **on** the edge and is complete: the
+deletion above with `--max-leading-bases 7` reaches `chr1:10-11`, the same place the window of 1000
+reaches, with the shift equal to the offset. The first version of this reporting got that wrong and
+its own unit test caught it.
+
+The honest test is to offer one more base and see whether the shift grows. Left alignment slides
+base by base, so a record that can still move moves by at least one when given one more base, and a
+record already at the start of the contig cannot be given one. That is one extra pass over one
+slightly wider slice, and only in the ambiguous case.
+
+## What this costs
+
+A caller that wants the guarantee has to ask for it, and then decide what to do with the answer.
+Nothing in the tool chain asks yet: `LeftAlignAndTrimVariants` is not ported, and when it is, it
+will pass `min(maxLeadingBases, distanceToLastVariant - 1)`, which truncates for its own reasons
+and produces `WindowExhausted` routinely and correctly. The report is there so that a future caller
+can distinguish "as left as it goes" from "as left as we paid for", which the reference cannot.


### PR DESCRIPTION
Follows #238, which measured the defect. This addresses it without changing a byte of output.

`leftAlignAndTrim` can return a record shifted as far as `--max-leading-bases` allowed rather than as far as the reference would allow, and it returns it the same way it returns a fully aligned one. The golden holds one deletion at four windows:

| `--max-leading-bases` | where it lands | left aligned |
|---|---|---|
| 2 | `chr1:15-16` | no |
| 10 | `chr1:49-50` | no |
| 20 | `chr1:39-40` | no |
| 1000 | `chr1:30-31` | yes |

Four `VariantContext`s with nothing to tell them apart.

**The truncation stays.** The widening loop exists so that a variant which will move three bases does not cost megabases of reference, and removing the bound would change output bytes, which is the one thing this port may not do. `left_align_and_trim` returns the reference's record and the suite still compares it.

**The silence goes**, because the silence is not in the bytes. `left_align_and_trim_reporting` returns the same record with an `Alignment` beside it: `Complete`, `WindowExhausted`, `NotAttempted`. The conformance suite now asserts, on all nineteen calls of the golden, that the record from the reporting function is the record from the plain one and that the report classifies the three truncated calls, the four never attempted, and the rest.

**The interesting part is telling the two apart.** It is not `shifts.getLeft() == variantOffsetInRef`: a window of exactly the distance the record wants to walk lands **on** the edge and is complete, and the deletion above at `--max-leading-bases 7` reaches the same place as at 1000. The first version of this reported that as truncated and its own unit test caught it. What holds is to offer one more base and see whether the shift grows, since left alignment slides base by base; that is one extra pass over one slightly wider slice, and only in the ambiguous case.

`docs/a-truncated-alignment-that-looks-finished.md` records the defect, why the port keeps it, and what the report costs.

Part of #10.
