### PR TITLE
Port the beta-binomial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=67fb5d16713c9e04166414742d038cfc98169b60#67fb5d16713c9e04166414742d038cfc98169b60"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=d0abc933b84337868ab26af8fb9e53ce48d50351#d0abc933b84337868ab26af8fb9e53ce48d50351"
 dependencies = [
  "htsjdk-bgzf",
  "md-5",
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=67fb5d16713c9e04166414742d038cfc98169b60#67fb5d16713c9e04166414742d038cfc98169b60"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=d0abc933b84337868ab26af8fb9e53ce48d50351#d0abc933b84337868ab26af8fb9e53ce48d50351"
 dependencies = [
  "flate2",
  "libz-sys",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=67fb5d16713c9e04166414742d038cfc98169b60#67fb5d16713c9e04166414742d038cfc98169b60"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=d0abc933b84337868ab26af8fb9e53ce48d50351#d0abc933b84337868ab26af8fb9e53ce48d50351"
 dependencies = [
  "flate2",
  "htsjdk-bam",
@@ -295,8 +295,9 @@ dependencies = [
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=67fb5d16713c9e04166414742d038cfc98169b60#67fb5d16713c9e04166414742d038cfc98169b60"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=d0abc933b84337868ab26af8fb9e53ce48d50351#d0abc933b84337868ab26af8fb9e53ce48d50351"
 dependencies = [
+ "htsjdk-tribble",
  "jmath",
 ]
 
@@ -313,7 +314,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=67fb5d16713c9e04166414742d038cfc98169b60#67fb5d16713c9e04166414742d038cfc98169b60"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=d0abc933b84337868ab26af8fb9e53ce48d50351#d0abc933b84337868ab26af8fb9e53ce48d50351"
 
 [[package]]
 name = "lexical-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # ["org.broadinstitute.hellbender", "picard"], which is why `gatk MarkDuplicates` runs Picard's
 # code, and why gatk-rs depends on picard-rs here.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
-picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "67fb5d16713c9e04166414742d038cfc98169b60" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
+picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }

--- a/crates/gatk-engine/src/beta_binomial.rs
+++ b/crates/gatk-engine/src/beta_binomial.rs
@@ -1,0 +1,182 @@
+//! `BetaBinomialDistribution`, ported from
+//! `org.broadinstitute.hellbender.tools.walkers.validation.basicshortmutpileup` (GATK 4.6.2.0).
+//!
+//! A binomial whose success probability is itself drawn from a beta. `SomaticClusteringModel` uses
+//! it for every cluster it carries: the flat background at `alpha = beta = 1`, and the high-AF
+//! cluster at `alpha = 10, beta = 1`.
+//!
+//! # Three commons-math calls
+//!
+//! ```java
+//! return k > n ? Double.NEGATIVE_INFINITY :
+//!         CombinatoricsUtils.binomialCoefficientLog(n, k) + Beta.logBeta(k + alpha, n - k + beta)
+//!                 - Beta.logBeta(alpha, beta);
+//! ```
+//!
+//! All three live in [`jmath`], where the branch structure that makes them what they are is
+//! documented. What this module adds is the argument checking and the order of the three terms.
+//!
+//! # The flat beta is not exactly flat
+//!
+//! At `alpha = beta = 1` the distribution is uniform over `0..=n` in the mathematics, and the
+//! reference does not quite say so in doubles: at `n = 10` the answer is `-2.3978952727983707` at
+//! `k = 0`, `-2.3978952727983716` at `k = 1` and `-2.39789527279837` at `k = 5`. The cancellation
+//! between the coefficient and the two beta terms is approximate, and it lands on three different
+//! doubles. A port that special-cased the uniform case would be smoother than the reference.
+//!
+//! # `k > n` is a branch, not arithmetic
+//!
+//! Negative infinity comes from the ternary rather than from a coefficient of zero, and it is
+//! checked *after* the negative-`k` refusal.
+
+use jmath::beta::{log_beta, BetaError};
+use jmath::combinatorics::{binomial_coefficient_log, CombinatoricsError};
+
+/// What the distribution refuses, each of them a `ParamUtils` check in the reference.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BetaBinomialError {
+    /// `alpha must be greater than zero.`
+    AlphaNotPositive { alpha: f64 },
+    /// `beta must be greater than zero.`
+    BetaNotPositive { beta: f64 },
+    /// `number of trials must be greater than (or equal to) zero.`
+    TrialsNegative { n: i32 },
+    /// `Number of successes must be greater than or equal to zero.`
+    SuccessesNegative { k: i32 },
+    /// A beta the port has not measured.
+    Beta(BetaError),
+    /// A coefficient the port has not measured.
+    Combinatorics(CombinatoricsError),
+}
+
+impl From<BetaError> for BetaBinomialError {
+    fn from(error: BetaError) -> Self {
+        BetaBinomialError::Beta(error)
+    }
+}
+
+impl From<CombinatoricsError> for BetaBinomialError {
+    fn from(error: CombinatoricsError) -> Self {
+        BetaBinomialError::Combinatorics(error)
+    }
+}
+
+/// The two shape parameters and a number of trials, validated once at construction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BetaBinomialDistribution {
+    alpha: f64,
+    beta: f64,
+    n: i32,
+}
+
+impl BetaBinomialDistribution {
+    /// The reference's constructor, with its three `ParamUtils` checks in order.
+    pub fn new(alpha: f64, beta: f64, n: i32) -> Result<Self, BetaBinomialError> {
+        // `isPositive` is `> 0`, so it refuses NaN as well as zero.
+        if alpha.is_nan() || alpha <= 0.0 {
+            return Err(BetaBinomialError::AlphaNotPositive { alpha });
+        }
+        if beta.is_nan() || beta <= 0.0 {
+            return Err(BetaBinomialError::BetaNotPositive { beta });
+        }
+        if n < 0 {
+            return Err(BetaBinomialError::TrialsNegative { n });
+        }
+        Ok(Self { alpha, beta, n })
+    }
+
+    /// `logProbability(k)`.
+    pub fn log_probability(&self, k: i32) -> Result<f64, BetaBinomialError> {
+        if k < 0 {
+            return Err(BetaBinomialError::SuccessesNegative { k });
+        }
+        if k > self.n {
+            return Ok(f64::NEG_INFINITY);
+        }
+        // `k + alpha` and `n - k + beta`, the integer part summed as an integer first.
+        Ok(binomial_coefficient_log(self.n as i64, k as i64)?
+            + log_beta(k as f64 + self.alpha, (self.n - k) as f64 + self.beta)?
+            - log_beta(self.alpha, self.beta)?)
+    }
+
+    /// `probability(k)`, which is `Math.exp` of the log.
+    ///
+    /// Under decision 0014 `Math.exp` cannot be transcribed, so this is the platform's `exp` and is
+    /// not asserted bit-exact anywhere. `log_probability` is the one the clustering model uses.
+    pub fn probability(&self, k: i32) -> Result<f64, BetaBinomialError> {
+        Ok(self.log_probability(k)?.exp())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flat() -> BetaBinomialDistribution {
+        BetaBinomialDistribution::new(1.0, 1.0, 10).expect("valid")
+    }
+
+    #[test]
+    fn the_flat_cluster_lands_on_three_different_doubles() {
+        assert_eq!(
+            flat().log_probability(0).expect("valid"),
+            -2.3978952727983707
+        );
+        assert_eq!(
+            flat().log_probability(1).expect("valid"),
+            -2.3978952727983716
+        );
+        assert_eq!(flat().log_probability(5).expect("valid"), -2.39789527279837);
+        // And `k = n` comes back to where `k = 0` was.
+        assert_eq!(
+            flat().log_probability(10).expect("valid"),
+            -2.3978952727983707
+        );
+    }
+
+    // The last value here is one digit short of `LN_2` and is a different double from it, which is
+    // the whole point of asserting it, so the lint that wants the constant is switched off.
+    #[allow(clippy::approx_constant)]
+    #[test]
+    fn the_high_af_cluster_rises_with_the_alternate_count() {
+        let high = BetaBinomialDistribution::new(10.0, 1.0, 10).expect("valid");
+        assert_eq!(high.log_probability(0).expect("valid"), -12.126791314602453);
+        assert_eq!(high.log_probability(1).expect("valid"), -9.824206221608407);
+        assert_eq!(high.log_probability(5).expect("valid"), -4.5248893547272875);
+        // Not `-0.6931471805599453`: one digit shorter, and a different double.
+        assert_eq!(high.log_probability(10).expect("valid"), -0.693147180559945);
+    }
+
+    #[test]
+    fn a_count_past_the_total_is_negative_infinity_and_a_negative_one_is_a_refusal() {
+        assert_eq!(
+            flat().log_probability(11).expect("valid"),
+            f64::NEG_INFINITY
+        );
+        assert_eq!(
+            flat().log_probability(-1),
+            Err(BetaBinomialError::SuccessesNegative { k: -1 })
+        );
+    }
+
+    #[test]
+    fn the_constructor_checks_in_the_reference_s_order() {
+        assert_eq!(
+            BetaBinomialDistribution::new(0.0, 1.0, 10),
+            Err(BetaBinomialError::AlphaNotPositive { alpha: 0.0 })
+        );
+        assert_eq!(
+            BetaBinomialDistribution::new(1.0, -1.0, 10),
+            Err(BetaBinomialError::BetaNotPositive { beta: -1.0 })
+        );
+        assert_eq!(
+            BetaBinomialDistribution::new(1.0, 1.0, -1),
+            Err(BetaBinomialError::TrialsNegative { n: -1 })
+        );
+        // A bad alpha is reported even when the trial count is bad too, and NaN is a bad alpha.
+        assert!(matches!(
+            BetaBinomialDistribution::new(f64::NAN, 1.0, -1),
+            Err(BetaBinomialError::AlphaNotPositive { alpha }) if alpha.is_nan()
+        ));
+    }
+}

--- a/crates/gatk-engine/src/feature_intervals.rs
+++ b/crates/gatk-engine/src/feature_intervals.rs
@@ -174,13 +174,16 @@ impl RegisteredCodecs {
             // a malformed header and a malformed record in the same file are two classes.
             Err(error) => return Err(IntervalArgumentError::FeatureSourceFailed(error.0)),
         };
+        // The version the file declared, which the codec's text transformer needs: the percent
+        // escapes are read back only from 4.3 onwards.
+        let version = frame.version;
         let header = htsjdk_vcf::header::VcfHeader {
             lines: Vec::new(),
             samples: frame.samples,
         };
         let mut intervals = Vec::new();
         for (number, line) in text.lines().enumerate() {
-            match htsjdk_vcf::record_parse::decode_line(line, &header, number) {
+            match htsjdk_vcf::record_parse::decode_line(line, &header, number, version) {
                 Ok(Some(decoded)) => {
                     let variant = decoded.variant;
                     intervals.push(crate::interval::parse_interval(

--- a/crates/gatk-engine/src/lib.rs
+++ b/crates/gatk-engine/src/lib.rs
@@ -16,6 +16,7 @@ pub mod assembly_region_walker;
 pub mod baq;
 pub mod base_recalibration_engine;
 pub mod base_utils;
+pub mod beta_binomial;
 pub mod bqsr_transformer;
 pub mod cigar_builder;
 pub mod cigar_utils;

--- a/crates/gatk-engine/tests/beta_binomial.rs
+++ b/crates/gatk-engine/tests/beta_binomial.rs
@@ -1,0 +1,86 @@
+//! Conformance for the beta-binomial against GATK 4.6.2.0, compared as every row of the dump.
+//!
+//! Golden from `tools/readfilter-conformance/BetaBinomialDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **`logBeta` is the four-branch NSWC expansion**, not `logGamma(p) + logGamma(q) -
+//!    logGamma(p + q)`, and the fifty-two shapes cross every branch boundary;
+//!  * **`logBeta(1, 1)` is negative zero**, which the comparison catches only because it is made on
+//!    the formatted string rather than on the double;
+//!  * **`binomialCoefficientLog` picks its route by `n`**, an exact integer coefficient at ten and a
+//!    rounded floating product at a hundred and a thousand;
+//!  * **the flat cluster is not bit-identically uniform**, landing on three different doubles at
+//!    `n = 10`;
+//!  * **and a count past the total is negative infinity while a negative one is a refusal**.
+//!
+//! Every row is reproduced, and every row is bit-identical: unlike the sibling Mutect suites nothing
+//! here goes through `exp`, so decision 0014 does not apply and there is no ulp allowance.
+
+use gatk_corpus as corpus;
+use gatk_engine::beta_binomial::{BetaBinomialDistribution, BetaBinomialError};
+use gatk_engine::tsv_table::java_double_to_string;
+use jmath::beta::log_beta;
+use jmath::combinatorics::binomial_coefficient_log;
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/beta_binomial.txt.gz"),
+    )
+}
+
+/// A label field, parsed the way `Double.toString` wrote it.
+fn double(text: &str) -> f64 {
+    text.parse().unwrap_or_else(|_| panic!("a double: {text}"))
+}
+
+fn integer(text: &str) -> i32 {
+    text.parse()
+        .unwrap_or_else(|_| panic!("an integer: {text}"))
+}
+
+/// The dump's line for one beta-binomial, refusal included.
+fn beta_binomial_line(label: &str) -> String {
+    let fields: Vec<&str> = label.split(',').collect();
+    let answer =
+        BetaBinomialDistribution::new(double(fields[0]), double(fields[1]), integer(fields[2]))
+            .and_then(|distribution| distribution.log_probability(integer(fields[3])));
+    match answer {
+        Ok(value) => format!("betabinom\t{label}\t{}", java_double_to_string(value)),
+        // The one refusal reachable here, reported as the reference's exception and message.
+        Err(BetaBinomialError::SuccessesNegative { .. }) => format!(
+            "error\t{label}\tjava.lang.IllegalArgumentException:Number of successes must be \
+             greater than or equal to zero."
+        ),
+        Err(other) => panic!("{label}: {other:?}"),
+    }
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let text = golden();
+    let mut rows = 0;
+    for line in text.lines().filter(|line| !line.starts_with('#')) {
+        let mut fields = line.splitn(3, '\t');
+        let kind = fields.next().expect("a kind");
+        let label = fields.next().expect("a label");
+        let ours = match kind {
+            "logbeta" => {
+                let (p, q) = label.split_once(',').expect("two shapes");
+                let value = log_beta(double(p), double(q)).expect("in range");
+                format!("logbeta\t{label}\t{}", java_double_to_string(value))
+            }
+            "binomlog" => {
+                let (n, k) = label.split_once(',').expect("a total and a count");
+                let value = binomial_coefficient_log(integer(n) as i64, integer(k) as i64)
+                    .expect("in range");
+                format!("binomlog\t{label}\t{}", java_double_to_string(value))
+            }
+            "betabinom" | "error" => beta_binomial_line(label),
+            other => panic!("an unexpected row: {other}"),
+        };
+        assert_eq!(ours, line);
+        rows += 1;
+    }
+    assert_eq!(rows, 89, "the golden's row count");
+}

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -3315,7 +3315,7 @@
         {
           "dump": "BetaBinomialDump",
           "golden": "crates/gatk-engine/tests/data/beta_binomial.txt.gz",
-          "why": "89 rows: no files at all. Fifty-two logBeta values over a 7x7 grid of shapes from 0.01 to 100 plus three shapes a fuzzy binomial cluster produces; fifteen binomial coefficients over five totals; twenty-one beta-binomial likelihoods over the two shapes SomaticClusteringModel starts with and three totals; and the two refusals. MEASURED AHEAD OF ANY PORT: the Rust side needs Beta.logBeta's four NSWC helpers, Gamma.gamma and both binomial-coefficient variants, of which jmath currently has log_gamma, log_gamma1p and the FastMath log. This golden is the instrument that port will be judged by. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 31882061904."
+          "why": "89 rows: no files at all. Fifty-two logBeta values over a 7x7 grid of shapes from 0.01 to 100 plus three shapes a fuzzy binomial cluster produces; fifteen binomial coefficients over five totals; twenty-one beta-binomial likelihoods over the two shapes SomaticClusteringModel starts with and three totals; and the two refusals. MEASURED AHEAD OF THE PORT, which then reproduced all 89 rows bit-identically: Beta.logBeta's four NSWC helpers, Gamma.gamma and both binomial-coefficient variants went into jmath beside the log_gamma and FastMath log it already had, and BetaBinomialDistribution into gatk-engine on top of them. Nothing here goes through exp, so decision 0014 does not apply and the comparison has no ulp allowance. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 31882061904."
         }
       ]
     }


### PR DESCRIPTION
Closes #321.

`BetaBinomialDistribution.logProbability`, which `SomaticClusteringModel` evaluates for every cluster
it carries, and the three commons-math calls under it:

```java
CombinatoricsUtils.binomialCoefficientLog(n, k) + Beta.logBeta(k + alpha, n - k + beta)
        - Beta.logBeta(alpha, beta)
```

The three primitives went into jmath (IPNP-BIPN/htsjdk-rs#165), beside the `log_gamma` and `FastMath`
log it already had; this side adds the argument checking and the order of the terms.

All 89 rows of the `beta-binomial` golden are reproduced **bit-identically**, including the ones that
make the port worth having:

- `logBeta(1, 1)` is **negative zero**, so the comparison is made on the formatted string rather than
  on the double, where `==` could not see it.
- The flat background cluster is uniform in the mathematics and lands on **three different doubles**
  at `n = 10` (`...707`, `...716`, `...700`). A port that special-cased the uniform case would be
  smoother than the reference.
- `binomialCoefficientLog` picks its route by `n`: an exact integer coefficient at ten, a rounded
  floating product at a hundred and a thousand.
- A count past the total is negative infinity by a branch rather than by arithmetic; a negative one
  is a refusal.

Nothing here goes through `exp`, so decision 0014 does not apply and the comparison carries no ulp
allowance, unlike the sibling Mutect suites.

The jmath bump also brings a `decode_line` that takes the version the file declared, its text
transformer reading the percent escapes only from 4.3 onwards. `feature_intervals` passes what the
header frame had already parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)