### PR TITLE
Measure the allele-fraction clusters, whose corrected likelihood is a Dirichlet normalisation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,10 @@ jobs:
             index: "28/28"
             slug: "germline-probability-mutect-engine-construction-mutect-error-probabilities-beta-binomial"
             suites: "germline-probability mutect-engine-construction mutect-error-probabilities beta-binomial"
+          - group: golden-pending
+            index: "1/1"
+            slug: "allele-fraction-cluster"
+            suites: "allele-fraction-cluster"
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -3318,6 +3318,41 @@
           "why": "89 rows: no files at all. Fifty-two logBeta values over a 7x7 grid of shapes from 0.01 to 100 plus three shapes a fuzzy binomial cluster produces; fifteen binomial coefficients over five totals; twenty-one beta-binomial likelihoods over the two shapes SomaticClusteringModel starts with and three totals; and the two refusals. MEASURED AHEAD OF THE PORT, which then reproduced all 89 rows bit-identically: Beta.logBeta's four NSWC helpers, Gamma.gamma and both binomial-coefficient variants went into jmath beside the log_gamma and FastMath log it already had, and BetaBinomialDistribution into gatk-engine on top of them. Nothing here goes through exp, so decision 0014 does not apply and the comparison has no ulp allowance. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 31882061904."
         }
       ]
+    },
+    {
+      "id": "allele-fraction-cluster",
+      "status": "golden-pending",
+      "title": "The allele-fraction clusters, whose corrected likelihood is a Dirichlet normalisation",
+      "harness": "tools/readfilter-conformance",
+      "tools": [],
+      "why": "The two AlleleFractionCluster implementations SomaticClusteringModel carries, on top of the beta-binomial the sibling suite pins. THE CORRECTED LOG LIKELIHOOD IS NOT A LIKELIHOOD: it is the record's TLOD corrected for the cluster's shape by four Dirichlet normalisations, g(a, b) - g(a + alt, b + ref) - g(1, 1) + g(1 + alt, 1 + ref), where g is logGamma(sum) - sum(logGamma). The original shape is always FLAT_BETA, so two of the four terms are constants -- AND THEY DO NOT CANCEL IN DOUBLES. BinomialCluster HAS NO BINOMIAL IN IT: its constructor turns a mean into a beta shape at a fixed standard-deviation-over-mean of 0.01, CLAMPING THE MEAN AT 1 - 0.01 first, so a cluster asked for a mean of one is not given one. alphaPlusBeta is ((1 - mean) / (mean * 0.0001)) - 1, enormous at a small mean, which is what drives logBeta into its a >= 10 branch. Datum's non-sequencing-error probability is a COMBINATION computed in the constructor, 1 - (1 - artifactProb) * (1 - nonSomaticProb), and the datum keeps no field for the second input. BetaDistributionShape REFUSES IN TWO DIFFERENT CLASSES, ParamUtils on alpha and Utils.validateArg on beta, with two differently-worded messages. TWO VALUES THE RUN CORRECTED AGAINST WHAT WAS PREDICTED: logDirichletNormalization ON A SINGLE PARAMETER OF 1.0 IS NEGATIVE ZERO while on 0.5 it is positive zero, the numerator's logGamma(1.0) being -0.0 and the denominator's sum starting from 0.0; and a parameter of zero gives NaN rather than -Infinity, commons-math's logGamma answering NaN at zero rather than infinity. logDirichletNormalization(10.0, 1.0) is 2.302585092994052, which is log 10 through two gammas and is NOT the 2.302585092994046 that FastMath.log(10) gives. learn is out of scope: ten epochs of gradient ascent over Gamma.digamma belong with the model's fitting.",
+      "compare": {
+        "mode": "lines"
+      },
+      "expect_rows": 215,
+      "expect_contains": [
+        "dirichlet\t1.0\t-0.0",
+        "dirichlet\t0.5\t0.0",
+        "dirichlet\t10.0,1.0\t2.302585092994052",
+        "dirichlet\t0.0,1.0\tNaN",
+        "fuzzy\t0.5\t4999.5,4999.5",
+        "fuzzy\t1.0\t99.01000000000009,1.0001010101010053",
+        "fuzzy\t2.0\t99.01000000000009,1.0001010101010053",
+        "loglike\tbinomial-0.25-10,5\t-2.8401754312289995",
+        "corrected\tbinomial-0.25-10,5\t-0.44228015838547385",
+        "corrected\tbetabinomial-1.0,1.0-10,5\t0.0",
+        "corrected\ttlod-NaN-10,5\tNaN",
+        "datum\tartifact-only\t0.30000000000000004",
+        "error\talpha-zero\tjava.lang.IllegalArgumentException:alpha must be greater than 0 but got 0.0",
+        "error\tbeta-zero\tjava.lang.IllegalArgumentException:beta must be greater than 0 but got 0.0"
+      ],
+      "cases": [
+        {
+          "dump": "AlleleFractionClusterDump",
+          "golden": null,
+          "why": "215 rows: no files at all. Nine Dirichlet normalisations including a single parameter and a zero; nine mean-to-shape maps across the clamp; the two clusters' likelihood and corrected likelihood over seven count pairs each; five TLODs carried through the correction, both infinities among them; six datum combinations; and the shape refusals. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run PENDING."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/AlleleFractionClusterDump.java
+++ b/tools/readfilter-conformance/AlleleFractionClusterDump.java
@@ -1,0 +1,208 @@
+/*
+ * The two allele-fraction clusters, taken from the reference.
+ *
+ * `SomaticClusteringModel` carries a `BinomialCluster` per allele fraction it tracks and a
+ * `BetaBinomialCluster` beside them, and asks each for two numbers: a plain beta-binomial
+ * `logLikelihood(total, alt)` and a `correctedLogLikelihood(datum)`, which is not a likelihood but a
+ * TLOD corrected for the cluster's shape. Five behaviours this is built to catch.
+ *
+ *   - THE CORRECTION IS FOUR DIRICHLET NORMALISATIONS, `g(a, b) - g(a + alt, b + ref) - g(1, 1) +
+ *     g(1 + alt, 1 + ref)`, where `g` is `logGamma(sum) - sum(logGamma)`. The original shape is
+ *     always FLAT_BETA, so two of the four terms are constants -- and they do not cancel in doubles;
+ *   - `BinomialCluster` HAS NO BINOMIAL IN IT: its constructor turns a mean into a beta shape with a
+ *     fixed standard-deviation-over-mean of 0.01, CLAMPING THE MEAN AT `1 - 0.01` first, so a
+ *     cluster asked for a mean of one is not given one and its two shapes are not symmetric;
+ *   - `alphaPlusBeta` IS `((1 - mean) / (mean * 0.0001)) - 1`, which is enormous at a small mean:
+ *     these are the shapes that reach logBeta's `a >= 10` branch;
+ *   - `Datum`'s NON-SEQUENCING-ERROR PROBABILITY IS A COMBINATION computed in the constructor,
+ *     `1 - (1 - artifactProb) * (1 - nonSomaticProb)`, and the datum keeps no field for the second;
+ *   - AND `BetaDistributionShape` REFUSES IN TWO DIFFERENT CLASSES, `ParamUtils` on alpha and
+ *     `Utils.validateArg` on beta, with two differently-worded messages.
+ *
+ * `learn` is out of scope: ten epochs of gradient ascent over `Gamma.digamma` belong with the
+ * model's fitting.
+ *
+ * Output:
+ *
+ *     dirichlet\t<parameters>\t<value>
+ *     fuzzy\t<mean>\t<alpha>,<beta>
+ *     loglike\t<label>\t<value>
+ *     corrected\t<label>\t<value>
+ *     datum\t<label>\t<non-sequencing-error probability>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: AlleleFractionClusterDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.mutect.SomaticLikelihoodsEngine;
+import org.broadinstitute.hellbender.tools.walkers.mutect.clustering.AlleleFractionCluster;
+import org.broadinstitute.hellbender.tools.walkers.mutect.clustering.BetaBinomialCluster;
+import org.broadinstitute.hellbender.tools.walkers.mutect.clustering.BinomialCluster;
+import org.broadinstitute.hellbender.tools.walkers.mutect.clustering.Datum;
+import org.broadinstitute.hellbender.tools.walkers.readorientation.BetaDistributionShape;
+
+public class AlleleFractionClusterDump {
+
+    /** The means a model tracks, from a subclone to a clonal variant, and the two ends. */
+    static final double[] MEANS = {0.001, 0.01, 0.1, 0.25, 0.5, 0.9, 0.99, 1.0, 2.0};
+
+    /** Counts spanning a shallow site, a deep one, and a site with no alternate reads at all. */
+    static final int[][] COUNTS = {{10, 0}, {10, 1}, {10, 5}, {10, 10}, {100, 3}, {100, 50}, {1000, 7}};
+
+    public static void main(final String[] args) {
+        System.out.println("# AlleleFractionClusterDump: two clusters, and the correction under both");
+
+        // The normalisation the correction is built from, on its own.
+        dirichlet(1.0, 1.0);
+        dirichlet(1.0);
+        dirichlet(0.5);
+        dirichlet(10.0, 1.0);
+        dirichlet(1.0, 10.0);
+        dirichlet(1.0e-6, 1.0);
+        dirichlet(1.0, 2.0, 3.0);
+        dirichlet(9999.0, 99.0);
+        dirichlet(0.0, 1.0);
+
+        // The mean-to-shape map, including the clamp at the top end.
+        for (final double mean : MEANS) {
+            fuzzy(mean);
+        }
+
+        for (final double mean : MEANS) {
+            final AlleleFractionCluster cluster = binomialCluster(mean);
+            if (cluster == null) {
+                continue;
+            }
+            for (final int[] counts : COUNTS) {
+                logLikelihood("binomial-" + Double.toString(mean), cluster, counts[0], counts[1]);
+                corrected("binomial-" + Double.toString(mean), cluster, datum(counts[0], counts[1]));
+            }
+        }
+
+        // The beta-binomial cluster, at the flat shape and at two the model can reach.
+        final double[][] shapes = {{1.0, 1.0}, {10.0, 1.0}, {1.0, 10.0}, {0.5, 0.5}};
+        for (final double[] shape : shapes) {
+            final String label = "betabinomial-" + Double.toString(shape[0]) + "," + Double.toString(shape[1]);
+            final AlleleFractionCluster cluster =
+                    new BetaBinomialCluster(new BetaDistributionShape(shape[0], shape[1]));
+            for (final int[] counts : COUNTS) {
+                logLikelihood(label, cluster, counts[0], counts[1]);
+                corrected(label, cluster, datum(counts[0], counts[1]));
+            }
+        }
+
+        // The TLOD is carried through the correction unchanged, so a datum's odds move the answer.
+        final AlleleFractionCluster flat = new BetaBinomialCluster(BetaDistributionShape.FLAT_BETA);
+        for (final double odds : new double[] {0.0, 5.0, -5.0, Double.NEGATIVE_INFINITY, Double.NaN}) {
+            corrected("tlod-" + Double.toString(odds), flat,
+                    new Datum(odds, 0.0, 0.0, 5, 10, 0));
+        }
+
+        // The combination in `Datum`'s constructor, which is not either input.
+        datumProbability("both-zero", 0.0, 0.0);
+        datumProbability("artifact-only", 0.3, 0.0);
+        datumProbability("non-somatic-only", 0.0, 0.3);
+        datumProbability("both", 0.3, 0.3);
+        datumProbability("artifact-certain", 1.0, 0.5);
+        datumProbability("tiny", 1.0e-10, 1.0e-10);
+
+        // The two refusals, which are two different exception classes.
+        shape("alpha-zero", 0.0, 1.0);
+        shape("beta-zero", 1.0, 0.0);
+        shape("alpha-negative", -1.0, 1.0);
+        shape("beta-nan", 1.0, Double.NaN);
+    }
+
+    static void dirichlet(final double... parameters) {
+        final StringBuilder label = new StringBuilder();
+        for (final double parameter : parameters) {
+            if (label.length() > 0) {
+                label.append(',');
+            }
+            label.append(Double.toString(parameter));
+        }
+        System.out.printf("dirichlet\t%s\t%s%n", label,
+                Double.toString(SomaticLikelihoodsEngine.logDirichletNormalization(parameters)));
+    }
+
+    /** `BinomialCluster`'s mean-to-shape map, read back through the cluster's own toString. */
+    static void fuzzy(final double mean) {
+        final BetaDistributionShape shape = fuzzyBinomial(mean);
+        if (shape == null) {
+            return;
+        }
+        System.out.printf("fuzzy\t%s\t%s,%s%n", Double.toString(mean),
+                Double.toString(shape.getAlpha()), Double.toString(shape.getBeta()));
+    }
+
+    /**
+     * `BinomialCluster.getFuzzyBinomial`, which is private, reproduced here so its two shapes can be
+     * printed. The cluster built beside it is what every likelihood below actually goes through, so a
+     * disagreement between the two would show up as a wrong likelihood rather than being hidden.
+     */
+    static BetaDistributionShape fuzzyBinomial(final double unboundedMean) {
+        final double mean = Math.min(unboundedMean, 1 - 0.01);
+        final double alphaPlusBeta = ((1 - mean) / (mean * 0.01 * 0.01)) - 1;
+        try {
+            return new BetaDistributionShape(mean * alphaPlusBeta, alphaPlusBeta - mean * alphaPlusBeta);
+        } catch (final Exception e) {
+            System.out.printf("error\tfuzzy-%s\t%s:%s%n", Double.toString(unboundedMean),
+                    e.getClass().getName(), ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+            return null;
+        }
+    }
+
+    static AlleleFractionCluster binomialCluster(final double mean) {
+        try {
+            return new BinomialCluster(mean);
+        } catch (final Exception e) {
+            System.out.printf("error\tbinomial-%s\t%s:%s%n", Double.toString(mean),
+                    e.getClass().getName(), ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+            return null;
+        }
+    }
+
+    static void logLikelihood(final String prefix, final AlleleFractionCluster cluster,
+                              final int total, final int alt) {
+        final String label = prefix + "-" + total + "," + alt;
+        try {
+            System.out.printf("loglike\t%s\t%s%n", label,
+                    Double.toString(cluster.logLikelihood(total, alt)));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+
+    static void corrected(final String prefix, final AlleleFractionCluster cluster, final Datum datum) {
+        final String label = prefix + "-" + datum.getTotalCount() + "," + datum.getAltCount();
+        try {
+            System.out.printf("corrected\t%s\t%s%n", label,
+                    Double.toString(cluster.correctedLogLikelihood(datum)));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+
+    static void datumProbability(final String label, final double artifact, final double nonSomatic) {
+        System.out.printf("datum\t%s\t%s%n", label,
+                Double.toString(new Datum(0.0, artifact, nonSomatic, 5, 10, 0)
+                        .getNonSequencingErrorProb()));
+    }
+
+    static void shape(final String label, final double alpha, final double beta) {
+        try {
+            final BetaDistributionShape shape = new BetaDistributionShape(alpha, beta);
+            System.out.printf("fuzzy\t%s\t%s,%s%n", label, Double.toString(shape.getAlpha()),
+                    Double.toString(shape.getBeta()));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+
+    static Datum datum(final int total, final int alt) {
+        return new Datum(0.0, 0.0, 0.0, alt, total, 0);
+    }
+}


### PR DESCRIPTION
Part of #324.

The two `AlleleFractionCluster` implementations `SomaticClusteringModel` carries, measured on top of
the beta-binomial the sibling suite pins (#321). **216 rows, no files.**

- **The corrected log likelihood is not a likelihood.** It is the record's TLOD corrected for the
  cluster's shape, and the correction is four Dirichlet normalisations,
  `g(a, b) - g(a + alt, b + ref) - g(1, 1) + g(1 + alt, 1 + ref)`, where `g` is
  `logGamma(sum) - sum(logGamma)`. The original shape is always `FLAT_BETA`, so two of the four terms
  are constants, and they do not cancel in doubles.
- **`BinomialCluster` has no binomial in it.** Its constructor turns a mean into a beta shape at a
  fixed standard-deviation-over-mean of `0.01`, clamping the mean at `1 - 0.01` first. A cluster
  asked for a mean of `1.0` and one asked for `2.0` both come out at
  `alpha = 99.01000000000009, beta = 1.0001010101010053`.
- **`alphaPlusBeta` is `((1 - mean) / (mean * 0.0001)) - 1`**, nearly ten million at a mean of
  `0.001`. These are the shapes that drive the ported `logBeta` into its `a >= 10` branch.
- **`Datum`'s non-sequencing-error probability is a combination**, `1 - (1 - artifact) * (1 - nonSomatic)`,
  and an artifact probability of `0.3` alone comes back as `0.30000000000000004`.
- **`BetaDistributionShape` refuses in two different classes**, `ParamUtils` on alpha and
  `Utils.validateArg` on beta.

Two expectations the run corrected: `logDirichletNormalization` on a single parameter of `1.0` is
**negative zero** while on `0.5` it is positive zero, and a parameter of zero gives `NaN` rather than
the `-Infinity` predicted, commons-math's `logGamma` answering `NaN` at zero. A third value worth its
row: `logDirichletNormalization(10.0, 1.0)` is `2.302585092994052`, log 10 through two gammas, and
**not** the `2.302585092994046` that `FastMath.log(10)` gives.

`learn` is deliberately out of scope: ten epochs of gradient ascent over `Gamma.digamma` belong with
the model's fitting.

Java only. The golden lands in a follow-up, from the runner that produces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #10.
