### PR TITLE
Measure the somatic clustering model as constructed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,10 @@ jobs:
             index: "28/28"
             slug: "germline-probability-mutect-engine-construction-mutect-error-probabilities-beta-binomial-allele-fraction-cluster"
             suites: "germline-probability mutect-engine-construction mutect-error-probabilities beta-binomial allele-fraction-cluster"
+          - group: golden-pending
+            index: "1/1"
+            slug: "somatic-clustering-model"
+            suites: "somatic-clustering-model"
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -3353,6 +3353,41 @@
           "why": "215 rows: no files at all. Nine Dirichlet normalisations including a single parameter and a zero; nine mean-to-shape maps across the clamp; the two clusters' likelihood and corrected likelihood over seven count pairs each; five TLODs carried through the correction, both infinities among them; six datum combinations; and the shape refusals. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 31884305133, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "somatic-clustering-model",
+      "status": "golden-pending",
+      "title": "The somatic clustering model as constructed, whose prior map grows when it is asked",
+      "harness": "tools/readfilter-conformance",
+      "tools": [],
+      "why": "SomaticClusteringModel before any learning: the state its constructor puts it in and the answers it gives from that state. getLogPriorOfSomaticVariant MUTATES THE MAP IT READS -- an indel length outside the +/-10 window is not in logVariantPriors, so the getter inserts the current minimum for it and returns that, and asking about a length once changes what a later question can be answered with. The same lengths are therefore asked in two orders, in two models built identically. A SNV'S PRIOR HAS LOG_ONE_THIRD ADDED TO IT AND AN INDEL'S DOES NOT. THE MITOCHONDRIAL DEFAULTS APPLY ONLY WHILE THE FIELD STILL HOLDS THE DEFAULT, the getter comparing field with default by ==. record MUTATES THE CALLER'S ARRAY, zeroing tumorADs for symbolic alleles in place before summing, so the array is printed before and after. TWO THRESHOLDS THAT LOOK ALIKE DO DIFFERENT THINGS: an artifact probability above 0.9 increments the obvious-artifact count and drops the datum, a non-somatic probability above 0.9 drops it silently, and the threshold itself is > and keeps the datum. THE INITIAL WEIGHTS ARE log1p(0.01) AND log(0.01), not a normalised pair: the background weight is log(1.01). logLikelihoodGivenSomatic is a logSumExp over the two initial clusters and is the first thing on this path carrying exp, so it is the part a port bounds at one ulp under decision 0014 rather than asserting equal. THE UNNORMALISED WEIGHTS ARE VISIBLE IN THE ANSWER: logLikelihoodGivenSomatic(0, 0) is 0.019802627296179723, a POSITIVE log likelihood, because the two weights sum to 1.01 rather than to 1. A SYMBOLIC ALTERNATE'S INDEL LENGTH IS -1 rather than zero or a refusal. The EM iteration and the quantile initialisation are out of scope.",
+      "compare": {
+        "mode": "lines"
+      },
+      "expect_rows": 66,
+      "expect_contains": [
+        "prior\tin-window-0\t-14.914122846632385",
+        "prior\tin-window-1\t-16.11809565095832",
+        "prior\trepeated-in-window\t-14.914122846632385",
+        "prior\tmito-snv\t-6.855075021153225",
+        "prior\tmito-snv-overridden\t-6.09861228866811",
+        "prior\tmito-indel-untouched\t-8.634694098727673",
+        "artifactprior\tdefault\t-2.302585092994046",
+        "loglike\t0,0\t0.019802627296179723",
+        "loglike\t10,5\t-2.386765488798953",
+        "ads\tsymbolic-alt-after\t[80, 20, 0]",
+        "artifactprior\tobvious-artifact-learned\t-1.0986122886681098",
+        "artifactprior\tobvious-non-somatic-learned\t-0.6931471805599453",
+        "indellength\tsymbolic\t-1",
+        "error\tshort-array\tjava.lang.IllegalArgumentException:tumorADs must have one entry per allele including the ref allele"
+      ],
+      "cases": [
+        {
+          "dump": "SomaticClusteringModelDump",
+          "golden": null,
+          "why": "66 rows: no files at all. Priors over the whole window and outside it in two orders, the tuned and mitochondrial argument collections, the emission likelihood over eight count pairs, the sequencing-error posterior over four log odds and three indel lengths, six records with their arrays before and after, and the indel length of four record shapes. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run PENDING."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/SomaticClusteringModelDump.java
+++ b/tools/readfilter-conformance/SomaticClusteringModelDump.java
@@ -1,0 +1,236 @@
+/*
+ * SomaticClusteringModel as constructed, taken from the reference.
+ *
+ * The state the constructor puts the model in, and the four read-only answers it gives from that
+ * state, before any learning has happened. Five behaviours this is built to catch.
+ *
+ *   - `getLogPriorOfSomaticVariant` MUTATES THE MAP IT READS. An indel length outside the +/-10
+ *     window is not in `logVariantPriors`, so the getter INSERTS THE CURRENT MINIMUM for it and
+ *     returns that. Asking about a length once changes what the map holds, so the same question
+ *     asked in a different order can be answered differently -- which is why the same lengths are
+ *     asked twice here, in two models built the same way;
+ *   - A SNV'S PRIOR HAS `LOG_ONE_THIRD` ADDED TO IT AND AN INDEL'S DOES NOT, so the two are not one
+ *     prior with a different number;
+ *   - `record` MUTATES THE CALLER'S ARRAY: it zeroes `tumorADs` for symbolic alleles in place before
+ *     summing, so the array the engine passed in comes back changed. The array is printed before and
+ *     after;
+ *   - TWO THRESHOLDS THAT LOOK ALIKE DO DIFFERENT THINGS: an artifact probability above 0.9
+ *     increments the obvious-artifact count and drops the datum, while a non-somatic probability
+ *     above 0.9 drops it silently. Neither is visible directly, so what is measured is the count of
+ *     data the model accumulated, read back through `learnAndClearAccumulatedData` being able to run;
+ *   - AND THE INITIAL WEIGHTS ARE `log1p(0.01)` AND `log(0.01)`, which are not a normalised pair:
+ *     the background weight is log(1.01) and not log(0.99). Their effect is visible in
+ *     `logLikelihoodGivenSomatic`, a logSumExp over the two initial clusters and the first thing
+ *     here that carries `exp`.
+ *
+ * The EM iteration, the quantile initialisation and everything that learns are out of scope.
+ *
+ * Output:
+ *
+ *     prior\t<label>\t<log prior of a somatic variant>
+ *     artifactprior\t<label>\t<log prior of variant versus artifact>
+ *     loglike\t<total>,<alt>\t<logLikelihoodGivenSomatic>
+ *     seqerror\t<label>\t<probabilityOfSequencingError>
+ *     ads\t<label>\t<the caller's array, after record returned>
+ *     indellength\t<label>\t<indelLength(vc, altIndex)>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: SomaticClusteringModelDump
+ */
+
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import org.broadinstitute.hellbender.tools.walkers.mutect.MutectStats;
+import org.broadinstitute.hellbender.tools.walkers.mutect.clustering.Datum;
+import org.broadinstitute.hellbender.tools.walkers.mutect.clustering.SomaticClusteringModel;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.M2FiltersArgumentCollection;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SomaticClusteringModelDump {
+
+    public static void main(final String[] args) {
+        System.out.println("# SomaticClusteringModelDump: the model as constructed, before it learns");
+
+        // The prior for every length in the window, and the two just outside it.
+        final SomaticClusteringModel inWindow = model();
+        for (final int length : new int[] {0, 1, -1, 2, -2, 10, -10}) {
+            prior("in-window-" + length, inWindow, length);
+        }
+
+        // Outside the window, where the getter inserts. Two models, asked the same lengths in
+        // opposite orders, which is what shows the insertion changing the later answer.
+        final SomaticClusteringModel ascending = model();
+        for (final int length : new int[] {11, -11, 50, -50}) {
+            prior("ascending-" + length, ascending, length);
+        }
+        final SomaticClusteringModel descending = model();
+        for (final int length : new int[] {-50, 50, -11, 11}) {
+            prior("descending-" + length, descending, length);
+        }
+        // And the same length twice, which the second time is a plain read.
+        final SomaticClusteringModel repeated = model();
+        prior("repeated-first", repeated, 11);
+        prior("repeated-second", repeated, 11);
+        prior("repeated-in-window", repeated, 0);
+
+        // The prior a non-default argument collection produces.
+        final M2FiltersArgumentCollection loud = new M2FiltersArgumentCollection();
+        loud.logSNVPrior = -5.0;
+        loud.logIndelPrior = -4.0;
+        loud.initialLogPriorOfVariantVersusArtifact = -1.0;
+        final SomaticClusteringModel tuned = new SomaticClusteringModel(loud, List.of());
+        prior("tuned-snv", tuned, 0);
+        prior("tuned-indel", tuned, 3);
+        System.out.printf("artifactprior\ttuned\t%s%n",
+                Double.toString(tuned.getLogPriorOfVariantVersusArtifact()));
+        System.out.printf("artifactprior\tdefault\t%s%n",
+                Double.toString(model().getLogPriorOfVariantVersusArtifact()));
+
+        // The mitochondrial defaults, which only apply while the field still holds the default: the
+        // getter compares the field with the default by ==, so a mitochondrial run that was told the
+        // default value explicitly gets the mitochondrial number and one told anything else does not.
+        final M2FiltersArgumentCollection mito = new M2FiltersArgumentCollection();
+        mito.mitochondria = true;
+        final SomaticClusteringModel mitoModel = new SomaticClusteringModel(mito, List.of());
+        prior("mito-snv", mitoModel, 0);
+        prior("mito-indel", mitoModel, 3);
+        final M2FiltersArgumentCollection mitoSet = new M2FiltersArgumentCollection();
+        mitoSet.mitochondria = true;
+        mitoSet.logSNVPrior = -5.0;
+        final SomaticClusteringModel mitoSetModel = new SomaticClusteringModel(mitoSet, List.of());
+        prior("mito-snv-overridden", mitoSetModel, 0);
+        prior("mito-indel-untouched", mitoSetModel, 3);
+
+        // The emission likelihood over the two initial clusters.
+        final SomaticClusteringModel fresh = model();
+        for (final int[] counts : new int[][] {{10, 0}, {10, 1}, {10, 5}, {10, 10}, {100, 3},
+                {100, 50}, {1000, 7}, {0, 0}}) {
+            logLikelihood(fresh, counts[0], counts[1]);
+        }
+
+        // The sequencing-error posterior, which is the same weighted sum through the corrected
+        // likelihood and then a prior.
+        for (final double odds : new double[] {0.0, 5.0, 20.0, -5.0}) {
+            for (final int[] counts : new int[][] {{10, 5}, {100, 3}}) {
+                sequencingError(fresh, odds, counts[0], counts[1], 0);
+            }
+        }
+        // The same counts at an indel length, which reaches a different prior.
+        sequencingError(fresh, 5.0, 10, 5, 3);
+        sequencingError(fresh, 5.0, 10, 5, -3);
+        // And at a length outside the window, which inserts on the way through.
+        sequencingError(fresh, 5.0, 10, 5, 40);
+
+        // `record`, which changes the array it was given.
+        recorded("one-alt", new int[] {80, 20},
+                new double[] {6.0}, List.of(0.0), List.of(0.0),
+                vc(Allele.REF_A, Allele.ALT_C));
+        recorded("symbolic-alt", new int[] {80, 20, 5},
+                new double[] {6.0, 6.0}, List.of(0.0, 0.0), List.of(0.0, 0.0),
+                vc(Allele.REF_A, Allele.ALT_C, Allele.create("<NON_REF>", false)));
+        recorded("obvious-artifact", new int[] {80, 20},
+                new double[] {6.0}, List.of(0.95), List.of(0.0),
+                vc(Allele.REF_A, Allele.ALT_C));
+        recorded("obvious-non-somatic", new int[] {80, 20},
+                new double[] {6.0}, List.of(0.0), List.of(0.95),
+                vc(Allele.REF_A, Allele.ALT_C));
+        // Exactly at the threshold, which is `>` and therefore keeps the datum.
+        recorded("at-threshold", new int[] {80, 20},
+                new double[] {6.0}, List.of(0.9), List.of(0.9),
+                vc(Allele.REF_A, Allele.ALT_C));
+        // An array whose length does not match the record's allele count.
+        recorded("short-array", new int[] {80},
+                new double[] {6.0}, List.of(0.0), List.of(0.0),
+                vc(Allele.REF_A, Allele.ALT_C));
+
+        // The indel length a record reports per alternate allele.
+        indelLength("snp", vc(Allele.REF_A, Allele.ALT_C), 0);
+        indelLength("insertion", vc(Allele.create("A", true), Allele.create("ACCC", false)), 0);
+        indelLength("deletion", vc(Allele.create("ACCC", true), Allele.create("A", false)), 0);
+        indelLength("symbolic", vc(Allele.REF_A, Allele.create("<DEL>", false)), 0);
+    }
+
+    static SomaticClusteringModel model() {
+        return new SomaticClusteringModel(new M2FiltersArgumentCollection(), List.of());
+    }
+
+    /** A model told how many callable sites there were, which is what switches on the empirical priors. */
+    static SomaticClusteringModel modelWithStats(final double callableSites) {
+        return new SomaticClusteringModel(new M2FiltersArgumentCollection(),
+                List.of(new MutectStats("callable", callableSites)));
+    }
+
+    static void prior(final String label, final SomaticClusteringModel model, final int indelLength) {
+        final VariantContext vc = indelLength == 0 ? vc(Allele.REF_A, Allele.ALT_C)
+                : indelLength > 0 ? vc(Allele.create("A", true), Allele.create("A" + "C".repeat(indelLength), false))
+                : vc(Allele.create("A" + "C".repeat(-indelLength), true), Allele.create("A", false));
+        try {
+            System.out.printf("prior\t%s\t%s%n", label,
+                    Double.toString(model.getLogPriorOfSomaticVariant(vc, 0)));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+
+    static void logLikelihood(final SomaticClusteringModel model, final int total, final int alt) {
+        final String label = total + "," + alt;
+        try {
+            System.out.printf("loglike\t%s\t%s%n", label,
+                    Double.toString(model.logLikelihoodGivenSomatic(total, alt)));
+        } catch (final Exception e) {
+            System.out.printf("error\tloglike-%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+
+    static void sequencingError(final SomaticClusteringModel model, final double odds,
+                                final int total, final int alt, final int indelLength) {
+        final String label = Double.toString(odds) + "-" + total + "," + alt + "-" + indelLength;
+        try {
+            System.out.printf("seqerror\t%s\t%s%n", label, Double.toString(
+                    model.probabilityOfSequencingError(new Datum(odds, 0.0, 0.0, alt, total, indelLength))));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+
+    static void recorded(final String label, final int[] tumorADs, final double[] tumorLogOdds,
+                         final List<Double> artifactProbabilities,
+                         final List<Double> nonSomaticProbabilities, final VariantContext vc) {
+        final SomaticClusteringModel model = modelWithStats(1000.0);
+        System.out.printf("ads\t%s-before\t%s%n", label, Arrays.toString(tumorADs));
+        try {
+            model.record(tumorADs, tumorLogOdds, artifactProbabilities, nonSomaticProbabilities, vc);
+            System.out.printf("ads\t%s-after\t%s%n", label, Arrays.toString(tumorADs));
+            // What the model accumulated, read back through the prior the EM iteration rewrites: a
+            // datum that was dropped cannot move it.
+            model.learnAndClearAccumulatedData();
+            System.out.printf("artifactprior\t%s-learned\t%s%n", label,
+                    Double.toString(model.getLogPriorOfVariantVersusArtifact()));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+
+    static void indelLength(final String label, final VariantContext vc, final int altIndex) {
+        try {
+            System.out.printf("indellength\t%s\t%d%n", label,
+                    SomaticClusteringModel.indelLength(vc, altIndex));
+        } catch (final Exception e) {
+            System.out.printf("error\tindellength-%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+
+    static VariantContext vc(final Allele... alleles) {
+        final Allele reference = alleles[0];
+        return new VariantContextBuilder("dump", "chr1", 100,
+                100 + reference.length() - 1, List.of(alleles)).make();
+    }
+}


### PR DESCRIPTION
Part of #328.

`SomaticClusteringModel` before any learning: the state its constructor puts it in and the answers it
gives from that state. **66 rows, no files.**

- **`getLogPriorOfSomaticVariant` mutates the map it reads.** An indel length outside the ±10 window
  is not in `logVariantPriors`, so the getter inserts the current minimum for it and returns that.
  The same lengths are asked in two orders, in two models built identically.
- **A SNV's prior has `LOG_ONE_THIRD` added to it and an indel's does not**, `-14.914122846632385`
  against `-16.11809565095832` at the defaults.
- **The mitochondrial defaults apply only while the field still holds the default**, the getter
  comparing field with default by `==`. A mitochondrial run whose SNV prior was set explicitly gets
  `-6.09861228866811` where an untouched one gets `-6.855075021153225`, and its indel prior stays
  mitochondrial.
- **`record` mutates the caller's array**, zeroing `tumorADs` for symbolic alleles in place before
  summing: `[80, 20, 5]` goes in and `[80, 20, 0]` comes back.
- **Two thresholds that look alike do different things.** An artifact probability above `0.9`
  increments the obvious-artifact count and drops the datum; a non-somatic probability above `0.9`
  drops it silently; and the comparison is `>`, so `0.9` exactly keeps it. The three learned priors
  that come out are all different.
- **The initial weights are not a normalised pair**, `log1p(0.01)` and `log(0.01)` summing to `1.01`,
  and it shows in the answer: `logLikelihoodGivenSomatic(0, 0)` is `0.019802627296179723`, a
  **positive** log likelihood.
- **A symbolic alternate's indel length is `-1`**, not zero and not a refusal.

`logLikelihoodGivenSomatic` and `probabilityOfSequencingError` are the first things on this path to
carry `exp`, through `logSumExp`, so the port will bound those rather than assert them equal under
htsjdk-rs decision 0014. Everything else here is exact.

Java only. The golden lands in a follow-up, from the runner that produces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #10.
