### PR TITLE
Port the somatic clustering model as constructed

### DIFF
--- a/crates/gatk-engine/src/lib.rs
+++ b/crates/gatk-engine/src/lib.rs
@@ -72,6 +72,7 @@ pub mod recalibration_tables;
 pub mod reference;
 pub mod sa_tag;
 pub mod sam_pileup;
+pub mod somatic_clustering_model;
 pub mod somatic_likelihoods;
 pub mod subset_alleles;
 pub mod threshold_calculator;

--- a/crates/gatk-engine/src/somatic_clustering_model.rs
+++ b/crates/gatk-engine/src/somatic_clustering_model.rs
@@ -1,0 +1,483 @@
+//! `SomaticClusteringModel` as constructed, ported from
+//! `org.broadinstitute.hellbender.tools.walkers.mutect.clustering` (GATK 4.6.2.0).
+//!
+//! The state the constructor puts the model in, and the answers it gives from that state.
+//!
+//! # The prior getter mutates the map it reads
+//!
+//! ```java
+//! if (!logVariantPriors.containsKey(indelLength)) {
+//!     logVariantPriors.put(indelLength, logVariantPriors.values().stream().mapToDouble(d -> d).min().getAsDouble());
+//! }
+//! return logVariantPriors.get(indelLength) + (indelLength == 0 ? MathUtils.LOG_ONE_THIRD : 0);
+//! ```
+//!
+//! The map is built for indel lengths in `-10..=10`, so anything outside that window is inserted on
+//! first ask, at the minimum of what is already there. It takes `&mut self` here for that reason.
+//! Nothing about it is a cache: after learning, the inserted value is one the EM iteration can
+//! rewrite, and which lengths were asked about decides which ones it rewrites.
+//!
+//! # A SNV's prior is not an indel's prior with a different number
+//!
+//! Only a SNV gets `LOG_ONE_THIRD` added, the prior being per mutation and a SNV having had three
+//! bases to choose from.
+//!
+//! # The mitochondrial defaults are decided by `==`
+//!
+//! `getLogSnvPrior` returns the mitochondrial default only while the field still holds the ordinary
+//! default, compared by `==`. A mitochondrial run told its SNV prior explicitly, even at the same
+//! value, gets the ordinary path.
+//!
+//! # The initial weights do not sum to one
+//!
+//! They are `log1p(0.01)` and `log(0.01)`, so the weights are `1.01` and `0.01`. It shows:
+//! [`SomaticClusteringModel::log_likelihood_given_somatic`] at `(0, 0)` is a **positive** log
+//! likelihood.
+//!
+//! # What is not here
+//!
+//! `learnAndClearAccumulatedData`, `initializeClusters` and `performEMIteration`. The EM iteration
+//! and its quantile initialisation are their own slice; [`SomaticClusteringModel::record`]
+//! accumulates the data they would consume.
+
+use crate::allele_fraction_cluster::{AlleleFractionCluster, BetaDistributionShape, Datum};
+use crate::mutect_engine::{log_one_third, posterior_probability_of_error};
+use crate::natural_log_utils::{log_sum_exp, NonFiniteSum};
+
+/// `MAX_INDEL_SIZE_IN_PRIOR_MAP`.
+pub const MAX_INDEL_SIZE_IN_PRIOR_MAP: i32 = 10;
+
+/// `INITIAL_HIGH_AF_WEIGHT`.
+pub const INITIAL_HIGH_AF_WEIGHT: f64 = 0.01;
+
+/// `OBVIOUS_ARTIFACT_PROBABILITY_THRESHOLD`, compared with `>` so a probability of exactly `0.9`
+/// keeps its datum.
+pub const OBVIOUS_ARTIFACT_PROBABILITY_THRESHOLD: f64 = 0.9;
+
+/// The `M2FiltersArgumentCollection` fields this model reads, with the two getters over them.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PriorArguments {
+    pub log_snv_prior: f64,
+    pub log_indel_prior: f64,
+    pub initial_log_prior_of_variant_versus_artifact: f64,
+    pub mitochondria: bool,
+}
+
+impl PriorArguments {
+    /// `DEFAULT_LOG_SNV_PRIOR`, `log10ToLog(-6)`.
+    pub fn default_log_snv_prior() -> f64 {
+        crate::mutect_engine::default_log_snv_prior()
+    }
+
+    /// `DEFAULT_LOG_INDEL_PRIOR`, `log10ToLog(-7)`.
+    pub fn default_log_indel_prior() -> f64 {
+        crate::mutect_engine::default_log_indel_prior()
+    }
+
+    /// `DEFAULT_LOG_SNV_PRIOR_FOR_MITO`, `log10ToLog(-2.5)`.
+    pub fn default_log_snv_prior_for_mito() -> f64 {
+        crate::allele_likelihoods::log10_to_log(-2.5)
+    }
+
+    /// `DEFAULT_LOG_INDEL_PRIOR_FOR_MITO`, `log10ToLog(-3.75)`.
+    pub fn default_log_indel_prior_for_mito() -> f64 {
+        crate::allele_likelihoods::log10_to_log(-3.75)
+    }
+
+    /// `new M2FiltersArgumentCollection()`.
+    pub fn new() -> Self {
+        Self {
+            log_snv_prior: Self::default_log_snv_prior(),
+            log_indel_prior: Self::default_log_indel_prior(),
+            initial_log_prior_of_variant_versus_artifact:
+                crate::mutect_engine::default_log_prior_of_variant_versus_artifact(),
+            mitochondria: false,
+        }
+    }
+
+    /// `getLogSnvPrior()`, whose mitochondrial arm is guarded by `==` against the default.
+    pub fn log_snv_prior(&self) -> f64 {
+        if self.mitochondria && self.log_snv_prior == Self::default_log_snv_prior() {
+            Self::default_log_snv_prior_for_mito()
+        } else {
+            self.log_snv_prior
+        }
+    }
+
+    /// `getLogIndelPrior()`.
+    pub fn log_indel_prior(&self) -> f64 {
+        if self.mitochondria && self.log_indel_prior == Self::default_log_indel_prior() {
+            Self::default_log_indel_prior_for_mito()
+        } else {
+            self.log_indel_prior
+        }
+    }
+}
+
+impl Default for PriorArguments {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// What `record` refuses.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RecordError {
+    /// `Utils.validateArg`: `tumorADs must have one entry per allele including the ref allele`.
+    AlleleDepthsMismatched,
+}
+
+/// One alternate allele of a record, as much of it as this model looks at.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AlternateAllele {
+    /// `Allele.length()`, which is **zero** for a symbolic allele rather than its text's length.
+    pub length: i32,
+    pub symbolic: bool,
+}
+
+/// `SomaticClusteringModel.indelLength(vc, altIndex)`.
+///
+/// A symbolic alternate's length is zero, so a symbolic allele against a one-base reference is an
+/// indel length of `-1` rather than zero or a refusal.
+pub fn indel_length(reference_length: i32, alternate: AlternateAllele) -> i32 {
+    alternate.length - reference_length
+}
+
+/// The model, before any learning.
+#[derive(Debug, Clone)]
+pub struct SomaticClusteringModel {
+    /// `logVariantPriors`, keyed by indel length. Grows when it is asked about a length it lacks.
+    log_variant_priors: Vec<(i32, f64)>,
+    log_variant_vs_artifact_prior: f64,
+    /// `callableSites`, empty when the stats say there were fewer than one.
+    callable_sites: Option<f64>,
+    clusters: Vec<AlleleFractionCluster>,
+    log_cluster_weights: Vec<f64>,
+    /// The data `record` accumulated, which the EM iteration would consume.
+    data: Vec<Datum>,
+    /// `obviousArtifactCount`, incremented only on the artifact threshold and not on the other.
+    obvious_artifact_count: i32,
+}
+
+impl SomaticClusteringModel {
+    /// `new SomaticClusteringModel(MTFAC, mutectStats)`.
+    ///
+    /// `callable_sites` is the `callable` statistic if the stats carry one; a value below one is
+    /// treated as absent, which is the reference's "something is seriously wrong" warning path.
+    pub fn new(arguments: PriorArguments, callable_sites_from_stats: Option<f64>) -> Self {
+        let mut log_variant_priors = Vec::new();
+        for length in -MAX_INDEL_SIZE_IN_PRIOR_MAP..=MAX_INDEL_SIZE_IN_PRIOR_MAP {
+            log_variant_priors.push((length, arguments.log_indel_prior()));
+        }
+        // Written after the loop, so zero holds the SNV prior rather than the indel one.
+        for entry in log_variant_priors.iter_mut() {
+            if entry.0 == 0 {
+                entry.1 = arguments.log_snv_prior();
+            }
+        }
+        let no_callable_sites = callable_sites_from_stats.is_some_and(|sites| sites < 1.0);
+        Self {
+            log_variant_priors,
+            log_variant_vs_artifact_prior: arguments.initial_log_prior_of_variant_versus_artifact,
+            callable_sites: if no_callable_sites {
+                None
+            } else {
+                callable_sites_from_stats
+            },
+            clusters: vec![
+                AlleleFractionCluster::beta_binomial(BetaDistributionShape::FLAT),
+                AlleleFractionCluster::beta_binomial(
+                    BetaDistributionShape::new(10.0, 1.0).expect("a valid initial shape"),
+                ),
+            ],
+            // `log1p(0.01)` and `log(0.01)`: weights of 1.01 and 0.01, which do not sum to one.
+            log_cluster_weights: vec![INITIAL_HIGH_AF_WEIGHT.ln_1p(), INITIAL_HIGH_AF_WEIGHT.ln()],
+            data: Vec::new(),
+            obvious_artifact_count: 0,
+        }
+    }
+
+    /// `getLogPriorOfVariantVersusArtifact()`.
+    pub fn log_prior_of_variant_versus_artifact(&self) -> f64 {
+        self.log_variant_vs_artifact_prior
+    }
+
+    /// `callableSites`, present only when the stats named at least one.
+    pub fn callable_sites(&self) -> Option<f64> {
+        self.callable_sites
+    }
+
+    /// How many data `record` has kept, which is not how many it was given.
+    pub fn accumulated(&self) -> usize {
+        self.data.len()
+    }
+
+    /// `obviousArtifactCount`.
+    pub fn obvious_artifact_count(&self) -> i32 {
+        self.obvious_artifact_count
+    }
+
+    /// `getLogPriorOfSomaticVariant(indelLength)`, which inserts before it reads.
+    pub fn log_prior_of_somatic_variant(&mut self, indel_length: i32) -> f64 {
+        if !self
+            .log_variant_priors
+            .iter()
+            .any(|(length, _)| *length == indel_length)
+        {
+            // `Stream.min` over the values, which is a plain minimum and not a NaN-aware one.
+            let minimum = self
+                .log_variant_priors
+                .iter()
+                .map(|(_, prior)| *prior)
+                .fold(f64::INFINITY, f64::min);
+            self.log_variant_priors.push((indel_length, minimum));
+        }
+        let prior = self
+            .log_variant_priors
+            .iter()
+            .find(|(length, _)| *length == indel_length)
+            .map(|(_, prior)| *prior)
+            .expect("just inserted if it was missing");
+        if indel_length == 0 {
+            prior + log_one_third()
+        } else {
+            prior
+        }
+    }
+
+    /// `logLikelihoodGivenSomatic(totalCount, altCount)`, the weighted sum over the clusters.
+    ///
+    /// The weights are not normalised, so this can be positive: at `(0, 0)` every cluster's
+    /// likelihood is zero and the answer is `log(1.01 + 0.01)`'s worth of weight.
+    pub fn log_likelihood_given_somatic(
+        &self,
+        total_count: i32,
+        alt_count: i32,
+    ) -> Result<f64, NonFiniteSum> {
+        log_sum_exp(&self.cluster_log_likelihoods(total_count, alt_count))
+    }
+
+    fn cluster_log_likelihoods(&self, total_count: i32, alt_count: i32) -> Vec<f64> {
+        self.clusters
+            .iter()
+            .enumerate()
+            .map(|(index, cluster)| {
+                self.log_cluster_weights[index]
+                    + cluster
+                        .log_likelihood(total_count, alt_count)
+                        .expect("the initial shapes and non-negative counts are in range")
+            })
+            .collect()
+    }
+
+    /// `probabilityOfSequencingError(datum)`.
+    ///
+    /// The weighted sum here is over `correctedLogLikelihood`, not over `logLikelihood`: the TLOD
+    /// enters, and the prior that follows depends on the datum's indel length, which is why this
+    /// takes `&mut self`.
+    pub fn probability_of_sequencing_error(&mut self, datum: &Datum) -> Result<f64, NonFiniteSum> {
+        let log_cluster_likelihoods: Vec<f64> = self
+            .clusters
+            .iter()
+            .enumerate()
+            .map(|(index, cluster)| {
+                self.log_cluster_weights[index] + cluster.corrected_log_likelihood(datum)
+            })
+            .collect();
+        let variant_log_likelihood = log_sum_exp(&log_cluster_likelihoods)?;
+        let prior = self.log_prior_of_somatic_variant(datum.indel_length());
+        posterior_probability_of_error(variant_log_likelihood, prior)
+    }
+
+    /// `record(tumorADs, tumorLogOdds, artifactProbabilities, nonSomaticProbabilities, vc)`.
+    ///
+    /// `tumor_ads` is `&mut` because the reference mutates the caller's array: a symbolic alternate's
+    /// depth is zeroed **in place** before the total is summed, and the engine sees the change.
+    pub fn record(
+        &mut self,
+        tumor_ads: &mut [i32],
+        tumor_log_odds: &[f64],
+        artifact_probabilities: &[f64],
+        non_somatic_probabilities: &[f64],
+        alternates: &[AlternateAllele],
+        reference_length: i32,
+    ) -> Result<(), RecordError> {
+        if tumor_ads.len() != alternates.len() + 1 {
+            return Err(RecordError::AlleleDepthsMismatched);
+        }
+        for (index, alternate) in alternates.iter().enumerate() {
+            if alternate.symbolic {
+                tumor_ads[index + 1] = 0;
+            }
+        }
+        let total_ad: i32 = tumor_ads.iter().sum();
+        for (index, alternate) in alternates.iter().enumerate().take(tumor_log_odds.len()) {
+            if alternate.symbolic {
+                continue;
+            }
+            // The two thresholds are the same number and not the same behaviour.
+            if artifact_probabilities[index] > OBVIOUS_ARTIFACT_PROBABILITY_THRESHOLD {
+                self.obvious_artifact_count += 1;
+                continue;
+            } else if non_somatic_probabilities[index] > OBVIOUS_ARTIFACT_PROBABILITY_THRESHOLD {
+                continue;
+            }
+            self.data.push(Datum::new(
+                tumor_log_odds[index],
+                artifact_probabilities[index],
+                non_somatic_probabilities[index],
+                tumor_ads[index + 1],
+                total_ad,
+                indel_length(reference_length, *alternate),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snp() -> AlternateAllele {
+        AlternateAllele {
+            length: 1,
+            symbolic: false,
+        }
+    }
+
+    fn symbolic() -> AlternateAllele {
+        AlternateAllele {
+            length: 0,
+            symbolic: true,
+        }
+    }
+
+    #[test]
+    fn the_prior_getter_grows_the_map() {
+        let mut model = SomaticClusteringModel::new(PriorArguments::new(), None);
+        let inside = model.log_prior_of_somatic_variant(1);
+        let outside = model.log_prior_of_somatic_variant(50);
+        // The minimum of a map holding one SNV prior and twenty indel priors is the indel one.
+        assert_eq!(outside, inside);
+        // And the length is in the map now, so asking again is a plain read.
+        assert_eq!(model.log_prior_of_somatic_variant(50), outside);
+    }
+
+    #[test]
+    fn only_a_snv_gets_the_third() {
+        let mut model = SomaticClusteringModel::new(PriorArguments::new(), None);
+        assert_eq!(
+            model.log_prior_of_somatic_variant(0) - log_one_third(),
+            PriorArguments::default_log_snv_prior()
+        );
+        assert_eq!(
+            model.log_prior_of_somatic_variant(1),
+            PriorArguments::default_log_indel_prior()
+        );
+    }
+
+    #[test]
+    fn the_mitochondrial_default_is_decided_by_an_equality() {
+        let mut arguments = PriorArguments::new();
+        arguments.mitochondria = true;
+        assert_eq!(
+            arguments.log_snv_prior(),
+            PriorArguments::default_log_snv_prior_for_mito()
+        );
+        // Told a different value, it takes that value.
+        arguments.log_snv_prior = -5.0;
+        assert_eq!(arguments.log_snv_prior(), -5.0);
+        // And told exactly the default, it goes back to the mitochondrial arm.
+        arguments.log_snv_prior = PriorArguments::default_log_snv_prior();
+        assert_eq!(
+            arguments.log_snv_prior(),
+            PriorArguments::default_log_snv_prior_for_mito()
+        );
+        // The indel prior is untouched by any of that.
+        assert_eq!(
+            arguments.log_indel_prior(),
+            PriorArguments::default_log_indel_prior_for_mito()
+        );
+    }
+
+    #[test]
+    fn the_unnormalised_weights_make_a_positive_log_likelihood() {
+        let model = SomaticClusteringModel::new(PriorArguments::new(), None);
+        assert!(model.log_likelihood_given_somatic(0, 0).expect("finite") > 0.0);
+    }
+
+    #[test]
+    fn record_zeroes_the_callers_array_and_drops_on_two_thresholds() {
+        let mut model = SomaticClusteringModel::new(PriorArguments::new(), Some(1000.0));
+        let mut ads = [80, 20, 5];
+        model
+            .record(
+                &mut ads,
+                &[6.0, 6.0],
+                &[0.0, 0.0],
+                &[0.0, 0.0],
+                &[snp(), symbolic()],
+                1,
+            )
+            .expect("recorded");
+        assert_eq!(ads, [80, 20, 0], "the caller's array came back changed");
+        assert_eq!(model.accumulated(), 1, "the symbolic alternate was skipped");
+        // The total the datum kept is the sum after the zeroing, not before.
+        assert_eq!(model.data[0].total_count(), 100);
+
+        let mut artifact = SomaticClusteringModel::new(PriorArguments::new(), Some(1000.0));
+        artifact
+            .record(&mut [80, 20], &[6.0], &[0.95], &[0.0], &[snp()], 1)
+            .expect("recorded");
+        assert_eq!(artifact.accumulated(), 0);
+        assert_eq!(artifact.obvious_artifact_count(), 1);
+
+        let mut non_somatic = SomaticClusteringModel::new(PriorArguments::new(), Some(1000.0));
+        non_somatic
+            .record(&mut [80, 20], &[6.0], &[0.0], &[0.95], &[snp()], 1)
+            .expect("recorded");
+        assert_eq!(non_somatic.accumulated(), 0);
+        // The other threshold does not count anything: this is what tells the two apart.
+        assert_eq!(non_somatic.obvious_artifact_count(), 0);
+
+        // And the threshold itself is `>`, so 0.9 exactly keeps the datum.
+        let mut at_threshold = SomaticClusteringModel::new(PriorArguments::new(), Some(1000.0));
+        at_threshold
+            .record(&mut [80, 20], &[6.0], &[0.9], &[0.9], &[snp()], 1)
+            .expect("recorded");
+        assert_eq!(at_threshold.accumulated(), 1);
+    }
+
+    #[test]
+    fn a_short_array_is_a_refusal_and_a_symbolic_length_is_negative() {
+        let mut model = SomaticClusteringModel::new(PriorArguments::new(), None);
+        assert_eq!(
+            model.record(&mut [80], &[6.0], &[0.0], &[0.0], &[snp()], 1),
+            Err(RecordError::AlleleDepthsMismatched)
+        );
+        assert_eq!(indel_length(1, symbolic()), -1);
+        assert_eq!(
+            indel_length(
+                1,
+                AlternateAllele {
+                    length: 4,
+                    symbolic: false
+                }
+            ),
+            3
+        );
+    }
+
+    #[test]
+    fn a_callable_site_count_below_one_is_no_count_at_all() {
+        assert_eq!(
+            SomaticClusteringModel::new(PriorArguments::new(), Some(0.0)).callable_sites(),
+            None
+        );
+        assert_eq!(
+            SomaticClusteringModel::new(PriorArguments::new(), Some(1.0)).callable_sites(),
+            Some(1.0)
+        );
+    }
+}

--- a/crates/gatk-engine/tests/somatic_clustering_model.rs
+++ b/crates/gatk-engine/tests/somatic_clustering_model.rs
@@ -1,0 +1,355 @@
+//! Conformance for `SomaticClusteringModel` as constructed against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/SomaticClusteringModelDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **the prior getter mutates the map it reads**, so the same lengths asked in two orders are
+//!    asked of two models here, exactly as the dump asks them;
+//!  * **only a SNV gets `LOG_ONE_THIRD`**;
+//!  * **the mitochondrial defaults are guarded by `==` against the ordinary default**;
+//!  * **`record` zeroes the caller's array in place**, printed before and after;
+//!  * **two thresholds that look alike do different things**, one counting and one silent;
+//!  * **and the initial weights do not sum to one**, which makes
+//!    `logLikelihoodGivenSomatic(0, 0)` positive.
+//!
+//! # What is compared, and what is not
+//!
+//! Every row except the five `artifactprior <label>-learned` ones, which are the dump reading back
+//! what `record` accumulated by running `learnAndClearAccumulatedData`. That call is the EM
+//! iteration and its quantile initialisation, which are not ported: the port asserts what `record`
+//! kept through `accumulated()` and `obvious_artifact_count()` in the module's own unit tests
+//! instead. The five labels are named in `NEEDS_THE_EM`, so a sixth cannot appear silently.
+//!
+//! The `loglike` and `seqerror` rows go through `logSumExp` and therefore `exp`, whose bit-exact
+//! transcription is withdrawn under htsjdk-rs decision 0014. Both are bit-identical here anyway;
+//! `EXP_BOUNDED` is empty, and the test fails if a row needs to be added to it.
+
+use gatk_corpus as corpus;
+use gatk_engine::allele_fraction_cluster::Datum;
+use gatk_engine::somatic_clustering_model::{
+    indel_length, AlternateAllele, PriorArguments, SomaticClusteringModel,
+};
+use gatk_engine::tsv_table::java_double_to_string;
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/somatic_clustering_model.txt.gz"),
+    )
+}
+
+/// The rows that need the EM iteration, which is the next slice rather than this one.
+const NEEDS_THE_EM: [&str; 5] = [
+    "one-alt-learned",
+    "symbolic-alt-learned",
+    "obvious-artifact-learned",
+    "obvious-non-somatic-learned",
+    "at-threshold-learned",
+];
+
+/// The rows allowed to sit one ulp away because they carry `exp`. None do.
+const EXP_BOUNDED: [&str; 0] = [];
+
+fn double(text: &str) -> f64 {
+    text.parse().unwrap_or_else(|_| panic!("a double: {text}"))
+}
+
+fn snp() -> AlternateAllele {
+    AlternateAllele {
+        length: 1,
+        symbolic: false,
+    }
+}
+
+/// An alternate of the indel length the label names, against a one-base reference for an insertion
+/// and a longer one for a deletion, matching the records the dump builds.
+fn record_shape(length: i32) -> (i32, AlternateAllele) {
+    if length >= 0 {
+        (
+            1,
+            AlternateAllele {
+                length: 1 + length,
+                symbolic: false,
+            },
+        )
+    } else {
+        (1 - length, snp())
+    }
+}
+
+/// A model built the way the dump builds its default one.
+fn model() -> SomaticClusteringModel {
+    SomaticClusteringModel::new(PriorArguments::new(), None)
+}
+
+fn prior_line(model: &mut SomaticClusteringModel, label: &str, length: i32) -> String {
+    let (reference_length, alternate) = record_shape(length);
+    let value = model.log_prior_of_somatic_variant(indel_length(reference_length, alternate));
+    format!("prior\t{label}\t{}", java_double_to_string(value))
+}
+
+/// Every `prior` and `artifactprior` row, in the dump's order, since the models are stateful.
+fn prior_rows() -> Vec<String> {
+    let mut rows = Vec::new();
+    let mut in_window = model();
+    for length in [0, 1, -1, 2, -2, 10, -10] {
+        rows.push(prior_line(
+            &mut in_window,
+            &format!("in-window-{length}"),
+            length,
+        ));
+    }
+    let mut ascending = model();
+    for length in [11, -11, 50, -50] {
+        rows.push(prior_line(
+            &mut ascending,
+            &format!("ascending-{length}"),
+            length,
+        ));
+    }
+    let mut descending = model();
+    for length in [-50, 50, -11, 11] {
+        rows.push(prior_line(
+            &mut descending,
+            &format!("descending-{length}"),
+            length,
+        ));
+    }
+    let mut repeated = model();
+    rows.push(prior_line(&mut repeated, "repeated-first", 11));
+    rows.push(prior_line(&mut repeated, "repeated-second", 11));
+    rows.push(prior_line(&mut repeated, "repeated-in-window", 0));
+
+    let mut tuned_arguments = PriorArguments::new();
+    tuned_arguments.log_snv_prior = -5.0;
+    tuned_arguments.log_indel_prior = -4.0;
+    tuned_arguments.initial_log_prior_of_variant_versus_artifact = -1.0;
+    let mut tuned = SomaticClusteringModel::new(tuned_arguments, None);
+    rows.push(prior_line(&mut tuned, "tuned-snv", 0));
+    rows.push(prior_line(&mut tuned, "tuned-indel", 3));
+    rows.push(format!(
+        "artifactprior\ttuned\t{}",
+        java_double_to_string(tuned.log_prior_of_variant_versus_artifact())
+    ));
+    rows.push(format!(
+        "artifactprior\tdefault\t{}",
+        java_double_to_string(model().log_prior_of_variant_versus_artifact())
+    ));
+
+    let mut mito_arguments = PriorArguments::new();
+    mito_arguments.mitochondria = true;
+    let mut mito = SomaticClusteringModel::new(mito_arguments, None);
+    rows.push(prior_line(&mut mito, "mito-snv", 0));
+    rows.push(prior_line(&mut mito, "mito-indel", 3));
+    let mut overridden_arguments = PriorArguments::new();
+    overridden_arguments.mitochondria = true;
+    overridden_arguments.log_snv_prior = -5.0;
+    let mut overridden = SomaticClusteringModel::new(overridden_arguments, None);
+    rows.push(prior_line(&mut overridden, "mito-snv-overridden", 0));
+    rows.push(prior_line(&mut overridden, "mito-indel-untouched", 3));
+    rows
+}
+
+/// The `ads` rows, which are the arrays `record` was handed, before and after.
+fn ads_rows() -> Vec<String> {
+    let mut rows = Vec::new();
+    let mut push = |label: &str,
+                    ads: &mut Vec<i32>,
+                    odds: &[f64],
+                    artifact: &[f64],
+                    non_somatic: &[f64],
+                    alternates: &[AlternateAllele],
+                    reference_length: i32| {
+        rows.push(format!("ads\t{label}-before\t{ads:?}"));
+        let mut model = SomaticClusteringModel::new(PriorArguments::new(), Some(1000.0));
+        if model
+            .record(
+                ads,
+                odds,
+                artifact,
+                non_somatic,
+                alternates,
+                reference_length,
+            )
+            .is_ok()
+        {
+            rows.push(format!("ads\t{label}-after\t{ads:?}"));
+        }
+    };
+    push(
+        "one-alt",
+        &mut vec![80, 20],
+        &[6.0],
+        &[0.0],
+        &[0.0],
+        &[snp()],
+        1,
+    );
+    push(
+        "symbolic-alt",
+        &mut vec![80, 20, 5],
+        &[6.0, 6.0],
+        &[0.0, 0.0],
+        &[0.0, 0.0],
+        &[
+            snp(),
+            AlternateAllele {
+                length: 0,
+                symbolic: true,
+            },
+        ],
+        1,
+    );
+    push(
+        "obvious-artifact",
+        &mut vec![80, 20],
+        &[6.0],
+        &[0.95],
+        &[0.0],
+        &[snp()],
+        1,
+    );
+    push(
+        "obvious-non-somatic",
+        &mut vec![80, 20],
+        &[6.0],
+        &[0.0],
+        &[0.95],
+        &[snp()],
+        1,
+    );
+    push(
+        "at-threshold",
+        &mut vec![80, 20],
+        &[6.0],
+        &[0.9],
+        &[0.9],
+        &[snp()],
+        1,
+    );
+    push(
+        "short-array",
+        &mut vec![80],
+        &[6.0],
+        &[0.0],
+        &[0.0],
+        &[snp()],
+        1,
+    );
+    rows.push(
+        "error\tshort-array\tjava.lang.IllegalArgumentException:tumorADs must have one entry per \
+         allele including the ref allele"
+            .to_string(),
+    );
+    rows
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let text = golden();
+    let lines: Vec<&str> = text.lines().filter(|line| !line.starts_with('#')).collect();
+
+    // The stateful rows are reproduced as whole sequences, since each answer depends on the ones
+    // before it.
+    let mut ours: Vec<String> = prior_rows();
+    let fresh = model();
+    for (total, alt) in [
+        (10, 0),
+        (10, 1),
+        (10, 5),
+        (10, 10),
+        (100, 3),
+        (100, 50),
+        (1000, 7),
+        (0, 0),
+    ] {
+        let value = fresh
+            .log_likelihood_given_somatic(total, alt)
+            .expect("finite");
+        ours.push(format!(
+            "loglike\t{total},{alt}\t{}",
+            java_double_to_string(value)
+        ));
+    }
+    // The sequencing-error rows share one model with the likelihood rows above, and the last of them
+    // inserts an indel length into its prior map on the way through.
+    let mut sequencing = fresh;
+    let error_row =
+        |model: &mut SomaticClusteringModel, odds: f64, total: i32, alt: i32, length: i32| {
+            let datum = Datum::new(odds, 0.0, 0.0, alt, total, length);
+            let value = model
+                .probability_of_sequencing_error(&datum)
+                .expect("finite");
+            format!(
+                "seqerror\t{}-{total},{alt}-{length}\t{}",
+                java_double_to_string(odds),
+                java_double_to_string(value)
+            )
+        };
+    for odds in [0.0, 5.0, 20.0, -5.0] {
+        for (total, alt) in [(10, 5), (100, 3)] {
+            ours.push(error_row(&mut sequencing, odds, total, alt, 0));
+        }
+    }
+    ours.push(error_row(&mut sequencing, 5.0, 10, 5, 3));
+    ours.push(error_row(&mut sequencing, 5.0, 10, 5, -3));
+    ours.push(error_row(&mut sequencing, 5.0, 10, 5, 40));
+
+    ours.extend(ads_rows());
+
+    for (label, reference_length, alternate) in [
+        ("snp", 1, snp()),
+        (
+            "insertion",
+            1,
+            AlternateAllele {
+                length: 4,
+                symbolic: false,
+            },
+        ),
+        ("deletion", 4, snp()),
+        (
+            "symbolic",
+            1,
+            AlternateAllele {
+                length: 0,
+                symbolic: true,
+            },
+        ),
+    ] {
+        ours.push(format!(
+            "indellength\t{label}\t{}",
+            indel_length(reference_length, alternate)
+        ));
+    }
+
+    // The golden's rows, minus the ones the EM iteration would answer.
+    let expected: Vec<&str> = lines
+        .iter()
+        .copied()
+        .filter(|line| {
+            let label = line.split('\t').nth(1).unwrap_or_default();
+            !(line.starts_with("artifactprior\t") && NEEDS_THE_EM.contains(&label))
+        })
+        .collect();
+    let deferred = lines.len() - expected.len();
+    assert_eq!(deferred, NEEDS_THE_EM.len(), "the deferred rows changed");
+    assert_eq!(lines.len(), 66, "the golden's row count");
+
+    for (mine, theirs) in ours.iter().zip(&expected) {
+        if mine == theirs {
+            continue;
+        }
+        let label = theirs.split('\t').nth(1).unwrap_or_default();
+        assert!(
+            EXP_BOUNDED.contains(&label),
+            "{label}: {mine} against {theirs}"
+        );
+        let value: f64 = double(mine.rsplit('\t').next().expect("a value"));
+        let reference: f64 = double(theirs.rsplit('\t').next().expect("a value"));
+        let ulps = ((value.to_bits() as i64) - (reference.to_bits() as i64)).abs();
+        assert!(ulps <= 1, "{label}: {mine} against {theirs}, {ulps} ulps");
+    }
+    assert_eq!(ours.len(), expected.len(), "every row is accounted for");
+}


### PR DESCRIPTION
Part of #328.

`SomaticClusteringModel` before any learning: the constructor's state and the answers it gives from
it. **61 of the golden's 66 rows are reproduced bit-identically**; the other five are named below.

- **`getLogPriorOfSomaticVariant` mutates the map it reads**, so it takes `&mut self`. An indel
  length outside the ±10 window is inserted at the minimum of what is already there, and asking about
  a length once changes what a later question can be answered with. The conformance test reproduces
  the prior rows as whole ordered sequences over the same models the dump used, not row by row.
- **The mitochondrial defaults are decided by `==`** against the ordinary default, so a mitochondrial
  run told its SNV prior explicitly takes the ordinary path even at the same value.
- **`record` takes `&mut [i32]`** because the reference mutates the caller's array: `[80, 20, 5]`
  goes in and `[80, 20, 0]` comes back.
- **The two `0.9` thresholds are one number and two behaviours**, one counting the drop and one
  silent, and the comparison is `>` so `0.9` exactly keeps its datum.
- **The initial weights sum to `1.01`**, so `log_likelihood_given_somatic(0, 0)` is positive.

### What is not compared, and why

The five `artifactprior <label>-learned` rows are the dump reading back what `record` accumulated by
calling `learnAndClearAccumulatedData` — the EM iteration and its quantile initialisation, neither of
which is ported here. The port asserts what `record` kept through `accumulated()` and
`obvious_artifact_count()` in its own unit tests instead, and the five labels are named in
`NEEDS_THE_EM` so a sixth cannot appear silently. **The EM iteration is the next slice.**

The `loglike` and `seqerror` rows carry `exp` through `logSumExp`, whose bit-exact transcription is
withdrawn under htsjdk-rs decision 0014. All of them are bit-identical anyway: `EXP_BOUNDED` is empty
and the test fails if a row has to be added to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #10.
