### PR TITLE
Port the EM iteration and the quantile initialisation

### DIFF
--- a/crates/gatk-engine/src/allele_fraction_cluster.rs
+++ b/crates/gatk-engine/src/allele_fraction_cluster.rs
@@ -147,7 +147,9 @@ pub fn fuzzy_binomial(unbounded_mean: f64) -> Result<BetaDistributionShape, Shap
     } else {
         unbounded_mean.min(bound)
     };
-    let alpha_plus_beta = ((1.0 - mean) / (mean * STD_DEV_OVER_MEAN * STD_DEV_OVER_MEAN)) - 1.0;
+    // `mean * MathUtils.square(STD_DEV_OVER_MEAN)`: the square is formed first, and
+    // `(mean * 0.01) * 0.01` is a different double.
+    let alpha_plus_beta = ((1.0 - mean) / (mean * (STD_DEV_OVER_MEAN * STD_DEV_OVER_MEAN))) - 1.0;
     let alpha = mean * alpha_plus_beta;
     BetaDistributionShape::new(alpha, alpha_plus_beta - alpha)
 }
@@ -192,6 +194,122 @@ pub fn log_likelihood(
 ) -> Result<f64, BetaBinomialError> {
     BetaBinomialDistribution::new(shape.alpha(), shape.beta(), total_count)?
         .log_probability(alt_count)
+}
+
+/// `BetaBinomialCluster`'s learning rate, its cap and its epoch count.
+const RATE: f64 = 0.01;
+const NUM_EPOCHS: usize = 10;
+
+/// `BetaBinomialCluster.learn(data, responsibilities)`.
+///
+/// Ten epochs of gradient ascent over `Gamma.digamma`, and three things about it that a smoother
+/// implementation would get wrong:
+///
+///  * **the update is sequential within an epoch.** Alpha and beta are read and written per datum,
+///    so the same data in a different order learn a different shape;
+///  * **the floors are applied every step**, not at the end, so a shape that would have dipped below
+///    `1.0` or `0.5` and come back cannot;
+///  * **`Math.max` propagates NaN** where Rust's `f64::max` answers the other argument, so the
+///    clamps are written out.
+pub fn learn_beta_binomial(
+    shape: BetaDistributionShape,
+    data: &[Datum],
+    responsibilities: &[f64],
+) -> Result<BetaDistributionShape, ShapeError> {
+    let mut alpha = shape.alpha();
+    let mut beta = shape.beta();
+    for _ in 0..NUM_EPOCHS {
+        for (index, datum) in data.iter().enumerate() {
+            let alt = datum.alt_count() as f64;
+            let reference = (datum.total_count() - datum.alt_count()) as f64;
+            let digamma_of_total_plus_alpha_plus_beta =
+                digamma(datum.total_count() as f64 + alpha + beta);
+            let digamma_of_alpha_plus_beta = digamma(alpha + beta);
+            let alpha_gradient =
+                digamma(alpha + alt) - digamma_of_total_plus_alpha_plus_beta - digamma(alpha)
+                    + digamma_of_alpha_plus_beta;
+            let beta_gradient =
+                digamma(beta + reference) - digamma_of_total_plus_alpha_plus_beta - digamma(beta)
+                    + digamma_of_alpha_plus_beta;
+            alpha = java_max(alpha + RATE * alpha_gradient * responsibilities[index], 1.0);
+            beta = java_max(beta + RATE * beta_gradient * responsibilities[index], 0.5);
+        }
+    }
+    BetaDistributionShape::new(alpha, beta)
+}
+
+/// `Gamma.digamma`, which jmath carries and which refuses nothing this reaches.
+fn digamma(x: f64) -> f64 {
+    jmath::gamma::digamma(x).unwrap_or(f64::NAN)
+}
+
+/// `Math.max`, which answers NaN when either argument is NaN.
+fn java_max(a: f64, b: f64) -> f64 {
+    if a.is_nan() || b.is_nan() {
+        f64::NAN
+    } else {
+        a.max(b)
+    }
+}
+
+/// `BinomialCluster.learn(data, responsibilities)`.
+///
+/// A responsibility-weighted mean with `0.0001` added to **both** sums. That is not a tie-breaker:
+/// it is what keeps a cluster given no responsibility at all from dividing zero by zero. Such a
+/// cluster lands at `0.0001 / 0.0001`, which the fuzzy binomial's own clamp turns into `0.99`.
+///
+/// Both sums are `DoubleStream.sum`, which is compensated rather than a plain loop.
+pub fn learn_binomial(
+    data: &[Datum],
+    responsibilities: &[f64],
+) -> Result<BetaDistributionShape, ShapeError> {
+    let alt_count = double_stream_sum(
+        &data
+            .iter()
+            .enumerate()
+            .map(|(index, datum)| datum.alt_count() as f64 * responsibilities[index])
+            .collect::<Vec<f64>>(),
+    ) + 0.0001;
+    let total_count = double_stream_sum(
+        &data
+            .iter()
+            .enumerate()
+            .map(|(index, datum)| datum.total_count() as f64 * responsibilities[index])
+            .collect::<Vec<f64>>(),
+    ) + 0.0001;
+    fuzzy_binomial(alt_count / total_count)
+}
+
+/// `DoubleStream.sum()`, which is Kahan summation with a simple sum kept beside it.
+///
+/// ```java
+/// double tmp = summands[0] + summands[1];
+/// double simpleSum = summands[summands.length - 1];
+/// if (Double.isNaN(tmp) && Double.isInfinite(simpleSum)) { return simpleSum; } else { return tmp; }
+/// ```
+///
+/// A plain loop is a different double on almost any list of more than two values, which is why this
+/// is not `MathUtils.sum`.
+pub fn double_stream_sum(values: &[f64]) -> f64 {
+    let mut sum = 0.0;
+    let mut compensation = 0.0;
+    let mut simple = 0.0;
+    for value in values {
+        let tmp = value - compensation;
+        let velvel = sum + tmp;
+        compensation = (velvel - sum) - tmp;
+        sum = velvel;
+        simple += value;
+    }
+    // The JDK ADDS the compensation rather than subtracting it -- "better error bounds to add both
+    // terms as the final sum", says the comment beside it -- even though the accumulator stores the
+    // error with the opposite sign. A textbook Kahan sum is a different double here.
+    let total = sum + compensation;
+    if total.is_nan() && simple.is_infinite() {
+        simple
+    } else {
+        total
+    }
 }
 
 /// The two clusters, which differ only in where their shape comes from.

--- a/crates/gatk-engine/src/somatic_clustering_model.rs
+++ b/crates/gatk-engine/src/somatic_clustering_model.rs
@@ -40,8 +40,15 @@
 //! and its quantile initialisation are their own slice; [`SomaticClusteringModel::record`]
 //! accumulates the data they would consume.
 
-use crate::allele_fraction_cluster::{AlleleFractionCluster, BetaDistributionShape, Datum};
+use crate::allele_fraction_cluster::{
+    double_stream_sum, learn_beta_binomial, learn_binomial, AlleleFractionCluster,
+    BetaDistributionShape, Datum, ShapeError,
+};
+use crate::java_format::format_decimals;
+use crate::java_hash::hash_map_order;
+use crate::math_utils::normalize_sum_to_one;
 use crate::mutect_engine::{log_one_third, posterior_probability_of_error};
+use crate::natural_log_utils::normalize_from_log_to_linear_space;
 use crate::natural_log_utils::{log_sum_exp, NonFiniteSum};
 
 /// `MAX_INDEL_SIZE_IN_PRIOR_MAP`.
@@ -157,6 +164,8 @@ pub struct SomaticClusteringModel {
     data: Vec<Datum>,
     /// `obviousArtifactCount`, incremented only on the artifact threshold and not on the other.
     obvious_artifact_count: i32,
+    /// `clustersHaveBeenInitialized`: the quantile initialisation runs once and never again.
+    clusters_have_been_initialized: bool,
 }
 
 impl SomaticClusteringModel {
@@ -194,6 +203,7 @@ impl SomaticClusteringModel {
             log_cluster_weights: vec![INITIAL_HIGH_AF_WEIGHT.ln_1p(), INITIAL_HIGH_AF_WEIGHT.ln()],
             data: Vec::new(),
             obvious_artifact_count: 0,
+            clusters_have_been_initialized: false,
         }
     }
 
@@ -332,6 +342,461 @@ impl SomaticClusteringModel {
             ));
         }
         Ok(())
+    }
+}
+
+/// `NUM_ITERATIONS`, the rounds of EM per call to learn.
+pub const NUM_ITERATIONS: usize = 5;
+
+/// `MAX_BINOMIAL_CLUSTERS`.
+pub const MAX_BINOMIAL_CLUSTERS: usize = 5;
+
+/// `NUM_INITIALIZATION_QUANTILES`.
+pub const NUM_INITIALIZATION_QUANTILES: usize = 50;
+
+/// `MIN_QUANTILE_INDEX_FOR_MAKING_CLUSTER`, `(int) (0.1 * 50)`.
+pub const MIN_QUANTILE_INDEX_FOR_MAKING_CLUSTER: usize = 5;
+
+/// `MAX_FRACTION_OF_BACKGROUND_TO_SPLIT_OFF`.
+pub const MAX_FRACTION_OF_BACKGROUND_TO_SPLIT_OFF: f64 = 0.9;
+
+/// `REGULARIZING_PSEUDOCOUNT`.
+pub const REGULARIZING_PSEUDOCOUNT: f64 = 1.0;
+
+/// `MathUtils.binomialProbability(n, k, p)`, which is commons-math's
+/// `BinomialDistribution.probability` over the saddle-point expansion.
+///
+/// The exponential is the reference's, so this is the one thing on the learning path that decision
+/// 0014 bounds rather than fixes.
+pub fn binomial_probability(n: i32, k: i32, p: f64) -> f64 {
+    if n == 0 {
+        return if k == 0 { 1.0 } else { 0.0 };
+    }
+    if k < 0 || k > n {
+        return 0.0;
+    }
+    let log_probability = jmath::saddle_point::log_binomial_probability(k, n, p, 1.0 - p);
+    if log_probability == f64::NEG_INFINITY {
+        0.0
+    } else {
+        log_probability.exp()
+    }
+}
+
+impl SomaticClusteringModel {
+    /// `probabilityOfSomaticVariant(datum)`.
+    fn probability_of_somatic_variant(&mut self, datum: &Datum) -> f64 {
+        let artifact_prob = datum.artifact_prob();
+        let non_somatic_prob = datum.non_sequencing_error_prob();
+        let sequencing_error_prob = self
+            .probability_of_sequencing_error(datum)
+            .unwrap_or(f64::NAN);
+        (1.0 - artifact_prob) * (1.0 - non_somatic_prob) * (1.0 - sequencing_error_prob)
+    }
+
+    /// `backgroundProbGivenSomatic(totalCount, altCount)`, the first cluster's normalised share.
+    fn background_prob_given_somatic(&self, total_count: i32, alt_count: i32) -> f64 {
+        normalize_from_log_to_linear_space(&self.cluster_log_likelihoods(total_count, alt_count))
+            .map(|probabilities| probabilities[0])
+            .unwrap_or(f64::NAN)
+    }
+
+    /// `learnAndClearAccumulatedData()`.
+    pub fn learn_and_clear_accumulated_data(&mut self) -> Result<(), ShapeError> {
+        if !self.clusters_have_been_initialized {
+            self.initialize_clusters()?;
+        }
+        for _ in 0..NUM_ITERATIONS {
+            self.perform_em_iteration(true)?;
+        }
+        self.data.clear();
+        self.obvious_artifact_count = 0;
+        Ok(())
+    }
+
+    /// `calculateAlleleFractionQuantiles()`.
+    ///
+    /// The sort is `Comparator.comparingDouble` on the allele fraction, which is stable, so equal
+    /// fractions keep the order the data arrived in. The final `distinct()` keeps the first of each.
+    fn allele_fraction_quantiles(&mut self) -> Vec<f64> {
+        let mut fractions_and_probs: Vec<(f64, f64)> = Vec::with_capacity(self.data.len());
+        for index in 0..self.data.len() {
+            let datum = self.data[index];
+            let fraction = datum.alt_count() as f64 / datum.total_count() as f64;
+            fractions_and_probs.push((fraction, self.probability_of_somatic_variant(&datum)));
+        }
+        fractions_and_probs.sort_by(|a, b| a.0.total_cmp(&b.0));
+        let total_somatic_prob: f64 = double_stream_sum(
+            &fractions_and_probs
+                .iter()
+                .map(|p| p.1)
+                .collect::<Vec<f64>>(),
+        );
+        let mut cumulative_prob = 0.0;
+        let quantile_step = total_somatic_prob / NUM_INITIALIZATION_QUANTILES as f64;
+        let mut quantile_prob = quantile_step;
+        let mut quantiles: Vec<f64> = Vec::new();
+        for (fraction, prob) in &fractions_and_probs {
+            cumulative_prob += prob;
+            if cumulative_prob > quantile_prob {
+                quantiles.push(*fraction);
+                while cumulative_prob > quantile_prob {
+                    quantile_prob += quantile_step;
+                }
+            }
+        }
+        // `distinct()`, which is by equality and keeps the first.
+        let mut distinct: Vec<f64> = Vec::new();
+        for quantile in quantiles {
+            if !distinct.contains(&quantile) {
+                distinct.push(quantile);
+            }
+        }
+        distinct
+    }
+
+    /// `calculateQuantileBackgroundResponsibilities(alleleFractionQuantiles, backgroundProbs)`.
+    ///
+    /// The density is the binomial one times `n + 1`, which is the flat-prior posterior density at
+    /// that allele fraction.
+    fn quantile_background_responsibilities(
+        &self,
+        quantiles: &[f64],
+        background_probs: &[f64],
+    ) -> Vec<f64> {
+        let mut totals = vec![0.0; quantiles.len()];
+        for (index, datum) in self.data.iter().enumerate() {
+            let background_prob = background_probs[index];
+            for (q, fraction) in quantiles.iter().enumerate() {
+                let density =
+                    binomial_probability(datum.total_count(), datum.alt_count(), *fraction);
+                totals[q] += density * background_prob * (datum.total_count() as f64 + 1.0);
+            }
+        }
+        totals
+    }
+
+    /// `calculatePeaksAndMasses(alleleFractionQuantiles, totalQuantileResponsibilities)`.
+    ///
+    /// Trapezoid quadrature between local minima, where the minimum test is on
+    /// `Double.compare` rather than on `<`, so a NaN responsibility sorts above everything.
+    fn peaks_and_masses(quantiles: &[f64], responsibilities: &[f64]) -> Vec<(f64, f64)> {
+        let mut peaks: Vec<(f64, f64)> = Vec::new();
+        let mut current_peak_mass = 0.0;
+        let mut current_peak = 0.0;
+        let mut current_peak_responsibility = 0.0;
+        for q in 0..quantiles.len() {
+            let left_responsibility = if q == 0 { 0.0 } else { responsibilities[q - 1] };
+            let responsibility = responsibilities[q];
+            let right_responsibility = if q == quantiles.len() - 1 {
+                0.0
+            } else {
+                responsibilities[q + 1]
+            };
+            let left_fraction = if q == 0 { 0.0 } else { quantiles[q - 1] };
+            let fraction = quantiles[q];
+            current_peak_mass +=
+                (fraction - left_fraction) * (left_responsibility + responsibility) / 2.0;
+            if responsibility > current_peak_responsibility {
+                current_peak = fraction;
+                current_peak_responsibility = responsibility;
+            }
+            let left_compare = responsibility.total_cmp(&left_responsibility);
+            let right_compare = responsibility.total_cmp(&right_responsibility);
+            let local_min = (left_compare.is_lt() && right_compare.is_le())
+                || (left_compare.is_le() && right_compare.is_lt());
+            if (local_min && q > 0) || q == quantiles.len() - 1 {
+                peaks.push((current_peak, current_peak_mass));
+                current_peak_mass = 0.0;
+                current_peak = fraction;
+                current_peak_responsibility = responsibility;
+            }
+        }
+        peaks
+    }
+
+    /// `initializeClusters()`.
+    ///
+    /// Splits the biggest peak off the background, runs five silent EM iterations, and keeps the
+    /// split only while the BIC improves -- at most five times. A peak below the 0.1 quantile stops
+    /// it outright.
+    fn initialize_clusters(&mut self) -> Result<(), ShapeError> {
+        let data = self.data.clone();
+        let somatic_probs: Vec<f64> = data
+            .iter()
+            .map(|datum| self.probability_of_somatic_variant(datum))
+            .collect();
+        let mut previous_bic = f64::NEG_INFINITY;
+        for _ in 0..MAX_BINOMIAL_CLUSTERS {
+            let old_log_cluster_weights = self.log_cluster_weights.clone();
+            let background_probs: Vec<f64> = data
+                .iter()
+                .enumerate()
+                .map(|(index, datum)| {
+                    somatic_probs[index]
+                        * self.background_prob_given_somatic(datum.total_count(), datum.alt_count())
+                })
+                .collect();
+            let quantiles = self.allele_fraction_quantiles();
+            let responsibilities =
+                self.quantile_background_responsibilities(&quantiles, &background_probs);
+            let peaks = Self::peaks_and_masses(&quantiles, &responsibilities);
+            if peaks.is_empty() {
+                break;
+            }
+            // `sorted(comparingDouble(getRight).reversed()).findFirst()`: a stable sort, so the
+            // first of equal masses wins.
+            let mut sorted = peaks.clone();
+            sorted.sort_by(|a, b| b.1.total_cmp(&a.1));
+            let (biggest_peak, biggest_mass) = sorted[0];
+            let floor_index = MIN_QUANTILE_INDEX_FOR_MAKING_CLUSTER.min(quantiles.len() - 1);
+            if biggest_peak < quantiles[floor_index] {
+                break;
+            }
+            let total_mass = double_stream_sum(&peaks.iter().map(|p| p.1).collect::<Vec<f64>>());
+            let fraction_of_background_to_split =
+                MAX_FRACTION_OF_BACKGROUND_TO_SPLIT_OFF.min(biggest_mass / total_mass);
+            let new_cluster_log_weight =
+                fraction_of_background_to_split.ln() + self.log_cluster_weights[0];
+            // `log1p`, not `log(1 - x)`: the background keeps MORE weight than it had.
+            let new_background_weight =
+                fraction_of_background_to_split.ln_1p() + self.log_cluster_weights[0];
+            self.clusters
+                .push(AlleleFractionCluster::binomial(biggest_peak)?);
+            self.log_cluster_weights.push(new_cluster_log_weight);
+            self.log_cluster_weights[0] = new_background_weight;
+
+            for _ in 0..NUM_ITERATIONS {
+                self.perform_em_iteration(false)?;
+            }
+
+            let log_likelihoods: Vec<f64> = data
+                .iter()
+                .map(|datum| {
+                    self.log_likelihood_given_somatic(datum.total_count(), datum.alt_count())
+                        .unwrap_or(f64::NAN)
+                })
+                .collect();
+            let weighted: Vec<f64> = log_likelihoods
+                .iter()
+                .enumerate()
+                .map(|(index, value)| somatic_probs[index] * value)
+                .collect();
+            // `MathUtils.sum`, a plain loop, over a product formed first: not the compensated sum.
+            let weighted_log_likelihood = crate::somatic_likelihoods::sum(&weighted);
+            let effective_somatic_count = crate::somatic_likelihoods::sum(&somatic_probs);
+            let num_parameters = 2.0 * self.clusters.len() as f64;
+            let current_bic =
+                weighted_log_likelihood - num_parameters * effective_somatic_count.ln();
+            if current_bic < previous_bic {
+                self.clusters.pop();
+                self.log_cluster_weights = old_log_cluster_weights;
+                break;
+            }
+            previous_bic = current_bic;
+        }
+        self.clusters_have_been_initialized = true;
+        Ok(())
+    }
+
+    /// `performEMIteration(updateSomaticPriors)`.
+    fn perform_em_iteration(&mut self, update_somatic_priors: bool) -> Result<(), ShapeError> {
+        // `Collectors.toMap` over `-10..=10`, which is a HashMap: its iteration order is the one the
+        // variant count is summed in, and a length outside the window is appended by `putIfAbsent`.
+        let mut counts: Vec<(i32, f64)> = (-MAX_INDEL_SIZE_IN_PRIOR_MAP
+            ..=MAX_INDEL_SIZE_IN_PRIOR_MAP)
+            .map(|length| (length, 0.0))
+            .collect();
+        let data = self.data.clone();
+        let mut responsibilities: Vec<Vec<f64>> = Vec::with_capacity(data.len());
+        let mut total_cluster_responsibilities = vec![0.0; self.clusters.len()];
+        for datum in &data {
+            let somatic_prob = self.probability_of_somatic_variant(datum);
+            let indel_length = datum.indel_length();
+            if !counts.iter().any(|(length, _)| *length == indel_length) {
+                counts.push((indel_length, 0.0));
+            }
+            if let Some(entry) = counts
+                .iter_mut()
+                .find(|(length, _)| *length == indel_length)
+            {
+                entry.1 += somatic_prob;
+            }
+            let cluster_log_likelihoods =
+                self.cluster_log_likelihoods(datum.total_count(), datum.alt_count());
+            let if_somatic = normalize_from_log_to_linear_space(&cluster_log_likelihoods)
+                .unwrap_or_else(|_| vec![f64::NAN; cluster_log_likelihoods.len()]);
+            let scaled: Vec<f64> = if_somatic
+                .iter()
+                .map(|value| somatic_prob * value)
+                .collect();
+            for (index, value) in scaled.iter().enumerate() {
+                total_cluster_responsibilities[index] += value;
+            }
+            responsibilities.push(scaled);
+        }
+        for value in total_cluster_responsibilities.iter_mut() {
+            *value += REGULARIZING_PSEUDOCOUNT;
+        }
+        self.log_cluster_weights = normalize_sum_to_one(&total_cluster_responsibilities)
+            .expect("the pseudocount keeps the sum positive")
+            .iter()
+            .map(|value| value.ln())
+            .collect();
+        let technical_artifact_count = self.obvious_artifact_count as f64
+            + double_stream_sum(
+                &data
+                    .iter()
+                    .map(|datum| datum.artifact_prob())
+                    .collect::<Vec<f64>>(),
+            );
+        // The map's values in the HashMap's own iteration order, summed the compensated way.
+        let variant_count = double_stream_sum(&Self::hash_map_values(&counts));
+
+        if update_somatic_priors {
+            self.log_variant_vs_artifact_prior = ((variant_count + REGULARIZING_PSEUDOCOUNT)
+                / (variant_count + technical_artifact_count + REGULARIZING_PSEUDOCOUNT * 2.0))
+                .ln();
+            if let Some(callable_sites) = self.callable_sites {
+                for length in -MAX_INDEL_SIZE_IN_PRIOR_MAP..=MAX_INDEL_SIZE_IN_PRIOR_MAP {
+                    let empirical_ratio = counts
+                        .iter()
+                        .find(|(key, _)| *key == length)
+                        .map(|(_, value)| *value)
+                        .unwrap_or(0.0)
+                        / callable_sites;
+                    let floor = if length == 0 { 1.0e-8 } else { 1.0e-9 };
+                    let prior = empirical_ratio.max(floor).ln();
+                    if let Some(entry) = self
+                        .log_variant_priors
+                        .iter_mut()
+                        .find(|(key, _)| *key == length)
+                    {
+                        entry.1 = prior;
+                    } else {
+                        self.log_variant_priors.push((length, prior));
+                    }
+                }
+            }
+        }
+
+        for index in 0..self.clusters.len() {
+            let for_this_cluster: Vec<f64> = responsibilities
+                .iter()
+                .map(|values| values[index])
+                .collect();
+            let shape = self.clusters[index].shape();
+            self.clusters[index] = match self.clusters[index] {
+                AlleleFractionCluster::Binomial(_) => {
+                    AlleleFractionCluster::Binomial(learn_binomial(&data, &for_this_cluster)?)
+                }
+                AlleleFractionCluster::BetaBinomial(_) => AlleleFractionCluster::BetaBinomial(
+                    learn_beta_binomial(shape, &data, &for_this_cluster)?,
+                ),
+            };
+        }
+        Ok(())
+    }
+
+    /// The values of the reference's `HashMap<Integer, MutableDouble>`, in its iteration order.
+    ///
+    /// `Integer.hashCode` is the value itself, so the order is the table's and not the insertion
+    /// order: it is what decides how the variant count's compensated sum accumulates.
+    fn hash_map_values(counts: &[(i32, f64)]) -> Vec<f64> {
+        // `Integer.hashCode` is the value itself.
+        let entries: Vec<(i32, i32)> = counts
+            .iter()
+            .map(|(length, _)| (*length, *length))
+            .collect();
+        match hash_map_order(&entries) {
+            Ok(order) => order
+                .iter()
+                .map(|key| {
+                    counts
+                        .iter()
+                        .find(|(length, _)| length == key)
+                        .map(|(_, value)| *value)
+                        .unwrap_or(0.0)
+                })
+                .collect(),
+            // An order the hash port has not measured: fall back to insertion order rather than
+            // guessing, which a test will catch as a wrong sum rather than as a silent one.
+            Err(_) => counts.iter().map(|(_, value)| *value).collect(),
+        }
+    }
+
+    /// `clusteringMetadata()`, whose numbers are formatted before anyone sees them.
+    ///
+    /// `%.4f` on the weights and `%.2f`/`%.3f` on the shapes, all of them Java's HALF_UP. A cluster
+    /// that moved in its last digits reads here as one that did not.
+    pub fn clustering_metadata(&self) -> Vec<(String, String)> {
+        let mut result = Vec::new();
+        for length in -MAX_INDEL_SIZE_IN_PRIOR_MAP..=MAX_INDEL_SIZE_IN_PRIOR_MAP {
+            let log_prior = self
+                .log_variant_priors
+                .iter()
+                .find(|(key, _)| *key == length)
+                .map(|(_, value)| *value)
+                .unwrap_or(f64::NAN);
+            let kind = if length == 0 {
+                "SNV".to_string()
+            } else if length < 0 {
+                format!("deletion of length {}", length.abs())
+            } else {
+                format!("insertion of length {length}")
+            };
+            result.push((
+                format!("Ln prior of {kind}"),
+                crate::tsv_table::java_double_to_string(log_prior),
+            ));
+        }
+        result.push((
+            "Background beta-binomial cluster".to_string(),
+            format!(
+                "weight = {}, {}",
+                format_decimals(self.log_cluster_weights[0].exp(), 4),
+                Self::describe(&self.clusters[0])
+            ),
+        ));
+        result.push((
+            "High-AF beta-binomial cluster".to_string(),
+            format!(
+                "weight = {}, {}",
+                format_decimals(self.log_cluster_weights[1].exp(), 4),
+                Self::describe(&self.clusters[1])
+            ),
+        ));
+        let mut rest: Vec<usize> = (2..self.clusters.len()).collect();
+        // `sorted(comparingDouble(c -> -logClusterWeights[c]))`, a stable sort on the negated weight.
+        rest.sort_by(|a, b| {
+            (-self.log_cluster_weights[*a]).total_cmp(&-self.log_cluster_weights[*b])
+        });
+        for index in rest {
+            result.push((
+                "Binomial cluster".to_string(),
+                format!(
+                    "weight = {}, {}",
+                    format_decimals(self.log_cluster_weights[index].exp(), 4),
+                    Self::describe(&self.clusters[index])
+                ),
+            ));
+        }
+        result
+    }
+
+    /// The two `toString`s: `alpha = %.2f, beta = %.2f` and `mean = %.3f`.
+    fn describe(cluster: &AlleleFractionCluster) -> String {
+        match cluster {
+            AlleleFractionCluster::BetaBinomial(shape) => format!(
+                "alpha = {}, beta = {}",
+                format_decimals(shape.alpha(), 2),
+                format_decimals(shape.beta(), 2)
+            ),
+            AlleleFractionCluster::Binomial(shape) => format!(
+                "mean = {}",
+                format_decimals(shape.alpha() / (shape.alpha() + shape.beta()), 3)
+            ),
+        }
     }
 }
 

--- a/crates/gatk-engine/tests/somatic_clustering_learn.rs
+++ b/crates/gatk-engine/tests/somatic_clustering_learn.rs
@@ -1,0 +1,293 @@
+//! Conformance for the EM iteration and the quantile initialisation against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/SomaticClusteringLearnDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **`learn` is sequential within an epoch**, so the same data in two orders learn two shapes
+//!    that `%.2f` prints identically and the probes tell apart;
+//!  * **the floors are applied every step**, so a cluster with no responsibility cannot move and one
+//!    with none of its own lands at `mean = 0.990`;
+//!  * **the initialisation splits peaks until the BIC stops improving**, at most five times;
+//!  * **the prior map is rewritten only when there is a callable-site count**;
+//!  * **and every number in `clusteringMetadata` is formatted before anyone sees it**, HALF_UP.
+//!
+//! The whole learning path runs through `exp`, whose bit-exact transcription is withdrawn under
+//! htsjdk-rs decision 0014: the binomial density is `exp` of a saddle point, and every
+//! responsibility is a normalisation of logs. Divergences are therefore bounded rather than absent,
+//! and every row that needs the allowance is named in `ULPS_APART` with the size it needs.
+
+use gatk_corpus as corpus;
+use gatk_engine::allele_fraction_cluster::{
+    learn_beta_binomial, learn_binomial, AlleleFractionCluster, BetaDistributionShape, Datum,
+};
+use gatk_engine::java_format::format_decimals;
+use gatk_engine::somatic_clustering_model::{
+    binomial_probability, AlternateAllele, PriorArguments, SomaticClusteringModel,
+};
+use gatk_engine::tsv_table::java_double_to_string;
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/somatic_clustering_learn.txt.gz"),
+    )
+}
+
+/// The probe counts the dump uses.
+const PROBES: [(i32, i32); 3] = [(10, 5), (100, 3), (100, 50)];
+
+/// The rows that need the decision 0014 allowance, and how many ulps each needs.
+const ULPS_APART: [(&str, i64); 0] = [];
+
+fn datum(total: i32, alt: i32) -> Datum {
+    Datum::new(20.0, 0.0, 0.0, alt, total, 0)
+}
+
+fn data(counts: &[(i32, i32)]) -> Vec<Datum> {
+    counts
+        .iter()
+        .map(|(total, alt)| datum(*total, *alt))
+        .collect()
+}
+
+fn describe(cluster: &AlleleFractionCluster) -> String {
+    match cluster {
+        AlleleFractionCluster::BetaBinomial(shape) => format!(
+            "alpha = {}, beta = {}",
+            format_decimals(shape.alpha(), 2),
+            format_decimals(shape.beta(), 2)
+        ),
+        AlleleFractionCluster::Binomial(shape) => format!(
+            "mean = {}",
+            format_decimals(shape.alpha() / (shape.alpha() + shape.beta()), 3)
+        ),
+    }
+}
+
+/// One `learn` call, printed as the dump prints it.
+fn learned(
+    label: &str,
+    cluster: AlleleFractionCluster,
+    data: &[Datum],
+    responsibilities: &[f64],
+) -> Vec<String> {
+    let learned = match cluster {
+        AlleleFractionCluster::BetaBinomial(shape) => AlleleFractionCluster::BetaBinomial(
+            learn_beta_binomial(shape, data, responsibilities).expect("a shape"),
+        ),
+        AlleleFractionCluster::Binomial(_) => AlleleFractionCluster::Binomial(
+            learn_binomial(data, responsibilities).expect("a shape"),
+        ),
+    };
+    let mut rows = vec![format!("learn\t{label}\t{}", describe(&learned))];
+    for (total, alt) in PROBES {
+        let value = learned.log_likelihood(total, alt).expect("in range");
+        rows.push(format!(
+            "probe\t{label}-{total},{alt}\t{}",
+            java_double_to_string(value)
+        ));
+    }
+    rows
+}
+
+fn flat() -> AlleleFractionCluster {
+    AlleleFractionCluster::beta_binomial(BetaDistributionShape::FLAT)
+}
+
+fn high_af() -> AlleleFractionCluster {
+    AlleleFractionCluster::beta_binomial(BetaDistributionShape::new(10.0, 1.0).expect("a shape"))
+}
+
+fn binomial(mean: f64) -> AlleleFractionCluster {
+    AlleleFractionCluster::binomial(mean).expect("a shape")
+}
+
+/// A model given the data one datum at a time, then told to learn.
+fn model(counts: &[Datum], callable_sites: Option<f64>) -> SomaticClusteringModel {
+    let mut model = SomaticClusteringModel::new(PriorArguments::new(), callable_sites);
+    feed(&mut model, counts);
+    model.learn_and_clear_accumulated_data().expect("learned");
+    model
+}
+
+fn feed(model: &mut SomaticClusteringModel, counts: &[Datum]) {
+    for datum in counts {
+        let mut ads = [datum.total_count() - datum.alt_count(), datum.alt_count()];
+        model
+            .record(
+                &mut ads,
+                &[datum.tumor_log_odds()],
+                &[datum.artifact_prob()],
+                &[0.0],
+                &[AlternateAllele {
+                    length: 1,
+                    symbolic: false,
+                }],
+                1,
+            )
+            .expect("recorded");
+    }
+}
+
+/// The `metadata`, `prior` and `artifactprior` rows one learned model produces.
+fn model_rows(label: &str, model: &mut SomaticClusteringModel) -> Vec<String> {
+    let mut rows: Vec<String> = model
+        .clustering_metadata()
+        .into_iter()
+        .map(|(key, value)| format!("metadata\t{label}\t{key}={value}"))
+        .collect();
+    for length in [0, 1, -1, 40] {
+        rows.push(format!(
+            "prior\t{label}-{length}\t{}",
+            java_double_to_string(model.log_prior_of_somatic_variant(length))
+        ));
+    }
+    rows.push(format!(
+        "artifactprior\t{label}\t{}",
+        java_double_to_string(model.log_prior_of_variant_versus_artifact())
+    ));
+    rows
+}
+
+fn ours() -> Vec<String> {
+    let mut rows = Vec::new();
+    for n in [10, 100] {
+        for k in [0, 1, 5, 10] {
+            if k <= n {
+                for f in [0.0, 0.01, 0.1, 0.5, 0.99, 1.0] {
+                    rows.push(format!(
+                        "binomprob\t{n},{k},{}\t{}",
+                        java_double_to_string(f),
+                        java_double_to_string(binomial_probability(n, k, f))
+                    ));
+                }
+            }
+        }
+    }
+
+    let clonal = data(&[(100, 50), (100, 48), (100, 52), (100, 51)]);
+    let ones = vec![1.0; clonal.len()];
+    rows.extend(learned("betabinomial-flat-clonal", flat(), &clonal, &ones));
+    rows.extend(learned(
+        "betabinomial-highaf-clonal",
+        high_af(),
+        &clonal,
+        &ones,
+    ));
+    rows.extend(learned("binomial-clonal", binomial(0.5), &clonal, &ones));
+
+    let mut reversed = clonal.clone();
+    reversed.reverse();
+    rows.extend(learned(
+        "betabinomial-flat-reversed",
+        flat(),
+        &reversed,
+        &ones,
+    ));
+    rows.extend(learned(
+        "binomial-reversed",
+        binomial(0.5),
+        &reversed,
+        &ones,
+    ));
+
+    let halved = vec![0.5; clonal.len()];
+    rows.extend(learned(
+        "betabinomial-flat-halved",
+        flat(),
+        &clonal,
+        &halved,
+    ));
+    rows.extend(learned("binomial-halved", binomial(0.5), &clonal, &halved));
+
+    let zeroes = vec![0.0; clonal.len()];
+    rows.extend(learned("betabinomial-flat-zero", flat(), &clonal, &zeroes));
+    rows.extend(learned("binomial-zero", binomial(0.5), &clonal, &zeroes));
+
+    rows.extend(learned("betabinomial-flat-empty", flat(), &[], &[]));
+    rows.extend(learned("binomial-empty", binomial(0.5), &[], &[]));
+
+    let subclonal = data(&[(100, 5), (100, 7), (100, 4), (100, 6)]);
+    let subclonal_ones = vec![1.0; subclonal.len()];
+    rows.extend(learned(
+        "betabinomial-flat-subclonal",
+        flat(),
+        &subclonal,
+        &subclonal_ones,
+    ));
+    rows.extend(learned(
+        "binomial-subclonal",
+        binomial(0.5),
+        &subclonal,
+        &subclonal_ones,
+    ));
+
+    let bimodal = data(&[
+        (100, 45),
+        (100, 48),
+        (100, 50),
+        (100, 14),
+        (100, 16),
+        (100, 15),
+        (100, 47),
+        (100, 13),
+    ]);
+    for (label, data, callable) in [
+        ("clonal", clonal.clone(), Some(10000.0)),
+        ("subclonal", subclonal.clone(), Some(10000.0)),
+        ("bimodal", bimodal, Some(10000.0)),
+        ("one-datum", data(&[(100, 50)]), Some(10000.0)),
+        ("no-data", Vec::new(), Some(10000.0)),
+        ("clonal-no-callable-sites", clonal.clone(), None),
+        ("clonal-zero-callable-sites", clonal.clone(), Some(0.0)),
+    ] {
+        let mut learned_model = model(&data, callable);
+        rows.extend(model_rows(label, &mut learned_model));
+    }
+
+    // Learned twice, with new data between the rounds.
+    let mut twice = model(&clonal, Some(10000.0));
+    rows.extend(model_rows("twice-first", &mut twice));
+    feed(&mut twice, &subclonal);
+    twice.learn_and_clear_accumulated_data().expect("learned");
+    rows.extend(model_rows("twice-second", &mut twice));
+    rows
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let text = golden();
+    let expected: Vec<&str> = text.lines().filter(|line| !line.starts_with('#')).collect();
+    assert_eq!(expected.len(), 357, "the golden's row count");
+
+    let mine = ours();
+    assert_eq!(mine.len(), expected.len(), "every row is accounted for");
+
+    for (ours, theirs) in mine.iter().zip(&expected) {
+        if ours == theirs {
+            continue;
+        }
+        let label = theirs.split('\t').nth(1).unwrap_or_default();
+        let allowance = ULPS_APART
+            .iter()
+            .find(|(name, _)| *name == label)
+            .map(|(_, ulps)| *ulps);
+        let allowed = allowance.unwrap_or_else(|| panic!("{label}: {ours} against {theirs}"));
+        let value: f64 = ours
+            .rsplit('\t')
+            .next()
+            .and_then(|text| text.parse().ok())
+            .unwrap_or_else(|| panic!("{label}: {ours} against {theirs}"));
+        let reference: f64 = theirs
+            .rsplit('\t')
+            .next()
+            .and_then(|text| text.parse().ok())
+            .unwrap_or_else(|| panic!("{label}: {ours} against {theirs}"));
+        let ulps = ((value.to_bits() as i64) - (reference.to_bits() as i64)).abs();
+        assert!(
+            ulps <= allowed,
+            "{label}: {ours} against {theirs}, {ulps} ulps"
+        );
+    }
+}

--- a/crates/gatk-engine/tests/somatic_clustering_model.rs
+++ b/crates/gatk-engine/tests/somatic_clustering_model.rs
@@ -13,17 +13,25 @@
 //!  * **and the initial weights do not sum to one**, which makes
 //!    `logLikelihoodGivenSomatic(0, 0)` positive.
 //!
-//! # What is compared, and what is not
+//! # Every row, including the five that once waited on the EM iteration
 //!
-//! Every row except the five `artifactprior <label>-learned` ones, which are the dump reading back
-//! what `record` accumulated by running `learnAndClearAccumulatedData`. That call is the EM
-//! iteration and its quantile initialisation, which are not ported: the port asserts what `record`
-//! kept through `accumulated()` and `obvious_artifact_count()` in the module's own unit tests
-//! instead. The five labels are named in `NEEDS_THE_EM`, so a sixth cannot appear silently.
+//! The `artifactprior <label>-learned` rows are the dump reading back what `record` accumulated by
+//! running `learnAndClearAccumulatedData`. That call is the EM iteration and its quantile
+//! initialisation, which the sibling `somatic-clustering-learn` slice ported, so the five rows are
+//! reproduced here rather than deferred.
 //!
-//! The `loglike` and `seqerror` rows go through `logSumExp` and therefore `exp`, whose bit-exact
-//! transcription is withdrawn under htsjdk-rs decision 0014. Both are bit-identical here anyway;
-//! `EXP_BOUNDED` is empty, and the test fails if a row needs to be added to it.
+//! # Where the exponential shows
+//!
+//! Everything on this path that carries `exp` -- `logSumExp` under `logLikelihoodGivenSomatic` and
+//! `probabilityOfSequencingError`, and the round of EM behind the `-learned` rows -- is bounded
+//! rather than equal, `exp` having no bit-exact transcription under htsjdk-rs decision 0014.
+//!
+//! Only two rows need the allowance and both need **90 ulps**: `one-alt-learned` and
+//! `symbolic-alt-learned`, whose data carry a TLOD of 6 where the sequencing-error probability is
+//! large enough to matter. One ulp of `exp` there moves a somatic probability, which moves the
+//! variant count, which the prior takes the log of. The three `-learned` rows beside them are
+//! bit-identical, as are every `loglike` and `seqerror` row. `EXP_BOUNDED` names the two with the
+//! size each needs, so neither a third row nor a larger divergence can appear quietly.
 
 use gatk_corpus as corpus;
 use gatk_engine::allele_fraction_cluster::Datum;
@@ -39,17 +47,8 @@ fn golden() -> String {
     )
 }
 
-/// The rows that need the EM iteration, which is the next slice rather than this one.
-const NEEDS_THE_EM: [&str; 5] = [
-    "one-alt-learned",
-    "symbolic-alt-learned",
-    "obvious-artifact-learned",
-    "obvious-non-somatic-learned",
-    "at-threshold-learned",
-];
-
-/// The rows allowed to sit one ulp away because they carry `exp`. None do.
-const EXP_BOUNDED: [&str; 0] = [];
+/// The rows allowed to differ because they carry `exp`, with the allowance each needs.
+const EXP_BOUNDED: [(&str, i64); 2] = [("one-alt-learned", 90), ("symbolic-alt-learned", 90)];
 
 fn double(text: &str) -> f64 {
     text.parse().unwrap_or_else(|_| panic!("a double: {text}"))
@@ -175,6 +174,15 @@ fn ads_rows() -> Vec<String> {
             .is_ok()
         {
             rows.push(format!("ads\t{label}-after\t{ads:?}"));
+            // What the model accumulated, read back through the prior one round of EM rewrites: a
+            // datum that was dropped cannot move it.
+            model
+                .learn_and_clear_accumulated_data()
+                .expect("the initial shapes stay in range");
+            rows.push(format!(
+                "artifactprior\t{label}-learned\t{}",
+                java_double_to_string(model.log_prior_of_variant_versus_artifact())
+            ));
         }
     };
     push(
@@ -324,32 +332,26 @@ fn every_row_matches_the_golden() {
         ));
     }
 
-    // The golden's rows, minus the ones the EM iteration would answer.
-    let expected: Vec<&str> = lines
-        .iter()
-        .copied()
-        .filter(|line| {
-            let label = line.split('\t').nth(1).unwrap_or_default();
-            !(line.starts_with("artifactprior\t") && NEEDS_THE_EM.contains(&label))
-        })
-        .collect();
-    let deferred = lines.len() - expected.len();
-    assert_eq!(deferred, NEEDS_THE_EM.len(), "the deferred rows changed");
+    let expected = &lines;
     assert_eq!(lines.len(), 66, "the golden's row count");
 
-    for (mine, theirs) in ours.iter().zip(&expected) {
+    for (mine, theirs) in ours.iter().zip(expected) {
         if mine == theirs {
             continue;
         }
         let label = theirs.split('\t').nth(1).unwrap_or_default();
-        assert!(
-            EXP_BOUNDED.contains(&label),
-            "{label}: {mine} against {theirs}"
-        );
+        let allowed = EXP_BOUNDED
+            .iter()
+            .find(|(name, _)| *name == label)
+            .map(|(_, ulps)| *ulps)
+            .unwrap_or_else(|| panic!("{label}: {mine} against {theirs}"));
         let value: f64 = double(mine.rsplit('\t').next().expect("a value"));
         let reference: f64 = double(theirs.rsplit('\t').next().expect("a value"));
         let ulps = ((value.to_bits() as i64) - (reference.to_bits() as i64)).abs();
-        assert!(ulps <= 1, "{label}: {mine} against {theirs}, {ulps} ulps");
+        assert!(
+            ulps <= allowed,
+            "{label}: {mine} against {theirs}, {ulps} ulps"
+        );
     }
     assert_eq!(ours.len(), expected.len(), "every row is accounted for");
 }


### PR DESCRIPTION
Closes #332.

`learnAndClearAccumulatedData` with `initializeClusters`, `performEMIteration` and both `learn`
methods under it. **All 357 rows of the golden are reproduced bit-identically**, with no ulp
allowance at all — `ULPS_APART` is empty even though the whole path runs through `exp`.

- **`learn` on the beta-binomial is sequential within an epoch** and floored *every step*, not at the
  end. `Math.max` propagates NaN where Rust's `f64::max` answers the other argument, so both clamps
  are written out.
- **Both of the binomial's sums are `DoubleStream.sum`**, which is compensated and not
  `MathUtils.sum`'s plain loop. The JDK *adds* the compensation in its final step rather than
  subtracting it — "better error bounds to add both terms as the final sum" — even though the
  accumulator stores the error with the other sign.
- **The fuzzy binomial forms its square first**: `mean * MathUtils.square(0.01)` is not
  `(mean * 0.01) * 0.01`. The first association this port used passed the sibling suite and failed
  here on the ninth digit of a learned likelihood. That is what the probes are for.
- **`initializeClusters` splits the biggest peak off the background** and keeps the split only while
  the BIC improves, at most five times. The new background weight is `log1p` of the split fraction,
  so the background comes out with *more* weight than it had.
- **The variant count is summed in the `HashMap`'s table order**, not the insertion order, which
  `java_hash::hash_map_order` supplies.
- **`clusteringMetadata` formats every number before anyone sees it**, `%.4f` and `%.2f`/`%.3f`, all
  HALF_UP.

### It releases the deferred rows

The five `NEEDS_THE_EM` rows of the `somatic-clustering-model` suite are now reproduced rather than
skipped. Two need an allowance and it is named: `one-alt-learned` and `symbolic-alt-learned` sit
**90 ulps** away, their data carrying a TLOD of 6 where the sequencing-error probability is large
enough that one ulp of `exp` moves a somatic probability, which moves the variant count, which the
prior takes the log of. The other three are bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)