### PR TITLE
A preflight that runs what CI runs, and the release-only failure it found

### DIFF
--- a/crates/gatk-engine/src/math_utils.rs
+++ b/crates/gatk-engine/src/math_utils.rs
@@ -69,14 +69,25 @@ pub fn max_element_index(array: &[f64], start: usize, end: usize) -> usize {
 ///
 /// **What**: ten raised to the power `x`.
 ///
-/// **How**: the platform's own `powf`. `10.0f64` writes the literal ten as a 64-bit float so that
-/// the method call resolves to the 64-bit version rather than the 32-bit one.
+/// **How**: the platform's own `powf`, called at run time and kept from being folded.
+///
+/// **Why it is not `jmath::strict_pow`**, which would be the obvious choice: `StrictMath.pow` and
+/// `Math.pow` are not the same function, and the goldens hold `Math.pow`. htsjdk-rs decision 0027
+/// measured the gap at one ulp, and one ulp is enough: swapping this to fdlibm makes the BAQ
+/// emission table match and makes `genotype-counts` stop matching. The host libm is the closer
+/// stand-in for the intrinsic on both platforms measured so far.
+///
+/// **Why the `black_box`**: without it LLVM folds `10.0f64.powf(constant)` at compile time with its
+/// own APFloat, and on aarch64 that disagrees with the same machine's libm in the last bit —
+/// `10^-0.4` is `3fd97a967f7524b2` at run time and `...b3` folded. The BAQ table is built from
+/// constants, so it passed in debug and failed in `--release`. Forcing the call keeps one answer
+/// per host rather than one per optimisation level.
 ///
 /// **Why it is a named function rather than inlined at each call site**: so that there is exactly
-/// one place to change if decision 0007 is ever closed by porting `Math.pow`, and so that a reader
-/// grepping for the deferred function finds every use of it.
+/// one place to change if decision 0007 is ever closed, and so that a reader grepping for the
+/// deferred function finds every use of it.
 pub fn pow10(x: f64) -> f64 {
-    10.0f64.powf(x)
+    std::hint::black_box(10.0f64).powf(x)
 }
 
 /// `MathUtils.log10SumLog10(array)`, with a **capital S**.

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Run, locally, every CI gate that does not need the runner's silicon.
+
+Written because a PR went red on `expect_rows`: a number that had been counted by hand from
+`wc -l` rather than taken from the harness, which the suite runner would have caught in seconds.
+The point of this script is that "I ran the tests" and "I ran what CI runs" stop being different
+claims. It mirrors .github/workflows/ci.yml in the workflow's own order and stops at the first
+failure.
+
+What it deliberately does NOT do: produce goldens. The oracle jobs run the pinned container and a
+golden may only come from a real x86-64 runner; `--suites` here is a smoke test of the harness and
+of the manifest's own expectations, which is exactly the part that has broken.
+
+Usage:
+    python3 tools/preflight.py                     # every gate, no suite runs
+    python3 tools/preflight.py --suites a,b        # and run these suites through the harness
+    python3 tools/preflight.py --fast              # skip the release test build
+"""
+
+import argparse
+import subprocess
+import sys
+import time
+
+REPO = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True,
+                      check=True).stdout.strip()
+
+
+def step(name, command, shell=False):
+    """One CI step, printed the way the workflow names it."""
+    started = time.time()
+    print(f"\n=== {name}", flush=True)
+    result = subprocess.run(command, cwd=REPO, shell=shell)
+    elapsed = time.time() - started
+    if result.returncode != 0:
+        print(f"\nFAILED after {elapsed:.0f}s: {name}", file=sys.stderr)
+        sys.exit(result.returncode)
+    print(f"--- ok ({elapsed:.0f}s)", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--suites", default="",
+                        help="comma-separated suite ids to run through the oracle harness")
+    parser.add_argument("--fast", action="store_true",
+                        help="skip `cargo test --workspace --release`, which CI runs in release")
+    arguments = parser.parse_args()
+
+    # guard: repository invariants
+    step("LICENSE and README state the same licence",
+         'grep -q "Apache License" LICENSE '
+         '&& grep -q "Apache License 2.0, matching GATK" README.md '
+         '&& grep -qi "not the official GATK" README.md', shell=True)
+    step("The workflow matches the conformance manifest",
+         ["python3", "tools/conformance/generate_ci.py", "--check"])
+    step("Every committed golden belongs to a declared suite",
+         ["python3", "tools/conformance/audit_goldens.py"])
+
+    # test: the x86-64 job, minus the parts that need the runner
+    step("Every ported symbol comes from a licence-compatible source",
+         ["python3", "tools/audit/provenance.py", "crates"])
+    step("A file already explained does not lose its explanations",
+         ["python3", "tools/audit/comment_density.py", "--check"])
+    step("cargo fmt", ["cargo", "fmt", "--all", "--", "--check"])
+    step("cargo clippy",
+         ["cargo", "clippy", "--workspace", "--all-targets", "--", "-D", "warnings"])
+    if not arguments.fast:
+        # CI tests in release. A debug-only run has passed while release failed before.
+        step("cargo test --release", ["cargo", "test", "--workspace", "--release"])
+    step("The ports below are pinned by revision, not by branch",
+         'if grep -E \'^(htsjdk|picard|jmath)[a-z-]* = \\{ git\' Cargo.toml | grep -qv \'rev = "\'; '
+         'then echo "a dependency is not pinned to a revision"; exit 1; fi', shell=True)
+
+    # dashboard
+    step("docs/STATUS.md is generated, not written",
+         ["python3", "tools/dashboard/generate.py", "--check"])
+
+    # The suites, last, because they are the slowest and need the oracle image.
+    suites = [s for s in arguments.suites.split(",") if s]
+    if suites:
+        step(f"oracle harness: {','.join(suites)}",
+             ["python3", "tools/conformance/run_suite.py", "--suites", ",".join(suites)])
+
+    print("\npreflight: every gate green")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Every CI gate that does not need the runner's silicon, in the workflow's own order, in one command:

```
python3 tools/preflight.py                  # every gate
python3 tools/preflight.py --suites <id>    # and put a suite through the oracle harness
```

Written because a PR went red on `expect_rows` — a number counted by hand from `wc -l`, which
included the dump's `#` header line, and which the harness would have corrected in seconds.
"I ran the tests" and "I ran what CI runs" were not the same claim.

### The first full run failed, on a test that had been passing

`cargo test --release` is what CI runs and what nothing here had been running:

```
assertion `left == right` failed: qual2prob[4]
  left: "3fd97a967f7524b3"
 right: "3fd97a967f7524b2"
```

`MathUtils.pow10` is `10.0f64.powf(x)` and the BAQ emission table is built from constants at
startup, so LLVM folded the call at compile time. Its APFloat and this machine's libm disagree in
the last bit on `10^-0.4`, so **the table depended on the optimisation level**: debug green, release
red, same host, same commit.

The fix keeps `Math.pow` and blocks the folding: `std::hint::black_box(10.0f64).powf(x)`.

The obvious alternative, `jmath::strict_pow`, was tried first and is **wrong here**.
`StrictMath.pow` and `Math.pow` are not the same function; htsjdk-rs decision 0027 measured the gap
at one ulp, and one ulp is enough — switching to fdlibm makes the BAQ table match and makes
`genotype-counts` stop matching. Both suites pass in both profiles now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #13.
