### PR TITLE
Port the allele filter's shared machinery

### DIFF
--- a/crates/gatk-engine/src/allele_filter.rs
+++ b/crates/gatk-engine/src/allele_filter.rs
@@ -1,0 +1,316 @@
+//! `Mutect2AlleleFilter` and `Mutect2Filter`, ported from
+//! `org.broadinstitute.hellbender.tools.walkers.mutect.filtering` (GATK 4.6.2.0), with
+//! `TumorEvidenceFilter` on top of them.
+//!
+//! What every per-allele filter stands on: gather one value per allele across the samples, answer a
+//! probability per alternate allele, and refuse to answer at all when the record lacks what the
+//! filter reads.
+//!
+//! # The gather zips two iterators and stops at the shorter one
+//!
+//! ```java
+//! Iterator<T> alleleDataIterator = getData.apply(g).iterator();
+//! Iterator<List<T>> dataByAlleleIterator = dataByAllele.values().iterator();
+//! while (alleleDataIterator.hasNext() && dataByAlleleIterator.hasNext())
+//!     dataByAlleleIterator.next().add(alleleDataIterator.next());
+//! ```
+//!
+//! No exception and no padding. Two consequences the measurement pinned:
+//!
+//!  * **a short list shifts the gather rather than shortening one allele's list.** A genotype giving
+//!    `[1]` against three alleles contributes to the first allele alone, so a second sample's
+//!    `[4, 5, 6]` lands as `A=[1, 4]`, `C=[5]`, `G=[6]`;
+//!  * **`getAltDataByAllele` does not skip the reference in the data.** Its map is keyed by the
+//!    alternate alleles alone, but the walk still starts at the caller's first element, so a caller
+//!    passing a full-length per-allele list gives the first alternate the *reference's* value and
+//!    drops the last.
+//!
+//! # An unanswerable filter answers nothing
+//!
+//! `errorProbabilities` checks that every required annotation is present and returns an **empty
+//! list** if one is not. `ErrorProbabilities` drops an empty list entirely rather than counting it
+//! as zero, so a filter that cannot be evaluated is not a filter that found nothing.
+
+use crate::allele_fraction_cluster::Datum;
+use crate::error_probabilities::ErrorType;
+use crate::mutect_engine::round_finite_precision_errors;
+use crate::somatic_clustering_model::{indel_length, AlternateAllele, SomaticClusteringModel};
+
+/// One genotype, as much of it as the gather and the depth sum look at.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenotypeData<T> {
+    /// Whether the engine calls this sample a tumour, which is the usual precondition.
+    pub tumor: bool,
+    /// `Genotype.getAD()`.
+    pub allele_depths: Vec<i32>,
+    /// The per-allele values the filter asked for, in the genotype's own order.
+    pub values: Vec<T>,
+}
+
+/// `getDataByAllele`: one list per allele of the record, the reference included.
+///
+/// The keys are the alleles in the record's order, so the result is returned as a `Vec` of
+/// `(allele, values)` rather than a map: it is a `LinkedHashMap` upstream, and its order is the
+/// record's.
+pub fn data_by_allele<T: Clone>(
+    alleles: &[String],
+    genotypes: &[GenotypeData<T>],
+    precondition: impl Fn(&GenotypeData<T>) -> bool,
+) -> Vec<(String, Vec<T>)> {
+    // `Collectors.toMap(identity, .., (a, b) -> a, LinkedHashMap::new)`: a repeated allele collapses
+    // to one key, and the first occurrence wins.
+    let mut gathered: Vec<(String, Vec<T>)> = Vec::new();
+    for allele in alleles {
+        if !gathered.iter().any(|(key, _)| key == allele) {
+            gathered.push((allele.clone(), Vec::new()));
+        }
+    }
+    combine(&mut gathered, genotypes, precondition);
+    gathered
+}
+
+/// `getAltDataByAllele`: one list per **alternate** allele.
+///
+/// The caller is expected to supply alternate-only data. Nothing checks that: the walk starts at the
+/// first element either way.
+pub fn alt_data_by_allele<T: Clone>(
+    alleles: &[String],
+    genotypes: &[GenotypeData<T>],
+    precondition: impl Fn(&GenotypeData<T>) -> bool,
+) -> Vec<(String, Vec<T>)> {
+    data_by_allele(&alleles[1..], genotypes, precondition)
+}
+
+/// `combineDataByAllele`, which is the zip.
+fn combine<T: Clone>(
+    gathered: &mut [(String, Vec<T>)],
+    genotypes: &[GenotypeData<T>],
+    precondition: impl Fn(&GenotypeData<T>) -> bool,
+) {
+    for genotype in genotypes.iter().filter(|g| precondition(g)) {
+        for (slot, value) in gathered.iter_mut().zip(&genotype.values) {
+            slot.1.push(value.clone());
+        }
+    }
+}
+
+/// What `sumADsOverSamples` refuses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlleleDepthTooShort {
+    pub index: usize,
+    pub length: usize,
+}
+
+impl AlleleDepthTooShort {
+    /// `ArrayIndexOutOfBoundsException`'s message, which names both numbers.
+    pub fn message(&self) -> String {
+        format!(
+            "Index {} out of bounds for length {}",
+            self.index, self.length
+        )
+    }
+}
+
+/// `Mutect2FilteringEngine.sumADsOverSamples(vc, includeTumor, includeNormal)`.
+///
+/// Every selected genotype is indexed by the **record's** allele count, so a genotype whose AD array
+/// is shorter is an out-of-bounds rather than a skip.
+pub fn sum_ads_over_samples<T>(
+    allele_count: usize,
+    genotypes: &[GenotypeData<T>],
+    include_tumor: bool,
+    include_normal: bool,
+) -> Result<Vec<i32>, AlleleDepthTooShort> {
+    let mut totals = vec![0; allele_count];
+    for genotype in genotypes {
+        if !((include_tumor && genotype.tumor) || (include_normal && !genotype.tumor)) {
+            continue;
+        }
+        // `new IndexRange(0, vc.getNAlleles()).forEach(n -> ADs[n] += ad[n])`: the range is the
+        // record's allele count, so it is the genotype's array that runs out.
+        for (index, total) in totals.iter_mut().enumerate() {
+            let depth = genotype
+                .allele_depths
+                .get(index)
+                .ok_or(AlleleDepthTooShort {
+                    index,
+                    length: genotype.allele_depths.len(),
+                })?;
+            *total += depth;
+        }
+    }
+    Ok(totals)
+}
+
+/// `Mutect2Filter.weightedMedianPosteriorProbability(depthsAndPosteriors)`.
+///
+/// The lowest posterior that accounts for half the total alternate depth. Three things a smoother
+/// implementation would get wrong: it **sorts the caller's list in place**, which is why this takes
+/// `&mut`; an empty list is `0.0` rather than a refusal; and the test is `>=`, so an even split
+/// returns the lower half's element.
+pub fn weighted_median_posterior_probability(depths_and_posteriors: &mut [(i32, f64)]) -> f64 {
+    let total_alt_depth: i32 = depths_and_posteriors.iter().map(|(depth, _)| depth).sum();
+    // `Comparator.comparingDouble`, a stable sort on the posterior alone.
+    depths_and_posteriors.sort_by(|a, b| a.1.total_cmp(&b.1));
+    let mut cumulative = 0;
+    for (depth, posterior) in depths_and_posteriors.iter() {
+        cumulative += depth;
+        if cumulative * 2 >= total_alt_depth {
+            return *posterior;
+        }
+    }
+    0.0
+}
+
+/// `TumorEvidenceFilter`'s identity.
+pub const TUMOR_EVIDENCE_FILTER_NAME: &str = "weak_evidence";
+pub const TUMOR_EVIDENCE_ERROR_TYPE: ErrorType = ErrorType::Sequencing;
+/// `phredScaledPosteriorAnnotationName`, `SEQUENCING_QUAL_KEY`.
+pub const TUMOR_EVIDENCE_ANNOTATION: &str = "SEQQ";
+
+/// `TumorEvidenceFilter.errorProbabilities(vc, engine, referenceContext)`.
+///
+/// `tumor_log_odds` is `getTumorLogOdds(vc)`, already converted from log10, and `None` is the record
+/// that has no `TLOD` at all: the required-annotation check answers an empty list rather than a
+/// probability.
+///
+/// The `Datum` is built with **both** probabilities zero, so the filter reads the clustering model
+/// without contributing to it; and the list is as long as the log-odds, not as long as the alternate
+/// alleles, so a `TLOD` shorter than the record answers for the alleles it covers and no more.
+pub fn tumor_evidence_error_probabilities<T>(
+    model: &mut SomaticClusteringModel,
+    tumor_log_odds: Option<&[f64]>,
+    genotypes: &[GenotypeData<T>],
+    alleles: &[AlternateAllele],
+    reference_length: i32,
+) -> Vec<f64> {
+    let Some(log_odds) = tumor_log_odds else {
+        return Vec::new();
+    };
+    let allele_depths = match sum_ads_over_samples(alleles.len() + 1, genotypes, true, false) {
+        Ok(depths) => depths,
+        Err(_) => return Vec::new(),
+    };
+    let total_count: i32 = allele_depths.iter().sum();
+    log_odds
+        .iter()
+        .enumerate()
+        .map(|(index, odds)| {
+            let datum = Datum::new(
+                *odds,
+                0.0,
+                0.0,
+                allele_depths[index + 1],
+                total_count,
+                indel_length(reference_length, alleles[index]),
+            );
+            let probability = model
+                .probability_of_sequencing_error(&datum)
+                .unwrap_or(f64::NAN);
+            round_finite_precision_errors(probability)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tumor(values: Vec<i32>) -> GenotypeData<i32> {
+        GenotypeData {
+            tumor: true,
+            allele_depths: vec![80, 20, 5],
+            values,
+        }
+    }
+
+    #[test]
+    fn a_short_list_shifts_the_gather() {
+        let alleles = ["A".to_string(), "C".to_string(), "G".to_string()];
+        let genotypes = vec![tumor(vec![1]), tumor(vec![4, 5, 6])];
+        let gathered = data_by_allele(&alleles, &genotypes, |g| g.tumor);
+        assert_eq!(gathered[0], ("A".to_string(), vec![1, 4]));
+        assert_eq!(gathered[1], ("C".to_string(), vec![5]));
+        assert_eq!(gathered[2], ("G".to_string(), vec![6]));
+    }
+
+    #[test]
+    fn the_alternate_gather_still_starts_at_the_callers_first_element() {
+        let alleles = ["A".to_string(), "C".to_string(), "G".to_string()];
+        let genotypes = vec![tumor(vec![1, 2, 3]), tumor(vec![4, 5, 6])];
+        let gathered = alt_data_by_allele(&alleles, &genotypes, |g| g.tumor);
+        // The first ALT takes what the reference's slot took in the full gather.
+        assert_eq!(gathered[0], ("C".to_string(), vec![1, 4]));
+        assert_eq!(gathered[1], ("G".to_string(), vec![2, 5]));
+    }
+
+    #[test]
+    fn a_repeated_allele_collapses_to_one_key() {
+        let alleles = ["A".to_string(), "C".to_string(), "C".to_string()];
+        let genotypes = vec![tumor(vec![1, 2, 3])];
+        let gathered = data_by_allele(&alleles, &genotypes, |g| g.tumor);
+        assert_eq!(gathered.len(), 2);
+        assert_eq!(gathered[1], ("C".to_string(), vec![2]));
+    }
+
+    #[test]
+    fn the_median_sorts_in_place_and_leans_low() {
+        let mut even = [(10, 0.1), (10, 0.9)];
+        assert_eq!(weighted_median_posterior_probability(&mut even), 0.1);
+        let mut unsorted = [(5, 0.9), (5, 0.2), (5, 0.5)];
+        assert_eq!(weighted_median_posterior_probability(&mut unsorted), 0.5);
+        assert_eq!(unsorted, [(5, 0.2), (5, 0.5), (5, 0.9)]);
+        // Every depth zero: the first element already satisfies `0 >= 0`.
+        let mut zero = [(0, 0.3), (0, 0.7)];
+        assert_eq!(weighted_median_posterior_probability(&mut zero), 0.3);
+        assert_eq!(weighted_median_posterior_probability(&mut []), 0.0);
+    }
+
+    #[test]
+    fn a_short_allele_depth_array_is_out_of_bounds() {
+        let genotypes = vec![GenotypeData::<i32> {
+            tumor: true,
+            allele_depths: vec![80, 20],
+            values: Vec::new(),
+        }];
+        assert_eq!(
+            sum_ads_over_samples(3, &genotypes, true, false),
+            Err(AlleleDepthTooShort {
+                index: 2,
+                length: 2
+            })
+        );
+    }
+
+    #[test]
+    fn the_flags_select_the_samples() {
+        let genotypes = vec![
+            GenotypeData::<i32> {
+                tumor: true,
+                allele_depths: vec![80, 20, 5],
+                values: Vec::new(),
+            },
+            GenotypeData::<i32> {
+                tumor: false,
+                allele_depths: vec![99, 1, 0],
+                values: Vec::new(),
+            },
+        ];
+        assert_eq!(
+            sum_ads_over_samples(3, &genotypes, true, false).expect("in range"),
+            vec![80, 20, 5]
+        );
+        assert_eq!(
+            sum_ads_over_samples(3, &genotypes, false, true).expect("in range"),
+            vec![99, 1, 0]
+        );
+        assert_eq!(
+            sum_ads_over_samples(3, &genotypes, true, true).expect("in range"),
+            vec![179, 21, 5]
+        );
+        assert_eq!(
+            sum_ads_over_samples(3, &genotypes, false, false).expect("in range"),
+            vec![0, 0, 0]
+        );
+    }
+}

--- a/crates/gatk-engine/src/error_probabilities.rs
+++ b/crates/gatk-engine/src/error_probabilities.rs
@@ -27,11 +27,26 @@
 
 use crate::mutect_engine::round_finite_precision_errors;
 
-/// `ErrorType`.
+/// `ErrorType`, in the enum's own declaration order.
+///
+/// The three categories exist because filters of one category are **not** independent: two of them
+/// combine by a maximum, and only across categories does `1 - (1 - p1)(1 - p2)` apply.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ErrorType {
     Artifact,
     NonSomatic,
+    Sequencing,
+}
+
+impl ErrorType {
+    /// The enum constant's name.
+    pub fn name(self) -> &'static str {
+        match self {
+            ErrorType::Artifact => "ARTIFACT",
+            ErrorType::NonSomatic => "NON_SOMATIC",
+            ErrorType::Sequencing => "SEQUENCING",
+        }
+    }
 }
 
 /// What `transpose` refuses.
@@ -103,7 +118,11 @@ pub fn kept(answers: &[FilterAnswer]) -> Vec<FilterAnswer> {
 pub fn combined(answers: &[FilterAnswer]) -> Result<Vec<f64>, RaggedLists> {
     let applied = kept(answers);
     let mut per_type: Vec<Vec<f64>> = Vec::new();
-    for error_type in [ErrorType::Artifact, ErrorType::NonSomatic] {
+    for error_type in [
+        ErrorType::Artifact,
+        ErrorType::NonSomatic,
+        ErrorType::Sequencing,
+    ] {
         let probabilities = by_type(&applied, error_type)?;
         if !probabilities.is_empty() {
             per_type.push(probabilities);

--- a/crates/gatk-engine/src/lib.rs
+++ b/crates/gatk-engine/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod activity_profile;
 pub mod alignment_state;
 pub mod alignment_utils;
+pub mod allele_filter;
 pub mod allele_fraction_cluster;
 pub mod allele_likelihoods;
 pub mod allele_list;

--- a/crates/gatk-engine/src/mutect_filter_list.rs
+++ b/crates/gatk-engine/src/mutect_filter_list.rs
@@ -27,24 +27,7 @@
 //! only the filters that **fired**. That is measured by running the tool end to end, in its own
 //! slice.
 
-/// `Mutect2Filter.errorType()`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ErrorType {
-    Sequencing,
-    Artifact,
-    NonSomatic,
-}
-
-impl ErrorType {
-    /// The enum constant's name, which is what the dump prints.
-    pub fn name(self) -> &'static str {
-        match self {
-            ErrorType::Sequencing => "SEQUENCING",
-            ErrorType::Artifact => "ARTIFACT",
-            ErrorType::NonSomatic => "NON_SOMATIC",
-        }
-    }
-}
+pub use crate::error_probabilities::ErrorType;
 
 /// Whether a filter answers one probability per allele or one for the site.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/gatk-engine/tests/allele_filter_base.rs
+++ b/crates/gatk-engine/tests/allele_filter_base.rs
@@ -1,0 +1,304 @@
+//! Conformance for the allele filter's shared machinery against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/AlleleFilterBaseDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **the gather zips two iterators and stops at the shorter one**, so a short list shifts the
+//!    whole gather rather than shortening one allele's list;
+//!  * **the alternate gather still starts at the caller's first element**, so full-length data gives
+//!    the first alternate the reference's value;
+//!  * **the weighted median sorts the caller's list in place** and leans to the lower half;
+//!  * **a short AD array is an out-of-bounds, not a skip**;
+//!  * **and a missing annotation is an empty list, not a zero.**
+//!
+//! The `evidence` rows go through the clustering model's `exp`, whose bit-exact transcription is
+//! withdrawn under htsjdk-rs decision 0014, so they are compared with an allowance. One row needs
+//! it and needs **one ulp**: `strong`, whose second allele is `0.74812961299286` upstream and
+//! `0.7481296129928601` here. `ULPS_APART` names it, so a second row cannot start diverging
+//! quietly. Everything else in this suite is exact.
+
+use gatk_corpus as corpus;
+use gatk_engine::allele_filter::{
+    alt_data_by_allele, data_by_allele, sum_ads_over_samples, tumor_evidence_error_probabilities,
+    weighted_median_posterior_probability, AlleleDepthTooShort, GenotypeData,
+    TUMOR_EVIDENCE_ANNOTATION, TUMOR_EVIDENCE_ERROR_TYPE, TUMOR_EVIDENCE_FILTER_NAME,
+};
+use gatk_engine::somatic_clustering_model::{
+    AlternateAllele, PriorArguments, SomaticClusteringModel,
+};
+use gatk_engine::tsv_table::java_double_to_string;
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/allele_filter_base.txt.gz"),
+    )
+}
+
+/// The rows that need the decision 0014 allowance, and how many ulps each needs.
+///
+/// `strong` alone, and one ulp: its second allele's probability is `0.74812961299286` upstream and
+/// `0.7481296129928601` here. Every other `evidence` row is bit-identical, including the two whose
+/// probabilities sit against 1.0, where an ulp would not show.
+const ULPS_APART: [(&str, i64); 1] = [("strong", 1)];
+
+/// The record every gather row is built from: two tumour samples and a normal.
+fn genotypes(values: [Vec<i32>; 3]) -> Vec<GenotypeData<i32>> {
+    let [first, second, normal] = values;
+    vec![
+        GenotypeData {
+            tumor: true,
+            allele_depths: vec![80, 20, 5],
+            values: first,
+        },
+        GenotypeData {
+            tumor: true,
+            allele_depths: vec![70, 30, 10],
+            values: second,
+        },
+        GenotypeData {
+            tumor: false,
+            allele_depths: vec![99, 1, 0],
+            values: normal,
+        },
+    ]
+}
+
+fn alleles() -> Vec<String> {
+    vec!["A".to_string(), "C".to_string(), "G".to_string()]
+}
+
+/// One gather, printed the way the dump prints a `LinkedHashMap`'s entries.
+fn gather_rows(kind: &str, label: &str, gathered: &[(String, Vec<i32>)]) -> Vec<String> {
+    gathered
+        .iter()
+        .map(|(allele, values)| {
+            let list = values
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<String>>()
+                .join(", ");
+            format!("{kind}\t{label}\t{allele}=[{list}]")
+        })
+        .collect()
+}
+
+/// `ImmutablePair.toString`, which is `(left,right)` with no space.
+fn pair_list(pairs: &[(i32, f64)]) -> String {
+    let inner = pairs
+        .iter()
+        .map(|(depth, posterior)| format!("({depth},{})", java_double_to_string(*posterior)))
+        .collect::<Vec<String>>()
+        .join(", ");
+    format!("[{inner}]")
+}
+
+fn median_rows(label: &str, input: &[(i32, f64)]) -> Vec<String> {
+    let mut mutable = input.to_vec();
+    let answer = weighted_median_posterior_probability(&mut mutable);
+    vec![
+        format!("median\t{label}\t{}", java_double_to_string(answer)),
+        format!("sorted\t{label}\t{}", pair_list(&mutable)),
+    ]
+}
+
+fn ads_row(label: &str, genotypes: &[GenotypeData<i32>], tumor: bool, normal: bool) -> String {
+    match sum_ads_over_samples(3, genotypes, tumor, normal) {
+        Ok(totals) => {
+            let list = totals
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<String>>()
+                .join(", ");
+            format!("ads\t{label}\t[{list}]")
+        }
+        Err(AlleleDepthTooShort { index, length }) => format!(
+            "error\tads-{label}\tjava.lang.ArrayIndexOutOfBoundsException:Index {index} out of \
+             bounds for length {length}"
+        ),
+    }
+}
+
+/// The dump's two alternate alleles, both single-base substitutions.
+fn alternates() -> Vec<AlternateAllele> {
+    vec![
+        AlternateAllele {
+            length: 1,
+            symbolic: false,
+        },
+        AlternateAllele {
+            length: 1,
+            symbolic: false,
+        },
+    ]
+}
+
+fn evidence_row(label: &str, tumor_log_odds: Option<&[f64]>) -> String {
+    // A model built the way the dump builds its engine: default arguments, no stats table.
+    let mut model = SomaticClusteringModel::new(PriorArguments::new(), None);
+    let probabilities = tumor_evidence_error_probabilities(
+        &mut model,
+        tumor_log_odds,
+        &genotypes([vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]),
+        &alternates(),
+        1,
+    );
+    let list = probabilities
+        .iter()
+        .map(|value| java_double_to_string(*value))
+        .collect::<Vec<String>>()
+        .join(", ");
+    format!("evidence\t{label}\t[{list}]")
+}
+
+/// `getTumorLogOdds`, which is `log10ToLog` of the annotation.
+fn log_odds(log10: &[f64]) -> Vec<f64> {
+    log10
+        .iter()
+        .map(|value| value * std::f64::consts::LN_10)
+        .collect()
+}
+
+fn ours() -> Vec<String> {
+    let mut rows = Vec::new();
+    let full = genotypes([vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]);
+    rows.extend(gather_rows(
+        "byallele",
+        "three-alleles-three-values",
+        &data_by_allele(&alleles(), &full, |g| g.tumor),
+    ));
+    rows.extend(gather_rows(
+        "altbyallele",
+        "three-alleles-three-values",
+        &alt_data_by_allele(&alleles(), &full, |g| g.tumor),
+    ));
+
+    let short = genotypes([vec![1], vec![4, 5, 6], vec![7, 8, 9]]);
+    rows.extend(gather_rows(
+        "byallele",
+        "short-list",
+        &data_by_allele(&alleles(), &short, |g| g.tumor),
+    ));
+    rows.extend(gather_rows(
+        "altbyallele",
+        "short-list",
+        &alt_data_by_allele(&alleles(), &short, |g| g.tumor),
+    ));
+
+    // The overlong run keeps one tumour sample and the normal.
+    let overlong = vec![
+        GenotypeData {
+            tumor: true,
+            allele_depths: vec![80, 20, 5],
+            values: vec![1, 2, 3, 4, 5],
+        },
+        GenotypeData {
+            tumor: false,
+            allele_depths: vec![99, 1, 0],
+            values: vec![7, 8, 9],
+        },
+    ];
+    rows.extend(gather_rows(
+        "byallele",
+        "long-list",
+        &data_by_allele(&alleles(), &overlong, |g| g.tumor),
+    ));
+
+    let normal_only = vec![GenotypeData {
+        tumor: false,
+        allele_depths: vec![99, 1, 0],
+        values: vec![7, 8, 9],
+    }];
+    rows.extend(gather_rows(
+        "byallele",
+        "no-tumor",
+        &data_by_allele(&alleles(), &normal_only, |g| g.tumor),
+    ));
+
+    for (label, pairs) in [
+        ("even-split", vec![(10, 0.1), (10, 0.9)]),
+        ("one-dominant", vec![(1, 0.1), (99, 0.9)]),
+        ("out-of-order", vec![(5, 0.9), (5, 0.2), (5, 0.5)]),
+        ("all-equal", vec![(4, 0.5), (4, 0.5), (4, 0.5)]),
+        ("zero-depth", vec![(0, 0.3), (0, 0.7)]),
+        ("single", vec![(7, 0.42)]),
+        ("empty", Vec::new()),
+    ] {
+        rows.extend(median_rows(label, &pairs));
+    }
+
+    rows.push(ads_row("tumor-only", &full, true, false));
+    rows.push(ads_row("normal-only", &full, false, true));
+    rows.push(ads_row("both", &full, true, true));
+    rows.push(ads_row("neither", &full, false, false));
+    rows.push(ads_row(
+        "short-ad",
+        &[
+            GenotypeData {
+                tumor: true,
+                allele_depths: vec![80, 20],
+                values: vec![1, 2, 3],
+            },
+            GenotypeData {
+                tumor: false,
+                allele_depths: vec![99, 1, 0],
+                values: vec![7, 8, 9],
+            },
+        ],
+        true,
+        false,
+    ));
+
+    rows.push(format!(
+        "name\ttumor-evidence\t{TUMOR_EVIDENCE_FILTER_NAME},{},{TUMOR_EVIDENCE_ANNOTATION}",
+        TUMOR_EVIDENCE_ERROR_TYPE.name()
+    ));
+    rows.push(evidence_row("strong", Some(&log_odds(&[20.0, 6.0]))));
+    rows.push(evidence_row("weak", Some(&log_odds(&[1.0, 0.5]))));
+    rows.push(evidence_row("negative", Some(&log_odds(&[-3.0, -0.1]))));
+    rows.push(evidence_row("no-tlod", None));
+    rows.push(evidence_row("short-tlod", Some(&log_odds(&[20.0]))));
+    rows
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let text = golden();
+    let expected: Vec<&str> = text.lines().filter(|line| !line.starts_with('#')).collect();
+    assert_eq!(expected.len(), 41, "the golden's row count");
+
+    let mine = ours();
+    assert_eq!(mine.len(), expected.len(), "every row is accounted for");
+
+    for (ours, theirs) in mine.iter().zip(&expected) {
+        if ours == theirs {
+            continue;
+        }
+        let label = theirs.split('\t').nth(1).unwrap_or_default();
+        let allowed = ULPS_APART
+            .iter()
+            .find(|(name, _)| *name == label)
+            .map(|(_, ulps)| *ulps)
+            .unwrap_or_else(|| panic!("{label}: {ours} against {theirs}"));
+        // A list of probabilities: compare entry by entry.
+        let mine_values = ours.rsplit('\t').next().expect("a value");
+        let their_values = theirs.rsplit('\t').next().expect("a value");
+        let parse = |text: &str| -> Vec<f64> {
+            text.trim_matches(['[', ']'])
+                .split(", ")
+                .filter(|piece| !piece.is_empty())
+                .map(|piece| piece.parse().expect("a double"))
+                .collect()
+        };
+        let (mine_values, their_values) = (parse(mine_values), parse(their_values));
+        assert_eq!(mine_values.len(), their_values.len(), "{label}");
+        for (value, reference) in mine_values.iter().zip(&their_values) {
+            let ulps = ((value.to_bits() as i64) - (reference.to_bits() as i64)).abs();
+            assert!(
+                ulps <= allowed,
+                "{label}: {ours} against {theirs}, {ulps} ulps"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #344. First of the ten filters #340's golden still needs.

`Mutect2AlleleFilter` and `Mutect2Filter` with `TumorEvidenceFilter` on top. **All 41 rows of the
golden are reproduced**; one carries the decision 0014 allowance and needs a single ulp.

- The gather zips two iterators and stops at the shorter one, so a short list **shifts** the gather
  rather than shortening one allele's list, and `getAltDataByAllele` still starts at the caller's
  first element — full-length data gives the first alternate the *reference's* value.
- `weightedMedianPosteriorProbability` takes `&mut` because the reference sorts the caller's list,
  answers `0.0` on an empty list, and leans to the lower half on an even split.
- `sumADsOverSamples` indexes by the **record's** allele count, so a short AD array is an
  out-of-bounds carrying both numbers rather than a skip.
- `TumorEvidenceFilter` builds its `Datum` with both probabilities zero, so it reads the clustering
  model without contributing to it, and answers as many probabilities as the TLOD has entries rather
  than as many as the record has alternates.

### Two things this fixes beyond the slice

`ErrorType` had **two** variants where the reference has three. `SEQUENCING` is now there, in the
enum's own declaration order, and `combined` iterates all three rather than the two it knew about.
Neither could have surfaced before: the `mutect-error-probabilities` golden uses ARTIFACT filters
alone — its dump says so in its own header — and `TumorEvidenceFilter` is the first SEQUENCING filter
ported. `mutect_filter_list`'s duplicate copy of the enum is gone with it.

The one-ulp row is `strong`, `0.74812961299286` upstream against `0.7481296129928601` here, through
the clustering model's `exp`. Named in `ULPS_APART` with the size it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)