### PR TITLE
Port the normal-artifact filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=d0abc933b84337868ab26af8fb9e53ce48d50351#d0abc933b84337868ab26af8fb9e53ce48d50351"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=dbf735c1585e91938646de0c92a2c433f00193bc#dbf735c1585e91938646de0c92a2c433f00193bc"
 dependencies = [
  "htsjdk-bgzf",
  "md-5",
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=d0abc933b84337868ab26af8fb9e53ce48d50351#d0abc933b84337868ab26af8fb9e53ce48d50351"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=dbf735c1585e91938646de0c92a2c433f00193bc#dbf735c1585e91938646de0c92a2c433f00193bc"
 dependencies = [
  "flate2",
  "libz-sys",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=d0abc933b84337868ab26af8fb9e53ce48d50351#d0abc933b84337868ab26af8fb9e53ce48d50351"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=dbf735c1585e91938646de0c92a2c433f00193bc#dbf735c1585e91938646de0c92a2c433f00193bc"
 dependencies = [
  "flate2",
  "htsjdk-bam",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=d0abc933b84337868ab26af8fb9e53ce48d50351#d0abc933b84337868ab26af8fb9e53ce48d50351"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=dbf735c1585e91938646de0c92a2c433f00193bc#dbf735c1585e91938646de0c92a2c433f00193bc"
 dependencies = [
  "htsjdk-tribble",
  "jmath",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=d0abc933b84337868ab26af8fb9e53ce48d50351#d0abc933b84337868ab26af8fb9e53ce48d50351"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=dbf735c1585e91938646de0c92a2c433f00193bc#dbf735c1585e91938646de0c92a2c433f00193bc"
 
 [[package]]
 name = "lexical-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # ["org.broadinstitute.hellbender", "picard"], which is why `gatk MarkDuplicates` runs Picard's
 # code, and why gatk-rs depends on picard-rs here.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
 picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }

--- a/crates/gatk-engine/src/lib.rs
+++ b/crates/gatk-engine/src/lib.rs
@@ -55,6 +55,7 @@ pub mod mutect_engine;
 pub mod mutect_filter_list;
 pub mod mutect_hard_filters;
 pub mod natural_log_utils;
+pub mod normal_artifact_filter;
 pub mod overhang_fixing_manager;
 pub mod permutation;
 pub mod persistence_optimizer;

--- a/crates/gatk-engine/src/normal_artifact_filter.rs
+++ b/crates/gatk-engine/src/normal_artifact_filter.rs
@@ -1,0 +1,324 @@
+//! `NormalArtifactFilter`, ported from
+//! `org.broadinstitute.hellbender.tools.walkers.mutect.filtering.NormalArtifactFilter`
+//! (GATK 4.6.2.0).
+//!
+//! "Does the matched normal carry this allele too?" Two answers are combined: the normal-artifact
+//! log odds Mutect2 already wrote into the record, and a p-value computed here from the normal's
+//! depth against the site's median base quality.
+//!
+//! # One index, read two different ways
+//!
+//! ```java
+//! final int indexOfMaxTumorLod = MathUtils.maxElementIndex(tumorLods);
+//! final int tumorAltDepth = tumorAlleleDepths[indexOfMaxTumorLod + 1];
+//! final double[] normalArtifactNegativeLogOdds = ...;
+//! ... normalArtifactNegativeLogOdds[indexOfMaxTumorLod] ...
+//! ```
+//!
+//! `indexOfMaxTumorLod` is the **alternate** allele's index. The depth arrays are indexed by the
+//! record's alleles and so need the `+ 1`; `TLOD` and `NALOD` are per-alternate and do not. An
+//! off-by-one either way is a wrong number rather than a crash.
+//!
+//! # Only the normal side of the ratio gate is guarded
+//!
+//! ```java
+//! final double tumorAlleleFraction = (double) tumorAltDepth / tumorDepth;
+//! final double normalAlleleFraction = normalDepth == 0 ? 0 : (double) normalAltDepth / normalDepth;
+//! if (normalAlleleFraction < MIN_NORMAL_ARTIFACT_RATIO * tumorAlleleFraction) { return 0.0; }
+//! ```
+//!
+//! The tumour side is a bare division, so a record with no tumour depth makes the comparison
+//! `0 < NaN`, which is **false**: instead of returning zero, such a record falls through to the
+//! arithmetic below and can be filtered.
+//!
+//! # The imputed base quality is unreachable from a record that lacks the annotation
+//!
+//! ```java
+//! final int medianRefBaseQuality = vc.getAttributeAsIntList(MEDIAN_BASE_QUALITY_KEY, IMPUTED_NORMAL_BASE_QUALITY).get(0);
+//! ```
+//!
+//! `getAttributeAsIntList(key, default)` maps the default over the elements of a **present** list,
+//! replacing a null or `"."`. An absent key is `Collections.emptyList()`, and `.get(0)` on that is
+//! an `IndexOutOfBoundsException`. The constant named `IMPUTED_NORMAL_BASE_QUALITY` never stands in
+//! for a missing `MBQ`; it stands in for a missing element of one that is there.
+//!
+//! And the quality it reads is the **site's** `MBQ`, whatever the comment beside it says about the
+//! average base quality of reference reads in the normal.
+//!
+//! # A missing required annotation is zero here, and an empty list next door
+//!
+//! `Mutect2VariantFilter.errorProbabilities` copies one probability to every alternate allele, and
+//! when a required annotation is absent that probability is `0.0`. The per-allele base class
+//! ([`crate::allele_filter`]) answers an empty list in the same situation, and `ErrorProbabilities`
+//! drops an empty list rather than counting it. The two base classes disagree.
+
+use crate::allele_filter::{sum_ads_over_samples, AlleleDepthTooShort, GenotypeData};
+use crate::allele_likelihoods::log10_to_log;
+use crate::math_utils::{max_element_index, qual_to_error_prob};
+use crate::mutect_engine::{posterior_probability_of_error, round_finite_precision_errors};
+use crate::natural_log_utils::NonFiniteSum;
+use crate::somatic_clustering_model::SomaticClusteringModel;
+use jmath::binomial::{cumulative_probability, BinomialError};
+
+/// `NormalArtifactFilter`'s identity.
+pub const FILTER_NAME: &str = "normal_artifact";
+
+/// `MIN_NORMAL_ARTIFACT_RATIO`: "don't call normal artifact if allele fraction in normal is much
+/// smaller than allele fraction in tumor".
+pub const MIN_NORMAL_ARTIFACT_RATIO: f64 = 0.1;
+
+/// `IMPUTED_NORMAL_BASE_QUALITY`, "only used if normal base quality annotation fails somehow" --
+/// which, per the module note, is not the same thing as the annotation being absent.
+pub const IMPUTED_NORMAL_BASE_QUALITY: i32 = 30;
+
+/// `M2FiltersArgumentCollection.DEFAULT_NORMAL_P_VALUE_THRESHOLD`.
+pub const DEFAULT_NORMAL_P_VALUE_THRESHOLD: f64 = 0.001;
+
+/// What this filter refuses, each of them something the reference throws or has not been measured.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NormalArtifactError {
+    /// `.get(0)` on the empty list an absent `MBQ` answers.
+    MedianBaseQualityMissing,
+    /// A genotype's `AD` is shorter than the record's allele count.
+    AlleleDepth(AlleleDepthTooShort),
+    /// The winning alternate index is past the end of one of the per-allele arrays.
+    IndexOutOfRange { index: usize, length: usize },
+    /// `normalizeFromLogToLinearSpace` over a sum that is not finite.
+    NonFiniteSum(NonFiniteSum),
+    /// The binomial p-value, or the beta underneath it.
+    Binomial(BinomialError),
+    /// `maxElementIndex` over an empty array, which the reference refuses and nothing has measured.
+    NoTumorLogOdds,
+}
+
+impl From<AlleleDepthTooShort> for NormalArtifactError {
+    fn from(error: AlleleDepthTooShort) -> Self {
+        NormalArtifactError::AlleleDepth(error)
+    }
+}
+
+impl From<NonFiniteSum> for NormalArtifactError {
+    fn from(error: NonFiniteSum) -> Self {
+        NormalArtifactError::NonFiniteSum(error)
+    }
+}
+
+impl From<BinomialError> for NormalArtifactError {
+    fn from(error: BinomialError) -> Self {
+        NormalArtifactError::Binomial(error)
+    }
+}
+
+/// `NormalArtifactFilter.errorProbabilities(vc, engine, referenceContext)`.
+///
+/// `tumor_log_10_odds` and `normal_artifact_log_10_odds` are the record's `TLOD` and `NALOD` as
+/// written, in log10; `None` is the annotation being absent, which is what the required-annotation
+/// check looks at. `median_base_qualities` is the record's `MBQ`, empty when it is absent.
+///
+/// The answer is one probability per alternate allele, all of them the same number.
+pub fn normal_artifact_error_probabilities<T>(
+    model: &SomaticClusteringModel,
+    tumor_log_10_odds: Option<&[f64]>,
+    normal_artifact_log_10_odds: Option<&[f64]>,
+    median_base_qualities: &[i32],
+    genotypes: &[GenotypeData<T>],
+    allele_count: usize,
+    normal_pileup_p_value_threshold: f64,
+) -> Result<Vec<f64>, NormalArtifactError> {
+    let alternate_count = allele_count - 1;
+    // `requiredInfoAnnotations().stream().allMatch(vc::hasAttribute) ? calculate... : 0.0`, and the
+    // 0.0 goes through the same rounding as a computed probability before being copied.
+    let (Some(tumor_log_10_odds), Some(normal_artifact_log_10_odds)) =
+        (tumor_log_10_odds, normal_artifact_log_10_odds)
+    else {
+        return Ok(vec![round_finite_precision_errors(0.0); alternate_count]);
+    };
+
+    let probability = calculate_error_probability(
+        model,
+        tumor_log_10_odds,
+        normal_artifact_log_10_odds,
+        median_base_qualities,
+        genotypes,
+        allele_count,
+        normal_pileup_p_value_threshold,
+    )?;
+    Ok(vec![
+        round_finite_precision_errors(probability);
+        alternate_count
+    ])
+}
+
+/// `calculateErrorProbability`, without the rounding and without the copy.
+#[allow(clippy::too_many_arguments)]
+fn calculate_error_probability<T>(
+    model: &SomaticClusteringModel,
+    tumor_log_10_odds: &[f64],
+    normal_artifact_log_10_odds: &[f64],
+    median_base_qualities: &[i32],
+    genotypes: &[GenotypeData<T>],
+    allele_count: usize,
+    normal_pileup_p_value_threshold: f64,
+) -> Result<f64, NormalArtifactError> {
+    if tumor_log_10_odds.is_empty() {
+        return Err(NormalArtifactError::NoTumorLogOdds);
+    }
+    // `getTumorLogOdds` converts to natural log first. The conversion is monotone, so the index it
+    // is taken over is the same one the log10 values would give; it is written the reference's way
+    // rather than shortened, because the values are read again below.
+    let tumor_lods: Vec<f64> = tumor_log_10_odds.iter().map(|x| log10_to_log(*x)).collect();
+    let index_of_max_tumor_lod = max_element_index(&tumor_lods, 0, tumor_lods.len());
+
+    let tumor_allele_depths = sum_ads_over_samples(allele_count, genotypes, true, false)?;
+    // `(int) MathUtils.sum(int[])`, which sums into a `long` and is then truncated to an `int`.
+    let tumor_depth = (tumor_allele_depths
+        .iter()
+        .map(|d| i64::from(*d))
+        .sum::<i64>()) as i32;
+    let tumor_alt_depth = at(&tumor_allele_depths, index_of_max_tumor_lod + 1)?;
+
+    let normal_allele_depths = sum_ads_over_samples(allele_count, genotypes, false, true)?;
+    let normal_depth = (normal_allele_depths
+        .iter()
+        .map(|d| i64::from(*d))
+        .sum::<i64>()) as i32;
+    let normal_alt_depth = at(&normal_allele_depths, index_of_max_tumor_lod + 1)?;
+
+    // The tumour side is unguarded: an empty tumour is `0 / 0`, which is NaN.
+    let tumor_allele_fraction = f64::from(tumor_alt_depth) / f64::from(tumor_depth);
+    let normal_allele_fraction = if normal_depth == 0 {
+        0.0
+    } else {
+        f64::from(normal_alt_depth) / f64::from(normal_depth)
+    };
+
+    // `x < NaN` is false, so a record with no tumour depth does NOT return here.
+    if normal_allele_fraction < MIN_NORMAL_ARTIFACT_RATIO * tumor_allele_fraction {
+        return Ok(0.0);
+    }
+
+    // `applyToArrayInPlace(getAttributeAsDoubleArray(vc, NALOD), x -> -log10ToLog(x))`, which
+    // negates in the natural-log space rather than negating the log10 value first.
+    let negative_log_odds =
+        -log10_to_log(at_f64(normal_artifact_log_10_odds, index_of_max_tumor_lod)?);
+    let normal_artifact_probability = posterior_probability_of_error(
+        negative_log_odds,
+        model.log_prior_of_variant_versus_artifact(),
+    )?;
+
+    // The empty list an absent `MBQ` answers, not the imputed quality.
+    let median_ref_base_quality = *median_base_qualities
+        .first()
+        .ok_or(NormalArtifactError::MedianBaseQualityMissing)?;
+    let normal_p_value = 1.0
+        - cumulative_probability(
+            normal_depth,
+            qual_to_error_prob(f64::from(median_ref_base_quality)),
+            normal_alt_depth - 1,
+        )?;
+
+    Ok(if normal_p_value < normal_pileup_p_value_threshold {
+        1.0
+    } else {
+        normal_artifact_probability
+    })
+}
+
+/// One element of a depth array, refusing where the reference throws `ArrayIndexOutOfBounds`.
+fn at(values: &[i32], index: usize) -> Result<i32, NormalArtifactError> {
+    values
+        .get(index)
+        .copied()
+        .ok_or(NormalArtifactError::IndexOutOfRange {
+            index,
+            length: values.len(),
+        })
+}
+
+/// The same, for the log-odds arrays.
+fn at_f64(values: &[f64], index: usize) -> Result<f64, NormalArtifactError> {
+    values
+        .get(index)
+        .copied()
+        .ok_or(NormalArtifactError::IndexOutOfRange {
+            index,
+            length: values.len(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::somatic_clustering_model::PriorArguments;
+
+    fn genotypes(tumor: &[i32], normal: &[i32]) -> Vec<GenotypeData<i32>> {
+        vec![
+            GenotypeData {
+                tumor: true,
+                allele_depths: tumor.to_vec(),
+                values: Vec::new(),
+            },
+            GenotypeData {
+                tumor: false,
+                allele_depths: normal.to_vec(),
+                values: Vec::new(),
+            },
+        ]
+    }
+
+    fn probabilities(
+        tumor: &[i32],
+        normal: &[i32],
+        median_base_qualities: &[i32],
+    ) -> Result<Vec<f64>, NormalArtifactError> {
+        let model = SomaticClusteringModel::new(PriorArguments::new(), None);
+        normal_artifact_error_probabilities(
+            &model,
+            Some(&[20.0, 6.0]),
+            Some(&[2.0, 0.5]),
+            median_base_qualities,
+            &genotypes(tumor, normal),
+            3,
+            DEFAULT_NORMAL_P_VALUE_THRESHOLD,
+        )
+    }
+
+    /// A tumour with no depth makes the gate `0 < NaN`, which is false: the record is filtered
+    /// rather than passed. A gate written the obvious way would return zero here.
+    #[test]
+    fn a_tumour_with_no_depth_falls_through_the_ratio_gate() {
+        let clean_normal =
+            probabilities(&[80, 20, 5], &[90, 0, 0], &[30, 30, 30]).expect("answered");
+        assert_eq!(clean_normal, vec![0.0, 0.0], "the gate returns zero");
+        let no_tumour = probabilities(&[0, 0, 0], &[90, 0, 0], &[30, 30, 30]).expect("answered");
+        assert!(no_tumour[0] > 0.0, "and NaN does not");
+    }
+
+    /// The imputed quality never stands in for an absent annotation.
+    #[test]
+    fn a_missing_median_base_quality_is_a_refusal_and_not_the_imputed_thirty() {
+        assert_eq!(
+            probabilities(&[80, 20, 5], &[90, 10, 2], &[]),
+            Err(NormalArtifactError::MedianBaseQualityMissing)
+        );
+        // And the constant that would have been used is still what the reference declares.
+        assert_eq!(IMPUTED_NORMAL_BASE_QUALITY, 30);
+    }
+
+    /// A missing required annotation is a zero per alternate allele, not an empty list.
+    #[test]
+    fn a_missing_annotation_answers_one_zero_per_alternate_allele() {
+        let model = SomaticClusteringModel::new(PriorArguments::new(), None);
+        let answer = normal_artifact_error_probabilities(
+            &model,
+            None,
+            Some(&[2.0, 0.5]),
+            &[30, 30, 30],
+            &genotypes(&[80, 20, 5], &[90, 10, 2]),
+            3,
+            DEFAULT_NORMAL_P_VALUE_THRESHOLD,
+        )
+        .expect("answered");
+        assert_eq!(answer, vec![0.0, 0.0]);
+    }
+}

--- a/crates/gatk-engine/tests/normal_artifact_filter.rs
+++ b/crates/gatk-engine/tests/normal_artifact_filter.rs
@@ -1,0 +1,286 @@
+//! Conformance for `NormalArtifactFilter` and the commons-math under it, against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/NormalArtifactFilterDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **`Beta.regularizedBeta` is two arrangements of the same fraction**, and which one a call
+//!    takes decides its last digits: one ulp either side of the branch boundary answers the same
+//!    double by two different routes, and the boundary itself answers another;
+//!  * **the binomial CDF's guards are answers**, not refusals: the filter asks about `-1` whenever
+//!    the normal is clean, and about `x >= trials` whenever every read supports the allele;
+//!  * **a missing `MBQ` is an out-of-bounds, not the imputed 30**;
+//!  * **only the normal side of the ratio gate is guarded**, so a record with no tumour depth
+//!    compares against NaN and falls through instead of returning zero;
+//!  * **and a missing required annotation is `0.0` per allele here**, where the per-allele base
+//!    class answers an empty list.
+//!
+//! Every row is compared. The `posterior` and `prob` rows reach the clustering model's `exp`, whose
+//! bit-exact transcription is withdrawn under htsjdk-rs decision 0014, so they carry an allowance
+//! named row by row in [`ULPS_APART`]; everything else, the twenty-two regularized betas included,
+//! is bit-identical.
+
+use gatk_corpus as corpus;
+use gatk_engine::allele_filter::GenotypeData;
+use gatk_engine::math_utils::qual_to_error_prob;
+use gatk_engine::mutect_engine::posterior_probability_of_error;
+use gatk_engine::normal_artifact_filter::{
+    normal_artifact_error_probabilities, NormalArtifactError, DEFAULT_NORMAL_P_VALUE_THRESHOLD,
+    FILTER_NAME,
+};
+use gatk_engine::somatic_clustering_model::{PriorArguments, SomaticClusteringModel};
+use gatk_engine::tsv_table::java_double_to_string;
+use jmath::beta::regularized_beta;
+use jmath::binomial::cumulative_probability;
+
+/// The rows that need the decision 0014 allowance, and how many ulps each needs.
+///
+/// One row, and it needs **three**. `posterior nalod-2.0` asks `logSumExp` for
+/// `exp(-2.4079456086518722)`, where `StrictMath.exp` answers `0x3fb70a3d70a3d708` and `Math.exp`
+/// answers `0x3fb70a3d70a3d709`: one ulp, the bound htsjdk-rs decision 0025 measured. That single
+/// ulp moves the accumulator from `1.09` to `1.0899999999999999`, which moves the log-sum by an
+/// ulp, and the final `exp` of a value shifted by that lands three ulps from the reference's
+/// `0.0825688073394495`. The other six posteriors and every one of the sixteen `prob` rows are
+/// bit-identical, so this is one input finding the seam rather than the seam being everywhere.
+const ULPS_APART: [(&str, i64); 1] = [("nalod-2.0", 3)];
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/normal_artifact_filter.txt.gz"),
+    )
+}
+
+/// The golden's rows as `(kind, label, payload)`.
+fn rows() -> Vec<(String, String, String)> {
+    golden()
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            (
+                fields.next().expect("a kind").to_string(),
+                fields.next().expect("a label").to_string(),
+                fields.next().expect("a payload").to_string(),
+            )
+        })
+        .collect()
+}
+
+/// `<inputs>=<answer>`, which is how every arithmetic row is written.
+fn split(payload: &str) -> (Vec<f64>, &str) {
+    let (inputs, answer) = payload.rsplit_once('=').expect("an answer");
+    (
+        inputs
+            .split(',')
+            .map(|value| value.parse::<f64>().expect("a double"))
+            .collect(),
+        answer,
+    )
+}
+
+/// Compare as text, so a negative zero and a NaN are compared as the reference wrote them.
+///
+/// A row that diverges is reported rather than panicked on, so one run names every divergence.
+fn same(ours: f64, expected: &str, what: &str, complaints: &mut Vec<String>) {
+    let printed = java_double_to_string(ours);
+    if printed == expected {
+        return;
+    }
+    let theirs: f64 = expected.parse().expect("a double");
+    let apart = (ours.to_bits() as i64 - theirs.to_bits() as i64).abs();
+    match ULPS_APART
+        .iter()
+        .find(|(label, _)| *label == what)
+        .map(|(_, ulps)| *ulps)
+    {
+        Some(ulps) if apart <= ulps => {}
+        Some(ulps) => complaints.push(format!(
+            "{what}: {apart} ulps apart, allowed {ulps} (ours {printed}, reference {expected})"
+        )),
+        None => complaints.push(format!(
+            "{what}: ours {printed}, reference {expected} ({apart} ulps)"
+        )),
+    }
+}
+
+/// One tumour sample and, usually, one normal.
+fn genotypes(tumor: &[i32], normal: Option<&[i32]>) -> Vec<GenotypeData<i32>> {
+    let mut samples = vec![GenotypeData {
+        tumor: true,
+        allele_depths: tumor.to_vec(),
+        values: Vec::new(),
+    }];
+    if let Some(normal) = normal {
+        samples.push(GenotypeData {
+            tumor: false,
+            allele_depths: normal.to_vec(),
+            values: Vec::new(),
+        });
+    }
+    samples
+}
+
+/// The dump's record for one `prob` label: the arguments the filter is handed.
+struct Case {
+    tumor_log_10_odds: Option<Vec<f64>>,
+    normal_artifact_log_10_odds: Option<Vec<f64>>,
+    median_base_qualities: Vec<i32>,
+    tumor: Vec<i32>,
+    normal: Option<Vec<i32>>,
+    allele_count: usize,
+}
+
+fn case(label: &str) -> Case {
+    // The base record: a triallelic site whose normal carries the allele.
+    let mut case = Case {
+        tumor_log_10_odds: Some(vec![20.0, 6.0]),
+        normal_artifact_log_10_odds: Some(vec![2.0, 0.5]),
+        median_base_qualities: vec![30, 30, 30],
+        tumor: vec![80, 20, 5],
+        normal: Some(vec![90, 10, 2]),
+        allele_count: 3,
+    };
+    match label {
+        "normal-carries-the-allele" => {}
+        "second-allele" => case.tumor_log_10_odds = Some(vec![6.0, 20.0]),
+        "normal-is-clean" => case.normal = Some(vec![90, 0, 0]),
+        "normal-at-the-ratio" => case.normal = Some(vec![80, 2, 0]),
+        "no-normal-sample" => case.normal = None,
+        "no-tumor-depth" => case.tumor = vec![0, 0, 0],
+        "no-tumor-depth-clean-normal" => {
+            case.tumor = vec![0, 0, 0];
+            case.normal = Some(vec![90, 0, 0]);
+        }
+        "normal-is-all-alt" => case.normal = Some(vec![0, 20, 0]),
+        "low-median-base-quality" => case.median_base_qualities = vec![2, 2, 2],
+        "high-median-base-quality" => case.median_base_qualities = vec![60, 60, 60],
+        "no-mbq" => case.median_base_qualities = Vec::new(),
+        "negative-nalod" => {
+            case.median_base_qualities = vec![2, 2, 2];
+            case.normal_artifact_log_10_odds = Some(vec![-5.0, -1.0]);
+        }
+        "large-nalod" => {
+            case.median_base_qualities = vec![2, 2, 2];
+            case.normal_artifact_log_10_odds = Some(vec![20.0, 20.0]);
+        }
+        "no-nalod" => case.normal_artifact_log_10_odds = None,
+        "no-tlod" => case.tumor_log_10_odds = None,
+        "biallelic" => {
+            case.tumor_log_10_odds = Some(vec![20.0]);
+            case.normal_artifact_log_10_odds = Some(vec![2.0]);
+            case.median_base_qualities = vec![30, 30];
+            case.tumor = vec![80, 20];
+            case.normal = Some(vec![90, 10]);
+            case.allele_count = 2;
+        }
+        other => panic!("no case named {other}"),
+    }
+    case
+}
+
+fn answer(label: &str) -> Result<Vec<f64>, NormalArtifactError> {
+    let case = case(label);
+    let model = SomaticClusteringModel::new(PriorArguments::new(), None);
+    normal_artifact_error_probabilities(
+        &model,
+        case.tumor_log_10_odds.as_deref(),
+        case.normal_artifact_log_10_odds.as_deref(),
+        &case.median_base_qualities,
+        &genotypes(&case.tumor, case.normal.as_deref()),
+        case.allele_count,
+        DEFAULT_NORMAL_P_VALUE_THRESHOLD,
+    )
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let rows = rows();
+    assert_eq!(rows.len(), 65, "the golden's row count");
+    let mut complaints: Vec<String> = Vec::new();
+    let mut seen = 0;
+    for (kind, label, payload) in &rows {
+        match kind.as_str() {
+            "regbeta" => {
+                let (inputs, expected) = split(payload);
+                let ours = regularized_beta(inputs[0], inputs[1], inputs[2]).expect("answered");
+                same(ours, expected, label, &mut complaints);
+            }
+            "cdf" => {
+                let (inputs, expected) = split(payload);
+                let ours = cumulative_probability(inputs[0] as i32, inputs[1], inputs[2] as i32)
+                    .expect("answered");
+                same(ours, expected, label, &mut complaints);
+            }
+            "qualerr" => {
+                let (inputs, expected) = split(payload);
+                same(
+                    qual_to_error_prob(inputs[0]),
+                    expected,
+                    label,
+                    &mut complaints,
+                );
+            }
+            "prior" => {
+                let model = SomaticClusteringModel::new(PriorArguments::new(), None);
+                same(
+                    model.log_prior_of_variant_versus_artifact(),
+                    payload,
+                    label,
+                    &mut complaints,
+                );
+            }
+            "posterior" => {
+                let (inputs, expected) = split(payload);
+                let model = SomaticClusteringModel::new(PriorArguments::new(), None);
+                let ours = posterior_probability_of_error(
+                    inputs[0],
+                    model.log_prior_of_variant_versus_artifact(),
+                )
+                .expect("finite");
+                same(ours, expected, label, &mut complaints);
+            }
+            "name" => {
+                // `<filterName>,<errorType>,<annotation>,<required annotations>`.
+                assert_eq!(*payload, format!("{FILTER_NAME},ARTIFACT,none,NALOD,TLOD"));
+            }
+            "prob" => {
+                let probabilities = answer(label).expect("answered");
+                let printed: Vec<String> = probabilities
+                    .iter()
+                    .map(|value| java_double_to_string(*value))
+                    .collect();
+                let ours = format!("[{}]", printed.join(", "));
+                if ours != *payload {
+                    // Fall back to the per-value comparison, which is where an allowance applies.
+                    let expected: Vec<&str> = payload
+                        .trim_start_matches('[')
+                        .trim_end_matches(']')
+                        .split(", ")
+                        .collect();
+                    assert_eq!(probabilities.len(), expected.len(), "{label}: allele count");
+                    for (ours, expected) in probabilities.iter().zip(expected) {
+                        same(*ours, expected, label, &mut complaints);
+                    }
+                }
+            }
+            "error" => {
+                // `IndexOutOfBoundsException: Index 0 out of bounds for length 0`, which is
+                // `.get(0)` on the empty list an absent `MBQ` answers.
+                assert_eq!(label, "prob-no-mbq");
+                assert_eq!(
+                    payload,
+                    "java.lang.IndexOutOfBoundsException:Index 0 out of bounds for length 0"
+                );
+                assert_eq!(
+                    answer("no-mbq"),
+                    Err(NormalArtifactError::MedianBaseQualityMissing)
+                );
+            }
+            other => panic!("no row kind {other}"),
+        }
+        seen += 1;
+    }
+    assert_eq!(seen, rows.len(), "every row compared");
+    assert!(complaints.is_empty(), "{}", complaints.join("\n"));
+}


### PR DESCRIPTION
Closes #348. Third of three: the measurement (#349), the golden (#350), and now the port.

Sixty-four of the golden's 65 rows are bit-identical, including all twenty-two `Beta.regularizedBeta`
values, all twelve binomial CDFs and all sixteen filter probabilities.

**The one allowance is three ulps, and it is attributable rather than tolerated.**
`posterior nalod-2.0` asks `logSumExp` for `exp(-2.4079456086518722)`:

| | bits |
|---|---|
| `StrictMath.exp` (what this port calls) | `0x3fb70a3d70a3d708` |
| `Math.exp` (what the reference calls) | `0x3fb70a3d70a3d709` |

That is exactly the 1-ulp bound htsjdk-rs decision 0025 measured. It moves the accumulator from
`1.09` to `1.0899999999999999`, moves the log-sum by an ulp, and the final exponential lands three
ulps from `0.0825688073394495`. The other six posteriors and every filter probability are exact, so
this is one input finding the seam rather than the seam being everywhere.

Behaviours the port kept rather than tidied, each pinned by a golden row:

- **Only the normal side of the ratio gate is guarded.** A record with no tumour depth compares
  against NaN, which is false, so it is filtered where a gate written the obvious way would pass it.
- **A missing `MBQ` is an `IndexOutOfBoundsException`, not the imputed 30.** The constant stands in
  for a missing *element* of a present list, never for a missing annotation.
- **One index read two ways**: `+ 1` into the depth arrays, bare into `TLOD`/`NALOD`.
- **`Mutect2VariantFilter` answers `0.0` per allele for a missing required annotation**, where the
  per-allele base class answers an empty list that `ErrorProbabilities` drops.

The htsjdk-rs pin moves to `dbf735c` for `jmath::binomial` and `jmath::beta::regularized_beta`
(IPNP-BIPN/htsjdk-rs#167). `tools/preflight.py` is green, release profile included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)