### PR TITLE
Measure the four remaining hard filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,10 @@ jobs:
             index: "30/30"
             slug: "normal-artifact-filter"
             suites: "normal-artifact-filter"
+          - group: golden-pending
+            index: "1/1"
+            slug: "remaining-hard-filters"
+            suites: "remaining-hard-filters"
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -3554,6 +3554,40 @@
           "why": "65 rows, no files: twenty-two regularizedBeta values over both arrangements of the symmetry branch, its three guards and the boundary walked with nextUp and nextDown; twelve binomial CDFs over the three arms, including the -1 and the x >= trials the filter reaches; six qualToErrorProb values; the clustering model's log prior of variant versus artifact and seven posteriors against it; the filter's identity; and sixteen error probabilities over a triallelic record whose tumour, normal, median base quality and log odds are each moved in turn. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32127388942, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "remaining-hard-filters",
+      "status": "golden-pending",
+      "title": "The four hard filters that cannot fire with the default arguments",
+      "harness": "tools/readfilter-conformance",
+      "tools": [],
+      "why": "DuplicatedAltReadFilter, NRatioFilter, MinAlleleFractionFilter and PanelOfNormalsFilter, the rest of the HardFilter/HardAlleleFilter family the filter-mutect-calls golden needs. None of them does arithmetic; all four answer 1.0 or 0.0 from one annotation and a threshold. ALL FOUR ARE BUILT UNCONDITIONALLY AND NONE OF THEM CAN FIRE WITH THE DEFAULT ARGUMENTS: DEFAULT_MIN_UNIQUE_ALT_READS = 0 against count <= uniqueAltReadCount, DEFAULT_MAX_N_RATIO = Double.POSITIVE_INFINITY against ratio >= maxNRatio, DEFAULT_MIN_AF = 0 against max < minAf, and PanelOfNormalsFilter needs an annotation that only exists when Mutect2 was given a panel. A default run therefore builds four filters that are structurally incapable of filtering anything, which is not the same thing as four filters that found nothing. NRatioFilter'S COMMENT CLAIMS A GUARD THE CODE DOES NOT HAVE: \"if there is no NCount annotation or the altCount is 0, don't apply the filter\", but only the altCount == 0 arm is written, a missing NCount being getAttributeAsInt(key, 0), a zero rather than a skip. MinAlleleFractionFilter REQUIRES NO ANNOTATION AT ALL, so it is evaluated on every record, and an allele with no data is orElse(1.0): it answers \"not an artifact\" from an absence. Its .filter(entry -> !vc.getReference().equals(entry.getKey())) is dead code, because getAltDataByAllele keys its map on the alternate alleles alone. PanelOfNormalsFilter READS PRESENCE, NOT VALUE: hasAttribute is true for PON=false. AND DuplicatedAltReadFilter'S LIST LENGTH COMES FROM THE ANNOTATION, NOT THE RECORD. WHAT THE RUN ADDED: a four-element AS_UNIQ_ALT_READ_COUNT on a two-alternate record answers FOUR probabilities, [1.0, 1.0, 1.0, 1.0], and a one-element list answers one; nothing checks the length against the record. The same dump shows the two base classes disagreeing side by side on a missing required annotation: duplicate-no-annotation is the empty list, which ErrorProbabilities drops, and nratio-no-annotation is [0.0, 0.0], which it counts.",
+      "compare": {
+        "mode": "lines"
+      },
+      "expect_rows": 27,
+      "expect_contains": [
+        "default\tuniqueAltReadCount\t0",
+        "default\tnRatio\tInfinity",
+        "default\tminAf\t0.0",
+        "name\tPanelOfNormalsFilter\tpanel_of_normals,ARTIFACT,none",
+        "filter\tduplicate-default\t[0.0, 0.0]",
+        "filter\tduplicate-long-list\t[1.0, 1.0, 1.0, 1.0]",
+        "filter\tduplicate-short-list\t[1.0]",
+        "filter\tduplicate-no-annotation\t[]",
+        "filter\tnratio-no-annotation\t[0.0, 0.0]",
+        "filter\tnratio-at-the-threshold\t[1.0, 1.0]",
+        "filter\tminaf-no-allele-fraction\t[0.0, 0.0]",
+        "filter\tminaf-full-length-list\t[0.0, 1.0]",
+        "filter\tpon-false\t[1.0, 1.0]"
+      ],
+      "cases": [
+        {
+          "dump": "RemainingHardFiltersDump",
+          "golden": null,
+          "why": "27 rows, no files: the three argument defaults, the four filters' identities, and twenty probabilities over a triallelic record whose unique-alt-read counts, N count, allele fractions and panel-of-normals annotation are each moved in turn, at the default threshold and at one that can actually fire. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run PENDING."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/RemainingHardFiltersDump.java
+++ b/tools/readfilter-conformance/RemainingHardFiltersDump.java
@@ -1,0 +1,165 @@
+/*
+ * The four remaining hard filters, taken from the reference.
+ *
+ * `DuplicatedAltReadFilter`, `NRatioFilter`, `MinAlleleFractionFilter` and `PanelOfNormalsFilter`:
+ * the rest of the `HardFilter`/`HardAlleleFilter` family, none of which does any arithmetic. Six
+ * behaviours this is built to catch.
+ *
+ *   - ALL FOUR ARE BUILT UNCONDITIONALLY AND NONE OF THEM CAN FIRE WITH THE DEFAULT ARGUMENTS.
+ *     `DEFAULT_MIN_UNIQUE_ALT_READS = 0` against `count <= uniqueAltReadCount`,
+ *     `DEFAULT_MAX_N_RATIO = Double.POSITIVE_INFINITY` against `ratio >= maxNRatio`, and
+ *     `DEFAULT_MIN_AF = 0` against `max < minAf`. `PanelOfNormalsFilter` needs an annotation that
+ *     only exists when Mutect2 was given a panel;
+ *   - `NRatioFilter`'S COMMENT CLAIMS A GUARD THE CODE DOES NOT HAVE. "if there is no NCount
+ *     annotation or the altCount is 0, don't apply the filter", but only the `altCount == 0` arm is
+ *     written: a missing `NCount` is `getAttributeAsInt(key, 0)`, a zero rather than a skip;
+ *   - `MinAlleleFractionFilter` REQUIRES NO ANNOTATION AT ALL, so it is evaluated on every record,
+ *     and an allele with no data is `orElse(1.0)`: it answers "not an artifact" from an absence;
+ *   - AND ITS `.filter(entry -> !vc.getReference().equals(entry.getKey()))` IS DEAD CODE, because
+ *     `getAltDataByAllele` keys its map on the alternate alleles alone;
+ *   - `PanelOfNormalsFilter` READS PRESENCE, NOT VALUE: `hasAttribute` is true for `PON=false`;
+ *   - AND `DuplicatedAltReadFilter`'S LIST LENGTH COMES FROM THE ANNOTATION, NOT THE RECORD, so a
+ *     short list answers for fewer alleles than the record has and an absent one is the empty list.
+ *
+ * Output:
+ *
+ *     name\t<filter>\t<filterName>,<errorType>,<annotation>,<required annotations>
+ *     default\t<argument>\t<value>
+ *     filter\t<label>\t<one probability per alternate allele>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: RemainingHardFiltersDump
+ */
+
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.GenotypeBuilder;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.DuplicatedAltReadFilter;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.M2FiltersArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.MinAlleleFractionFilter;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.Mutect2Filter;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.Mutect2FilteringEngine;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.NRatioFilter;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.PanelOfNormalsFilter;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class RemainingHardFiltersDump {
+
+    public static void main(final String[] args) throws Exception {
+        System.out.println("# RemainingHardFiltersDump: the rest of the hard filter family");
+
+        final M2FiltersArgumentCollection arguments = new M2FiltersArgumentCollection();
+        System.out.printf("default\tuniqueAltReadCount\t%d%n", arguments.uniqueAltReadCount);
+        System.out.printf("default\tnRatio\t%s%n", Double.toString(arguments.nRatio));
+        System.out.printf("default\tminAf\t%s%n", Double.toString(arguments.minAf));
+
+        final Set<VCFHeaderLine> lines = new LinkedHashSet<>();
+        lines.add(new VCFHeaderLine("normal_sample", "N1"));
+        final VCFHeader header = new VCFHeader(lines, List.of("T1", "N1"));
+        final Mutect2FilteringEngine engine = new Mutect2FilteringEngine(arguments, header,
+                new File("no-such-stats-file.tsv"));
+
+        final Mutect2Filter duplicated = new DuplicatedAltReadFilter(arguments.uniqueAltReadCount);
+        final Mutect2Filter duplicatedTuned = new DuplicatedAltReadFilter(2);
+        final Mutect2Filter nRatio = new NRatioFilter(arguments.nRatio);
+        final Mutect2Filter nRatioTuned = new NRatioFilter(0.5);
+        final Mutect2Filter minAf = new MinAlleleFractionFilter(arguments.minAf);
+        final Mutect2Filter minAfTuned = new MinAlleleFractionFilter(0.1);
+        final Mutect2Filter pon = new PanelOfNormalsFilter();
+        for (final Mutect2Filter filter : List.of(duplicated, nRatio, minAf, pon)) {
+            System.out.printf("name\t%s\t%s,%s,%s%n", filter.getClass().getSimpleName(),
+                    filter.filterName(), filter.errorType(),
+                    filter.phredScaledPosteriorAnnotationName().orElse("none"));
+        }
+
+        // A triallelic record carrying every annotation the four read, with a tumour and a normal.
+        final VariantContext base = new VariantContextBuilder("dump", "chr1", 100, 100,
+                List.of(Allele.REF_A, Allele.ALT_C, Allele.ALT_G))
+                .attribute("AS_UNIQ_ALT_READ_COUNT", List.of(3, 1))
+                .attribute("NCount", 4)
+                .genotypes(List.of(
+                        genotype("T1", new int[] {80, 20, 5}, List.of(0.2, 0.05)),
+                        genotype("N1", new int[] {90, 1, 0}, List.of(0.01, 0.0))))
+                .make();
+
+        // DuplicatedAltReadFilter: the default threshold of 0 against counts of 3 and 1.
+        filter("duplicate-default", duplicated, engine, base);
+        filter("duplicate-threshold-two", duplicatedTuned, engine, base);
+        // A list shorter than the alternate alleles, and one longer.
+        filter("duplicate-short-list", duplicatedTuned, engine,
+                new VariantContextBuilder(base).attribute("AS_UNIQ_ALT_READ_COUNT", List.of(1)).make());
+        filter("duplicate-long-list", duplicatedTuned, engine,
+                new VariantContextBuilder(base)
+                        .attribute("AS_UNIQ_ALT_READ_COUNT", List.of(1, 1, 1, 1)).make());
+        // No annotation: the required-annotation check answers an empty list.
+        filter("duplicate-no-annotation", duplicatedTuned, engine,
+                new VariantContextBuilder(base).rmAttribute("AS_UNIQ_ALT_READ_COUNT").make());
+
+        // NRatioFilter: 4 Ns against 26 alternate reads over both samples.
+        filter("nratio-default", nRatio, engine, base);
+        filter("nratio-threshold-half", nRatioTuned, engine, base);
+        // The alternate count is zero, which is the one guard the filter has.
+        filter("nratio-no-alt-reads", nRatioTuned, engine, new VariantContextBuilder(base)
+                .genotypes(List.of(genotype("T1", new int[] {80, 0, 0}, List.of(0.0, 0.0)),
+                        genotype("N1", new int[] {90, 0, 0}, List.of(0.0, 0.0)))).make());
+        // No NCount: the required-annotation check answers 0.0 before the default can be used.
+        filter("nratio-no-annotation", nRatioTuned, engine,
+                new VariantContextBuilder(base).rmAttribute("NCount").make());
+        // A ratio exactly at the threshold, which `>=` calls an artifact.
+        filter("nratio-at-the-threshold", nRatioTuned, engine,
+                new VariantContextBuilder(base).attribute("NCount", 13).make());
+
+        // MinAlleleFractionFilter: it requires no annotation, so every record reaches it.
+        filter("minaf-default", minAf, engine, base);
+        filter("minaf-threshold-tenth", minAfTuned, engine, base);
+        // No AF on any genotype at all: every allele is `orElse(1.0)`.
+        filter("minaf-no-allele-fraction", minAfTuned, engine, new VariantContextBuilder(base)
+                .genotypes(List.of(
+                        new GenotypeBuilder("T1", List.of(Allele.REF_A, Allele.ALT_C))
+                                .AD(new int[] {80, 20, 5}).make())).make());
+        // The normal carries a low fraction and the tumour a high one: only the tumour is read.
+        filter("minaf-normal-is-low", minAfTuned, engine, new VariantContextBuilder(base)
+                .genotypes(List.of(genotype("T1", new int[] {80, 20, 5}, List.of(0.5, 0.5)),
+                        genotype("N1", new int[] {90, 1, 0}, List.of(0.001, 0.001)))).make());
+        // An AF list as long as the RECORD rather than as long as the alternates: the zip stops at
+        // the map's two entries and the last value is dropped.
+        filter("minaf-full-length-list", minAfTuned, engine, new VariantContextBuilder(base)
+                .genotypes(List.of(genotype("T1", new int[] {80, 20, 5}, List.of(0.9, 0.05, 0.9))))
+                .make());
+        // A fraction exactly at the threshold, which the strict `<` keeps.
+        filter("minaf-at-the-threshold", minAfTuned, engine, new VariantContextBuilder(base)
+                .genotypes(List.of(genotype("T1", new int[] {80, 20, 5}, List.of(0.1, 0.1)))).make());
+
+        // PanelOfNormalsFilter: presence, not value.
+        filter("pon-absent", pon, engine, base);
+        filter("pon-present", pon, engine,
+                new VariantContextBuilder(base).attribute("PON", true).make());
+        filter("pon-false", pon, engine,
+                new VariantContextBuilder(base).attribute("PON", false).make());
+        filter("pon-empty-string", pon, engine,
+                new VariantContextBuilder(base).attribute("PON", "").make());
+    }
+
+    static Genotype genotype(final String sample, final int[] ad, final List<Double> alleleFractions) {
+        return new GenotypeBuilder(sample, List.of(Allele.REF_A, Allele.ALT_C))
+                .AD(ad).attribute("AF", alleleFractions).make();
+    }
+
+    static void filter(final String label, final Mutect2Filter filter,
+                       final Mutect2FilteringEngine engine, final VariantContext vc) {
+        try {
+            System.out.printf("filter\t%s\t%s%n", label, filter.errorProbabilities(vc, engine, null));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+}


### PR DESCRIPTION
For #353, third and fourth of #340's ten in one slice, plus two more: the four filters left in the
`HardFilter`/`HardAlleleFilter` family. 27 rows, no files.

What the run showed that reading the source did not settle:

- **A four-element `AS_UNIQ_ALT_READ_COUNT` on a two-alternate record answers four probabilities.**
  `[1.0, 1.0, 1.0, 1.0]`. A one-element list answers one. `DuplicatedAltReadFilter` maps over the
  annotation and nothing compares its length to the record's.
- **The two base classes disagree on a missing required annotation, in the same dump.**
  `duplicate-no-annotation` is `[]`, which `ErrorProbabilities` drops entirely;
  `nratio-no-annotation` is `[0.0, 0.0]`, which it counts. Same absence, two different meanings.
- **`PON=false` is filtered**, along with `PON=""`. The filter reads `hasAttribute`.
- **A record with no `AF` at all passes**, because `orElse(1.0)` is not below any threshold.

And the argument defaults, which are the point of the slice: `uniqueAltReadCount = 0`,
`nRatio = Infinity`, `minAf = 0.0`. Against `count <= 0`, `ratio >= Infinity` and `max < 0`, none of
the three can be satisfied.

Golden-pending, so nothing is compared: the row count and thirteen named behaviours are asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #10.
