### PR TITLE
Port the four remaining hard filters

### DIFF
--- a/crates/gatk-engine/src/mutect_hard_filters.rs
+++ b/crates/gatk-engine/src/mutect_hard_filters.rs
@@ -203,6 +203,90 @@ pub fn multiallelic_is_artifact(
     Ok(passing > number_of_alt_alleles_threshold)
 }
 
+/// `M2FiltersArgumentCollection.DEFAULT_MIN_UNIQUE_ALT_READS`, against `count <= threshold`.
+///
+/// Zero, and a unique-alt-read count is at least one, so the filter cannot fire as configured.
+pub const DEFAULT_MIN_UNIQUE_ALT_READS: i32 = 0;
+
+/// `M2FiltersArgumentCollection.DEFAULT_MAX_N_RATIO`, against `ratio >= maximum`.
+///
+/// Positive infinity, and no finite ratio reaches it.
+pub const DEFAULT_MAX_N_RATIO: f64 = f64::INFINITY;
+
+/// `M2FiltersArgumentCollection.DEFAULT_MIN_AF`, against `max < minimum`.
+///
+/// Zero, and no allele fraction is below it.
+pub const DEFAULT_MIN_AF: f64 = 0.0;
+
+/// `DuplicatedAltReadFilter`: PCR duplicates with unique UMIs amplifying one allele.
+///
+/// The list is as long as `AS_UNIQ_ALT_READ_COUNT`, **not** as long as the record's alternate
+/// alleles: the filter maps over the annotation and nothing compares the two. A four-element
+/// annotation on a two-alternate record answers four probabilities, and a one-element one answers
+/// one.
+pub fn duplicated_alt_read_artifacts(unique_alt_read_counts: &[i32], threshold: i32) -> Vec<bool> {
+    unique_alt_read_counts
+        .iter()
+        .map(|count| *count <= threshold)
+        .collect()
+}
+
+/// `NRatioFilter`: too many Ns beside the alternate reads.
+///
+/// `allele_depths` is `sumADsOverSamples(vc, true, true)`, tumour **and** normal, and the alternate
+/// count is the total minus the reference's entry.
+///
+/// The comment above the guard says "if there is no NCount annotation or the altCount is 0, don't
+/// apply the filter", and only the second half is written. A missing `NCount` is
+/// `getAttributeAsInt(key, 0)`, a zero rather than a skip; the skip lives one level up, in
+/// `requiredInfoAnnotations`. The comparison is `>=`, so a ratio exactly at the maximum is an
+/// artifact.
+pub fn n_ratio_is_artifact(allele_depths: &[i32], n_count: i32, max_n_ratio: f64) -> bool {
+    let total: i32 = allele_depths.iter().map(|d| i64::from(*d)).sum::<i64>() as i32;
+    let alt_count = total - allele_depths[0];
+    if alt_count == 0 {
+        return false;
+    }
+    f64::from(n_count) / f64::from(alt_count) >= max_n_ratio
+}
+
+/// `MinAlleleFractionFilter`: the tumour's allele fraction is too low to believe.
+///
+/// `fractions_by_alt_allele` is what `getAltDataByAllele` gathered over the tumour genotypes that
+/// carry `AF`, one list per alternate allele.
+///
+/// Two things this keeps. **An allele with no data is `orElse(1.0)`**, which is below no threshold,
+/// so the filter answers "not an artifact" from an absence; `requiredInfoAnnotations` is empty, so
+/// a record with no `AF` anywhere still reaches this and still passes. And the reference's
+/// `.filter(entry -> !vc.getReference().equals(entry.getKey()))` is **dead code**, since the map it
+/// filters is keyed on the alternate alleles alone; there is nothing here to model.
+pub fn min_allele_fraction_artifacts(
+    fractions_by_alt_allele: &[Vec<f64>],
+    minimum: f64,
+) -> Vec<bool> {
+    fractions_by_alt_allele
+        .iter()
+        .map(|fractions| {
+            // `Stream.max(Double::compare)`, which is a total order: `-0.0 < 0.0`, and NaN is the
+            // largest of all. `total_cmp` is the same order; `f64::max` is not.
+            fractions
+                .iter()
+                .copied()
+                .max_by(|a, b| a.total_cmp(b))
+                .unwrap_or(1.0)
+                < minimum
+        })
+        .collect()
+}
+
+/// `PanelOfNormalsFilter`: `vc.hasAttribute(PON)`.
+///
+/// Presence, not value. A record annotated `PON=false` or `PON=""` is filtered exactly as one
+/// annotated `PON=true` is.
+pub fn panel_of_normals_is_artifact(has_pon_attribute: bool) -> bool {
+    has_pon_attribute
+}
+
 /// `HardFilter.calculateErrorProbability`: a hard filter answers one or zero.
 pub fn error_probability(is_artifact: bool) -> f64 {
     if is_artifact {
@@ -319,5 +403,45 @@ mod tests {
     fn a_hard_filter_answers_one_or_zero() {
         assert_eq!(error_probability(true), 1.0);
         assert_eq!(error_probability(false), 0.0);
+    }
+
+    /// The three defaults are each on the wrong side of their own comparison.
+    #[test]
+    fn none_of_the_three_thresholds_can_be_met() {
+        // `count <= 0`, and a unique-alt-read count is at least one.
+        assert_eq!(
+            duplicated_alt_read_artifacts(&[1, 5, 100], DEFAULT_MIN_UNIQUE_ALT_READS),
+            vec![false, false, false]
+        );
+        // `ratio >= Infinity`, whatever the counts.
+        assert!(!n_ratio_is_artifact(
+            &[10, 10, 10],
+            1_000_000,
+            DEFAULT_MAX_N_RATIO
+        ));
+        // `max < 0`, and an allele fraction is not negative.
+        assert_eq!(
+            min_allele_fraction_artifacts(&[vec![0.0], vec![1.0]], DEFAULT_MIN_AF),
+            vec![false, false]
+        );
+    }
+
+    /// An allele with no fraction at all is `orElse(1.0)`: an absence answers "not an artifact".
+    #[test]
+    fn an_allele_with_no_data_passes_every_threshold() {
+        assert_eq!(
+            min_allele_fraction_artifacts(&[Vec::new(), vec![0.05]], 0.1),
+            vec![false, true]
+        );
+    }
+
+    /// The one guard the N-ratio filter has, and the `>=` beside it.
+    #[test]
+    fn the_n_ratio_guard_is_the_alternate_count_and_the_comparison_is_inclusive() {
+        // Every read is reference: the alternate count is zero and nothing is computed.
+        assert!(!n_ratio_is_artifact(&[100, 0, 0], 50, 0.5));
+        // Exactly at the maximum, which `>=` calls an artifact.
+        assert!(n_ratio_is_artifact(&[100, 20, 20], 20, 0.5));
+        assert!(!n_ratio_is_artifact(&[100, 20, 20], 19, 0.5));
     }
 }

--- a/crates/gatk-engine/tests/remaining_hard_filters.rs
+++ b/crates/gatk-engine/tests/remaining_hard_filters.rs
@@ -1,0 +1,258 @@
+//! Conformance for the four remaining hard filters against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/RemainingHardFiltersDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **none of the four can fire with the default arguments**, and the defaults are compared as
+//!    values rather than assumed;
+//!  * **`DuplicatedAltReadFilter`'s answer is as long as its annotation**, not as long as the
+//!    record: four counts on a two-alternate record answer four probabilities;
+//!  * **the two base classes disagree on a missing required annotation**, in the same golden: the
+//!    per-allele one answers `[]`, which `ErrorProbabilities` drops, and the per-site one answers
+//!    `[0.0, 0.0]`, which it counts;
+//!  * **`MinAlleleFractionFilter` answers "not an artifact" from an absence**, an allele with no
+//!    data being `orElse(1.0)`;
+//!  * **and `PanelOfNormalsFilter` reads presence rather than value**, so `PON=false` is filtered.
+//!
+//! Every row is compared and every row is bit-identical. Nothing here is arithmetic beyond one
+//! division.
+
+use gatk_corpus as corpus;
+use gatk_engine::allele_filter::alt_data_by_allele;
+use gatk_engine::allele_filter::GenotypeData;
+use gatk_engine::mutect_engine::round_finite_precision_errors;
+use gatk_engine::mutect_filter_list::FILTERS;
+use gatk_engine::mutect_hard_filters::{
+    duplicated_alt_read_artifacts, error_probability, min_allele_fraction_artifacts,
+    n_ratio_is_artifact, panel_of_normals_is_artifact, DEFAULT_MAX_N_RATIO, DEFAULT_MIN_AF,
+    DEFAULT_MIN_UNIQUE_ALT_READS,
+};
+use gatk_engine::tsv_table::java_double_to_string;
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/remaining_hard_filters.txt.gz"),
+    )
+}
+
+fn rows() -> Vec<(String, String, String)> {
+    golden()
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            (
+                fields.next().expect("a kind").to_string(),
+                fields.next().expect("a label").to_string(),
+                fields.next().expect("a payload").to_string(),
+            )
+        })
+        .collect()
+}
+
+/// The record's three alleles, and its two alternates.
+const ALLELES: [&str; 3] = ["A", "C", "G"];
+
+/// One genotype: its allele depths, and the allele fractions it carries (empty when it has none).
+fn genotype(tumor: bool, allele_depths: &[i32], fractions: &[f64]) -> GenotypeData<f64> {
+    GenotypeData {
+        tumor,
+        allele_depths: allele_depths.to_vec(),
+        values: fractions.to_vec(),
+    }
+}
+
+/// The base record's two samples.
+fn base_genotypes() -> Vec<GenotypeData<f64>> {
+    vec![
+        genotype(true, &[80, 20, 5], &[0.2, 0.05]),
+        genotype(false, &[90, 1, 0], &[0.01, 0.0]),
+    ]
+}
+
+/// `Mutect2AlleleFilter.errorProbabilities`: an empty list when a required annotation is missing,
+/// and one rounded probability per element of whatever the filter answered otherwise.
+fn allele_probabilities(present: bool, artifacts: Vec<bool>) -> Vec<f64> {
+    if !present {
+        return Vec::new();
+    }
+    artifacts
+        .into_iter()
+        .map(|artifact| round_finite_precision_errors(error_probability(artifact)))
+        .collect()
+}
+
+/// `Mutect2VariantFilter.errorProbabilities`: one probability copied to every alternate allele, and
+/// that probability is `0.0` when a required annotation is missing.
+fn site_probabilities(present: bool, artifact: bool, alternate_count: usize) -> Vec<f64> {
+    let probability = round_finite_precision_errors(if present {
+        error_probability(artifact)
+    } else {
+        0.0
+    });
+    vec![probability; alternate_count]
+}
+
+/// `sumADsOverSamples(vc, true, true)`: both samples, indexed by the record's allele count.
+fn all_allele_depths(genotypes: &[GenotypeData<f64>]) -> Vec<i32> {
+    let mut totals = vec![0; ALLELES.len()];
+    for genotype in genotypes {
+        for (total, depth) in totals.iter_mut().zip(&genotype.allele_depths) {
+            *total += depth;
+        }
+    }
+    totals
+}
+
+/// `getAltDataByAllele(vc, g -> g.hasExtendedAttribute(AF) && isTumor(g), ...)`.
+fn fractions_by_alt_allele(genotypes: &[GenotypeData<f64>]) -> Vec<Vec<f64>> {
+    let alleles: Vec<String> = ALLELES.iter().map(|a| a.to_string()).collect();
+    alt_data_by_allele(&alleles, genotypes, |g| g.tumor && !g.values.is_empty())
+        .into_iter()
+        .map(|(_, values)| values)
+        .collect()
+}
+
+fn probabilities(label: &str) -> Vec<f64> {
+    match label {
+        // `DuplicatedAltReadFilter`, whose answer is as long as its annotation.
+        "duplicate-default" => allele_probabilities(
+            true,
+            duplicated_alt_read_artifacts(&[3, 1], DEFAULT_MIN_UNIQUE_ALT_READS),
+        ),
+        "duplicate-threshold-two" => {
+            allele_probabilities(true, duplicated_alt_read_artifacts(&[3, 1], 2))
+        }
+        "duplicate-short-list" => {
+            allele_probabilities(true, duplicated_alt_read_artifacts(&[1], 2))
+        }
+        "duplicate-long-list" => {
+            allele_probabilities(true, duplicated_alt_read_artifacts(&[1, 1, 1, 1], 2))
+        }
+        "duplicate-no-annotation" => allele_probabilities(false, Vec::new()),
+
+        // `NRatioFilter`, over both samples' depths.
+        "nratio-default" => site_probabilities(
+            true,
+            n_ratio_is_artifact(
+                &all_allele_depths(&base_genotypes()),
+                4,
+                DEFAULT_MAX_N_RATIO,
+            ),
+            2,
+        ),
+        "nratio-threshold-half" => site_probabilities(
+            true,
+            n_ratio_is_artifact(&all_allele_depths(&base_genotypes()), 4, 0.5),
+            2,
+        ),
+        "nratio-no-alt-reads" => {
+            let genotypes = vec![
+                genotype(true, &[80, 0, 0], &[0.0, 0.0]),
+                genotype(false, &[90, 0, 0], &[0.0, 0.0]),
+            ];
+            site_probabilities(
+                true,
+                n_ratio_is_artifact(&all_allele_depths(&genotypes), 4, 0.5),
+                2,
+            )
+        }
+        "nratio-no-annotation" => site_probabilities(false, false, 2),
+        "nratio-at-the-threshold" => site_probabilities(
+            true,
+            n_ratio_is_artifact(&all_allele_depths(&base_genotypes()), 13, 0.5),
+            2,
+        ),
+
+        // `MinAlleleFractionFilter`, which requires no annotation at all.
+        "minaf-default" => allele_probabilities(
+            true,
+            min_allele_fraction_artifacts(
+                &fractions_by_alt_allele(&base_genotypes()),
+                DEFAULT_MIN_AF,
+            ),
+        ),
+        "minaf-threshold-tenth" => allele_probabilities(
+            true,
+            min_allele_fraction_artifacts(&fractions_by_alt_allele(&base_genotypes()), 0.1),
+        ),
+        "minaf-no-allele-fraction" => {
+            let genotypes = vec![genotype(true, &[80, 20, 5], &[])];
+            allele_probabilities(
+                true,
+                min_allele_fraction_artifacts(&fractions_by_alt_allele(&genotypes), 0.1),
+            )
+        }
+        "minaf-normal-is-low" => {
+            let genotypes = vec![
+                genotype(true, &[80, 20, 5], &[0.5, 0.5]),
+                genotype(false, &[90, 1, 0], &[0.001, 0.001]),
+            ];
+            allele_probabilities(
+                true,
+                min_allele_fraction_artifacts(&fractions_by_alt_allele(&genotypes), 0.1),
+            )
+        }
+        "minaf-full-length-list" => {
+            let genotypes = vec![genotype(true, &[80, 20, 5], &[0.9, 0.05, 0.9])];
+            allele_probabilities(
+                true,
+                min_allele_fraction_artifacts(&fractions_by_alt_allele(&genotypes), 0.1),
+            )
+        }
+        "minaf-at-the-threshold" => {
+            let genotypes = vec![genotype(true, &[80, 20, 5], &[0.1, 0.1])];
+            allele_probabilities(
+                true,
+                min_allele_fraction_artifacts(&fractions_by_alt_allele(&genotypes), 0.1),
+            )
+        }
+
+        // `PanelOfNormalsFilter`, which reads presence rather than value.
+        "pon-absent" => site_probabilities(true, panel_of_normals_is_artifact(false), 2),
+        "pon-present" | "pon-false" | "pon-empty-string" => {
+            site_probabilities(true, panel_of_normals_is_artifact(true), 2)
+        }
+        other => panic!("no case named {other}"),
+    }
+}
+
+fn printed(values: &[f64]) -> String {
+    let parts: Vec<String> = values.iter().map(|v| java_double_to_string(*v)).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let rows = rows();
+    assert_eq!(rows.len(), 27, "the golden's row count");
+    for (kind, label, payload) in &rows {
+        match kind.as_str() {
+            "default" => {
+                let ours = match label.as_str() {
+                    "uniqueAltReadCount" => DEFAULT_MIN_UNIQUE_ALT_READS.to_string(),
+                    "nRatio" => java_double_to_string(DEFAULT_MAX_N_RATIO),
+                    "minAf" => java_double_to_string(DEFAULT_MIN_AF),
+                    other => panic!("no default named {other}"),
+                };
+                assert_eq!(*payload, ours, "default {label}");
+            }
+            "name" => {
+                let filter = FILTERS
+                    .iter()
+                    .find(|f| f.class == label)
+                    .unwrap_or_else(|| panic!("no filter class {label}"));
+                // `phredScaledPosteriorAnnotationName` is empty for every hard filter.
+                assert_eq!(
+                    *payload,
+                    format!("{},{},none", filter.filter_name, filter.error_type.name()),
+                    "name {label}"
+                );
+            }
+            "filter" => assert_eq!(printed(&probabilities(label)), *payload, "filter {label}"),
+            other => panic!("no row kind {other}"),
+        }
+    }
+}


### PR DESCRIPTION
Closes #353. Third of three: the measurement (#354), the golden (#355), and now the port.

All 27 golden rows bit-identical, no allowance. Four of #340's ten filters land here, taking the
count from two ported to six.

What the port kept rather than tidied:

- **`DuplicatedAltReadFilter`'s answer is as long as its annotation**, so four counts on a
  two-alternate record answer four probabilities. A port that sized the result from the record
  would be wrong on exactly the input the golden runs.
- **The three defaults are each on the wrong side of their own comparison**: `count <= 0`,
  `ratio >= Infinity`, `max < 0`. Ported as constants so a caller can see it rather than infer it.
- **`Stream.max(Double::compare)` is a total order**, `-0.0 < 0.0` and NaN largest. That is
  `total_cmp`, not `f64::max`, which propagates differently.
- **An allele with no data is `orElse(1.0)`.** `MinAlleleFractionFilter` requires no annotation, so
  a record with no `AF` anywhere still reaches it and still passes.

The reference's `.filter(entry -> !vc.getReference().equals(entry.getKey()))` is unreachable, the
map being keyed on the alternate alleles alone. The module records that rather than porting a
branch that cannot run.

`tools/preflight.py` green, release profile included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)