### PR TITLE
Port the polymerase slippage filter

### DIFF
--- a/crates/gatk-engine/src/lib.rs
+++ b/crates/gatk-engine/src/lib.rs
@@ -75,6 +75,7 @@ pub mod recalibration_tables;
 pub mod reference;
 pub mod sa_tag;
 pub mod sam_pileup;
+pub mod slippage_filter;
 pub mod somatic_clustering_model;
 pub mod somatic_likelihoods;
 pub mod subset_alleles;

--- a/crates/gatk-engine/src/slippage_filter.rs
+++ b/crates/gatk-engine/src/slippage_filter.rs
@@ -1,0 +1,285 @@
+//! `PolymeraseSlippageFilter`, ported from
+//! `org.broadinstitute.hellbender.tools.walkers.mutect.filtering.PolymeraseSlippageFilter`
+//! (GATK 4.6.2.0).
+//!
+//! "Is this indel a PCR artifact of a short tandem repeat?" A somatic likelihood is weighed against
+//! the likelihood that a polymerase slipped, and the second of those is a regularized beta.
+//!
+//! # The beta is about one allele and the likelihood is about all of them
+//!
+//! ```java
+//! final int depth = (int) MathUtils.sum(ADs);
+//! final int altCount = (int) MathUtils.sum(ADs) - ADs[0];
+//! final double logSomaticLikelihood = ...logLikelihoodGivenSomatic(depth, altCount);
+//! likelihoodGivenSlippageArtifact = Beta.regularizedBeta(slippageRate, ADs[1] + 1, ADs[0] + 1);
+//! ```
+//!
+//! `altCount` sums **every** alternate allele's depth; `ADs[1]` is the **first** alternate's alone.
+//! On a biallelic record they are the same number. On a triallelic one the two halves of the same
+//! log-odds are about different alleles, and nothing reconciles them.
+//!
+//! # The prior's allele index is hard-coded
+//!
+//! `filteringEngine.posteriorProbabilityOfError(vc, logOdds, 0)` reads
+//! `getLogPriorOfSomaticVariant(vc, 0)`, so the prior comes from alternate **zero**'s indel length
+//! whichever allele slipped. The one probability that comes out is then copied to every alternate
+//! by `Mutect2VariantFilter.errorProbabilities`.
+//!
+//! # `RPA` is parsed, not read
+//!
+//! ```java
+//! vc.getAttributeAsList(REPEATS_PER_ALLELE_KEY).stream()
+//!         .mapToInt(o -> Integer.parseInt(String.valueOf(o))).toArray();
+//! ```
+//!
+//! `Integer.parseInt` is handed the *string form* of whatever the attribute holds, so an `RPA` of
+//! `10.0` is a `NumberFormatException` on the string `"10.0"` rather than a truncation to ten.
+//! `rpa.length < 2` is the only length check there is.
+//!
+//! # The fallback cannot be reached
+//!
+//! The `catch (MaxCountExceededException)` arm computes a binomial probability instead. Three-argument
+//! `regularizedBeta` passes `Integer.MAX_VALUE` iterations, so nothing short of a diverging continued
+//! fraction reaches it, and no golden can exercise it. It is [`SlippageError::FallbackUnmeasured`]
+//! here rather than a guess.
+
+use crate::allele_filter::{sum_ads_over_samples, AlleleDepthTooShort, GenotypeData};
+use crate::mutect_engine::{posterior_probability_of_error, round_finite_precision_errors};
+use crate::natural_log_utils::NonFiniteSum;
+use crate::somatic_clustering_model::{indel_length, AlternateAllele, SomaticClusteringModel};
+use jmath::beta::{regularized_beta, BetaError};
+use jmath::continued_fraction::ContinuedFractionError;
+
+/// `PolymeraseSlippageFilter`'s identity.
+pub const FILTER_NAME: &str = "slippage";
+
+/// `phredScaledPosteriorAnnotationName`, `POLYMERASE_SLIPPAGE_QUAL_KEY`.
+pub const ANNOTATION: &str = "STRQ";
+
+/// `M2FiltersArgumentCollection.DEFAULT_MIN_SLIPPAGE_LENGTH`.
+pub const DEFAULT_MIN_SLIPPAGE_LENGTH: i32 = 8;
+
+/// `M2FiltersArgumentCollection.DEFAULT_SLIPPAGE_RATE`.
+pub const DEFAULT_SLIPPAGE_RATE: f64 = 0.1;
+
+/// What this filter refuses.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SlippageError {
+    /// `Integer.parseInt` on an `RPA` entry that is not an integer.
+    NumberFormat { input: String },
+    /// A genotype's `AD` is shorter than the record's allele count.
+    AlleleDepth(AlleleDepthTooShort),
+    /// `logSumExp` over a sum that is not finite.
+    NonFiniteSum(NonFiniteSum),
+    /// The beta refused for a reason that is not the unreachable iteration cap.
+    Beta(BetaError),
+    /// The continued fraction ran out of iterations, which is the arm whose `BinomialDistribution`
+    /// fallback no golden can reach.
+    FallbackUnmeasured,
+}
+
+impl SlippageError {
+    /// The exception class the reference throws, for the refusals that have one.
+    pub fn class(&self) -> Option<&'static str> {
+        match self {
+            SlippageError::NumberFormat { .. } => Some("java.lang.NumberFormatException"),
+            SlippageError::AlleleDepth(_) => Some("java.lang.ArrayIndexOutOfBoundsException"),
+            _ => None,
+        }
+    }
+
+    /// `NumberFormatException`'s message, which quotes the input.
+    pub fn message(&self) -> Option<String> {
+        match self {
+            SlippageError::NumberFormat { input } => Some(format!("For input string: \"{input}\"")),
+            SlippageError::AlleleDepth(error) => Some(error.message()),
+            _ => None,
+        }
+    }
+}
+
+impl From<AlleleDepthTooShort> for SlippageError {
+    fn from(error: AlleleDepthTooShort) -> Self {
+        SlippageError::AlleleDepth(error)
+    }
+}
+
+impl From<NonFiniteSum> for SlippageError {
+    fn from(error: NonFiniteSum) -> Self {
+        SlippageError::NonFiniteSum(error)
+    }
+}
+
+impl From<BetaError> for SlippageError {
+    fn from(error: BetaError) -> Self {
+        match error {
+            BetaError::ContinuedFraction(ContinuedFractionError::NotConvergent { .. }) => {
+                SlippageError::FallbackUnmeasured
+            }
+            other => SlippageError::Beta(other),
+        }
+    }
+}
+
+/// `PolymeraseSlippageFilter.errorProbabilities(vc, engine, referenceContext)`.
+///
+/// `repeats_per_allele` is `RPA` as written, one string per entry, because the reference parses the
+/// string form; `None` is the annotation being absent. `repeat_unit` is `RU`, likewise. The answer
+/// is one probability per alternate allele, all of them the same number.
+#[allow(clippy::too_many_arguments)]
+pub fn slippage_error_probabilities<T>(
+    model: &mut SomaticClusteringModel,
+    repeats_per_allele: Option<&[String]>,
+    repeat_unit: Option<&str>,
+    genotypes: &[GenotypeData<T>],
+    alternates: &[AlternateAllele],
+    reference_length: i32,
+    min_slippage_length: i32,
+    slippage_rate: f64,
+) -> Result<Vec<f64>, SlippageError> {
+    let alternate_count = alternates.len();
+    let (Some(repeats_per_allele), Some(repeat_unit)) = (repeats_per_allele, repeat_unit) else {
+        return Ok(vec![round_finite_precision_errors(0.0); alternate_count]);
+    };
+
+    let probability = calculate_error_probability(
+        model,
+        repeats_per_allele,
+        repeat_unit,
+        genotypes,
+        alternates,
+        reference_length,
+        min_slippage_length,
+        slippage_rate,
+    )?;
+    Ok(vec![
+        round_finite_precision_errors(probability);
+        alternate_count
+    ])
+}
+
+/// `calculateErrorProbability`, without the copy.
+#[allow(clippy::too_many_arguments)]
+fn calculate_error_probability<T>(
+    model: &mut SomaticClusteringModel,
+    repeats_per_allele: &[String],
+    repeat_unit: &str,
+    genotypes: &[GenotypeData<T>],
+    alternates: &[AlternateAllele],
+    reference_length: i32,
+    min_slippage_length: i32,
+    slippage_rate: f64,
+) -> Result<f64, SlippageError> {
+    let mut repeats = Vec::with_capacity(repeats_per_allele.len());
+    for entry in repeats_per_allele {
+        repeats.push(parse_int(entry)?);
+    }
+    if repeats.len() < 2 {
+        return Ok(0.0);
+    }
+
+    // `ru.length()` counts UTF-16 code units, which for a repeat unit of DNA is its bases.
+    let reference_str_base_count = repeat_unit.encode_utf16().count() as i32 * repeats[0];
+    let number_of_pcr_slips = repeats[0] - repeats[1];
+    if !(reference_str_base_count >= min_slippage_length && number_of_pcr_slips.abs() == 1) {
+        return Ok(0.0);
+    }
+
+    let allele_depths = sum_ads_over_samples(alternates.len() + 1, genotypes, true, false)?;
+    if allele_depths.len() < 2 {
+        return Ok(0.0);
+    }
+    // `(int) MathUtils.sum(int[])`, which sums into a `long` and is then truncated.
+    let depth = (allele_depths.iter().map(|d| i64::from(*d)).sum::<i64>()) as i32;
+    // The reference sums the array a second time rather than reusing `depth`, which is the same
+    // number by construction.
+    let alt_count = depth - allele_depths[0];
+    let log_somatic_likelihood = model.log_likelihood_given_somatic(depth, alt_count)?;
+
+    // `ADs[1]`, the FIRST alternate's depth, against `alt_count` above, which summed them all.
+    let likelihood_given_slippage_artifact = regularized_beta(
+        slippage_rate,
+        f64::from(allele_depths[1]) + 1.0,
+        f64::from(allele_depths[0]) + 1.0,
+    )?;
+
+    let log_odds = log_somatic_likelihood - jmath::math::log(likelihood_given_slippage_artifact);
+    // `posteriorProbabilityOfError(vc, logOdds, 0)`: alternate ZERO's indel length, always.
+    let prior = model.log_prior_of_somatic_variant(indel_length(reference_length, alternates[0]));
+    Ok(posterior_probability_of_error(log_odds, prior)?)
+}
+
+/// `Integer.parseInt(String.valueOf(o))`, refusing where the reference throws.
+fn parse_int(text: &str) -> Result<i32, SlippageError> {
+    text.parse::<i32>()
+        .map_err(|_| SlippageError::NumberFormat {
+            input: text.to_string(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::somatic_clustering_model::PriorArguments;
+
+    fn genotypes() -> Vec<GenotypeData<i32>> {
+        vec![
+            GenotypeData {
+                tumor: true,
+                allele_depths: vec![80, 20],
+                values: Vec::new(),
+            },
+            GenotypeData {
+                tumor: false,
+                allele_depths: vec![90, 1],
+                values: Vec::new(),
+            },
+        ]
+    }
+
+    fn answer(repeats: &[&str], repeat_unit: &str) -> Result<Vec<f64>, SlippageError> {
+        let mut model = SomaticClusteringModel::new(PriorArguments::new(), None);
+        let repeats: Vec<String> = repeats.iter().map(|r| r.to_string()).collect();
+        slippage_error_probabilities(
+            &mut model,
+            Some(&repeats),
+            Some(repeat_unit),
+            &genotypes(),
+            &[AlternateAllele {
+                length: 1,
+                symbolic: false,
+            }],
+            2,
+            DEFAULT_MIN_SLIPPAGE_LENGTH,
+            DEFAULT_SLIPPAGE_RATE,
+        )
+    }
+
+    /// The gate needs both halves, and the base count is the repeat unit's length times the
+    /// reference's repeat count.
+    #[test]
+    fn both_halves_of_the_gate_are_needed() {
+        // Ten bases and one slip: filtered.
+        assert!(answer(&["10", "9"], "A").expect("answered")[0] > 0.0);
+        // Ten bases and two slips.
+        assert_eq!(answer(&["10", "8"], "A").expect("answered"), vec![0.0]);
+        // One slip and seven bases.
+        assert_eq!(answer(&["7", "6"], "A").expect("answered"), vec![0.0]);
+        // A two-base repeat unit reaches the minimum with half the repeats.
+        assert!(answer(&["5", "4"], "AT").expect("answered")[0] > 0.0);
+        // And an empty repeat unit is zero bases however long the repeat.
+        assert_eq!(answer(&["100", "99"], "").expect("answered"), vec![0.0]);
+    }
+
+    /// `Integer.parseInt` is handed the string form, so a decimal is a refusal rather than a
+    /// truncation, and the message quotes what it was given.
+    #[test]
+    fn a_decimal_repeat_count_is_refused_with_the_string_it_was_given() {
+        let error = answer(&["10.0", "9.0"], "A").expect_err("refused");
+        assert_eq!(error.class(), Some("java.lang.NumberFormatException"));
+        assert_eq!(
+            error.message(),
+            Some("For input string: \"10.0\"".to_string())
+        );
+    }
+}

--- a/crates/gatk-engine/tests/slippage_filter.rs
+++ b/crates/gatk-engine/tests/slippage_filter.rs
@@ -1,0 +1,228 @@
+//! Conformance for `PolymeraseSlippageFilter` against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/PolymeraseSlippageFilterDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **the beta is about `ADs[1]` and the likelihood beside it is about every alternate**, which
+//!    only agree on a biallelic record;
+//!  * **the prior's allele index is hard-coded to zero**, whichever allele slipped;
+//!  * **`RPA` is parsed from its string form**, so `10.0` is a `NumberFormatException` rather than a
+//!    truncation;
+//!  * **the gate needs `ru.length() * rpa[0] >= minSlippageLength` and exactly one slip**, so an
+//!    empty repeat unit and a two-repeat contraction both answer zero;
+//!  * **and two calls through one model are two identical answers**, even though the prior inserts
+//!    before it reads.
+//!
+//! Every row is compared. The probabilities reach the clustering model's `exp`, whose bit-exact
+//! transcription is withdrawn under htsjdk-rs decision 0014, so any divergence would be named in
+//! [`ULPS_APART`]; none is.
+
+use gatk_corpus as corpus;
+use gatk_engine::allele_filter::GenotypeData;
+use gatk_engine::slippage_filter::{
+    slippage_error_probabilities, SlippageError, ANNOTATION, DEFAULT_MIN_SLIPPAGE_LENGTH,
+    DEFAULT_SLIPPAGE_RATE, FILTER_NAME,
+};
+use gatk_engine::somatic_clustering_model::{
+    AlternateAllele, PriorArguments, SomaticClusteringModel,
+};
+use gatk_engine::tsv_table::java_double_to_string;
+
+/// The rows that need the decision 0014 allowance. None of them does.
+const ULPS_APART: [(&str, i64); 0] = [];
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/slippage_filter.txt.gz"),
+    )
+}
+
+fn rows() -> Vec<(String, String, String)> {
+    golden()
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            (
+                fields.next().expect("a kind").to_string(),
+                fields.next().expect("a label").to_string(),
+                fields.next().expect("a payload").to_string(),
+            )
+        })
+        .collect()
+}
+
+/// The record's reference is `AA`, its first alternate the deletion `A`, its second the insertion
+/// `AAA`.
+const REFERENCE_LENGTH: i32 = 2;
+
+fn deletion() -> AlternateAllele {
+    AlternateAllele {
+        length: 1,
+        symbolic: false,
+    }
+}
+
+fn insertion() -> AlternateAllele {
+    AlternateAllele {
+        length: 3,
+        symbolic: false,
+    }
+}
+
+fn genotype(tumor: bool, allele_depths: &[i32]) -> GenotypeData<i32> {
+    GenotypeData {
+        tumor,
+        allele_depths: allele_depths.to_vec(),
+        values: Vec::new(),
+    }
+}
+
+/// The dump's record for one label.
+struct Case {
+    repeats: Option<Vec<String>>,
+    repeat_unit: Option<String>,
+    genotypes: Vec<GenotypeData<i32>>,
+    alternates: Vec<AlternateAllele>,
+    slippage_rate: f64,
+}
+
+fn strings(values: &[&str]) -> Option<Vec<String>> {
+    Some(values.iter().map(|v| v.to_string()).collect())
+}
+
+fn case(label: &str) -> Case {
+    let mut case = Case {
+        repeats: strings(&["10", "9"]),
+        repeat_unit: Some("A".to_string()),
+        genotypes: vec![genotype(true, &[80, 20]), genotype(false, &[90, 1])],
+        alternates: vec![deletion()],
+        slippage_rate: DEFAULT_SLIPPAGE_RATE,
+    };
+    match label {
+        "contracted-by-one" | "called-twice-first" | "called-twice-second" => {}
+        "expanded-by-one" => case.repeats = strings(&["9", "10"]),
+        "contracted-by-two" => case.repeats = strings(&["10", "8"]),
+        "two-base-repeat-unit" => {
+            case.repeats = strings(&["5", "4"]);
+            case.repeat_unit = Some("AT".to_string());
+        }
+        "below-the-minimum" => case.repeats = strings(&["7", "6"]),
+        "at-the-minimum" => case.repeats = strings(&["8", "7"]),
+        "empty-repeat-unit" => case.repeat_unit = Some(String::new()),
+        "one-entry-in-rpa" => case.repeats = strings(&["10"]),
+        "non-integer-rpa" => case.repeats = strings(&["ten", "nine"]),
+        "decimal-rpa" => case.repeats = strings(&["10.0", "9.0"]),
+        "no-rpa" => case.repeats = None,
+        "no-ru" => case.repeat_unit = None,
+        "no-alt-reads" => case.genotypes[0] = genotype(true, &[100, 0]),
+        "all-alt-reads" => case.genotypes[0] = genotype(true, &[0, 100]),
+        "shallow" => case.genotypes[0] = genotype(true, &[4, 2]),
+        "deep" => case.genotypes[0] = genotype(true, &[800, 200]),
+        "triallelic" => {
+            case.repeats = strings(&["10", "9", "11"]);
+            case.genotypes = vec![genotype(true, &[80, 20, 40]), genotype(false, &[90, 1, 0])];
+            case.alternates = vec![deletion(), insertion()];
+        }
+        "slippage-rate-one" => case.slippage_rate = 1.0,
+        "slippage-rate-zero" => case.slippage_rate = 0.0,
+        "slippage-rate-tiny" => case.slippage_rate = 1.0e-12,
+        other => panic!("no case named {other}"),
+    }
+    case
+}
+
+fn answer(label: &str, model: &mut SomaticClusteringModel) -> Result<Vec<f64>, SlippageError> {
+    let case = case(label);
+    slippage_error_probabilities(
+        model,
+        case.repeats.as_deref(),
+        case.repeat_unit.as_deref(),
+        &case.genotypes,
+        &case.alternates,
+        REFERENCE_LENGTH,
+        DEFAULT_MIN_SLIPPAGE_LENGTH,
+        case.slippage_rate,
+    )
+}
+
+/// A fresh model per case, as the dump uses a fresh engine per case.
+fn alone(label: &str) -> Result<Vec<f64>, SlippageError> {
+    let mut model = SomaticClusteringModel::new(PriorArguments::new(), None);
+    answer(label, &mut model)
+}
+
+fn printed(values: &[f64]) -> String {
+    let parts: Vec<String> = values.iter().map(|v| java_double_to_string(*v)).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+/// Compare as text, with the decision 0014 allowance named row by row.
+fn same(ours: &[f64], payload: &str, label: &str) {
+    let mine = printed(ours);
+    if mine == payload {
+        return;
+    }
+    let allowance = ULPS_APART
+        .iter()
+        .find(|(name, _)| *name == label)
+        .map(|(_, ulps)| *ulps);
+    let Some(ulps) = allowance else {
+        panic!("{label}: ours {mine}, reference {payload}");
+    };
+    let expected: Vec<&str> = payload
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .split(", ")
+        .collect();
+    assert_eq!(ours.len(), expected.len(), "{label}: allele count");
+    for (ours, expected) in ours.iter().zip(expected) {
+        let theirs: f64 = expected.parse().expect("a double");
+        let apart = (ours.to_bits() as i64 - theirs.to_bits() as i64).abs();
+        assert!(apart <= ulps, "{label}: {apart} ulps apart, allowed {ulps}");
+    }
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let rows = rows();
+    assert_eq!(rows.len(), 25, "the golden's row count");
+    // The two `called-twice` rows share one model, which the first call inserted into.
+    let mut shared = SomaticClusteringModel::new(PriorArguments::new(), None);
+    for (kind, label, payload) in &rows {
+        match kind.as_str() {
+            "default" => {
+                let ours = match label.as_str() {
+                    "minSlippageLength" => DEFAULT_MIN_SLIPPAGE_LENGTH.to_string(),
+                    "slippageRate" => java_double_to_string(DEFAULT_SLIPPAGE_RATE),
+                    other => panic!("no default named {other}"),
+                };
+                assert_eq!(*payload, ours, "default {label}");
+            }
+            "name" => assert_eq!(
+                *payload,
+                format!("{FILTER_NAME},ARTIFACT,{ANNOTATION},RPA,RU"),
+                "name {label}"
+            ),
+            "prob" => {
+                let ours = if label.starts_with("called-twice") {
+                    answer(label, &mut shared).expect("answered")
+                } else {
+                    alone(label).expect("answered")
+                };
+                same(&ours, payload, label);
+            }
+            "error" => {
+                let error = alone(label).expect_err("refused");
+                let rendered = format!(
+                    "{}:{}",
+                    error.class().expect("a class"),
+                    error.message().expect("a message")
+                );
+                assert_eq!(*payload, rendered, "error {label}");
+            }
+            other => panic!("no row kind {other}"),
+        }
+    }
+}


### PR DESCRIPTION
Closes #357. Third of three: the measurement (#358), the golden (#359), and now the port.

All 25 golden rows bit-identical, no allowance. Seven of #340's ten filters ported.

Worth saying plainly: this filter's answer goes through the clustering model's `exp`, which is
`StrictMath.exp` here and `Math.exp` upstream (htsjdk-rs decision 0025, bounded at 1 ulp). The
normal-artifact slice needed a 3-ulp allowance on one row for exactly that reason. This one needs
none: all twenty-two probabilities, including `9.16666575000028E-93` and `2.5778239729917374E-222`,
land on the reference's bits.

What the port kept rather than tidied:

- **The beta is about `ADs[1]` and the likelihood beside it is about every alternate.** They agree
  on a biallelic record and nowhere else.
- **The prior's allele index is hard-coded to zero**, whichever allele slipped.
- **`RPA` is parsed from its string form**, so the port carries strings rather than integers and
  reproduces `For input string: "10.0"`.
- **The reference sums the depth array twice** rather than reusing `depth`. Same number, written out
  anyway.

The `MaxCountExceededException` fallback is refused rather than guessed: three-argument
`regularizedBeta` passes `Integer.MAX_VALUE` iterations, so no golden can reach the
`BinomialDistribution.probability` in the catch.

`tools/preflight.py` green, release profile included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)