### PR TITLE
Measure the contamination filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,10 @@ jobs:
             index: "30/30"
             slug: "normal-artifact-filter-remaining-hard-filters-slippage-filter"
             suites: "normal-artifact-filter remaining-hard-filters slippage-filter"
+          - group: golden-pending
+            index: "1/1"
+            slug: "contamination-filter"
+            suites: "contamination-filter"
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -3622,6 +3622,38 @@
           "why": "25 rows, no files: the two argument defaults, the filter's identity, and twenty-two probabilities over a ten-base reference repeat contracted by one, moved through both slip directions, both sides of the minimum length, an empty repeat unit, a one-entry and two unparseable RPAs, both missing required annotations, four depth shapes, a triallelic record and three slippage rates, plus the same record twice through one engine. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32131954707, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "contamination-filter",
+      "status": "golden-pending",
+      "title": "The contamination filter, which can answer NaN for an allele its annotation does not cover",
+      "harness": "tools/readfilter-conformance",
+      "tools": [],
+      "why": "ContaminationFilter, the eighth of the ten filters the filter-mutect-calls golden needs, and one of only two in the NON_SOMATIC error type, which decides which other filters can mask it. THIS FILTER CAN ANSWER NaN: depthsAndPosteriorsPerAllele is sized from the record's alleles, but every loop that fills it runs over alleleFrequencies.length, which is POPAF's, so an allele the annotation does not cover keeps an EMPTY list, and an empty list is Double.NaN, which roundFinitePrecisionErrors passes through unchanged because Math.min and Math.max propagate NaN. A POPAF LONGER THAN THE RECORD IS AN ArrayIndexOutOfBoundsException, the same loop indexing altADs, which is sized from the genotype's AD. THE CONTAMINATION IS CLAMPED ON BOTH SIDES, Math.max(0, Math.min(fromFile, 1 - EPSILON)), where EPSILON is an INSTANCE field of 1.0e-10 and the comment says the clamp exists to handle a file with contamination == 1. THE TWO CONTAMINATION HYPOTHESES ARE COMPARED BY MAXIMUM AND LOGGED ONCE, log(max(single, many)), picking the larger rather than summing, so which hypothesis wins can change with the depth alone. THE PRIOR'S ALLELE INDEX IS THE LOOP'S, unlike PolymeraseSlippageFilter which hard-codes zero in the same call. AND THE ANSWER IS A DEPTH-WEIGHTED MEDIAN ACROSS SAMPLES rather than an average. WHAT THE RUN ADDED: a normal-only record answers [NaN, NaN], so a filter can report NaN for every allele and still be counted; a contamination of one and a contamination of two answer the same numbers, the clamp making both 1 - 1e-10; and a negative contamination, an infinite POPAF and the default contamination of zero all answer exactly 0.0, the binomial at p = 0 being zero, its logarithm negative infinity and the posterior of error zero.",
+      "compare": {
+        "mode": "lines"
+      },
+      "expect_rows": 22,
+      "expect_contains": [
+        "default\tcontaminationEstimate\t0.0",
+        "name\tcontamination\tcontamination,NON_SOMATIC,CONTQ,POPAF",
+        "prob\tcontamination-default\t[0.0, 0.0]",
+        "prob\tcontamination-negative\t[0.0, 0.0]",
+        "prob\tcontamination-one\t[2.4242278794837682E-4, 0.9649217819170469]",
+        "prob\tcontamination-above-one\t[2.4242278794837682E-4, 0.9649217819170469]",
+        "prob\tinfinite-popaf\t[0.0, 0.0]",
+        "prob\tshort-popaf\t[0.006028219175187632, NaN]",
+        "error\tlong-popaf\tjava.lang.ArrayIndexOutOfBoundsException:Index 2 out of bounds for length 2",
+        "prob\tno-popaf\t[]",
+        "prob\tnormal-only\t[NaN, NaN]"
+      ],
+      "cases": [
+        {
+          "dump": "ContaminationFilterDump",
+          "golden": null,
+          "why": "22 rows, no files: the argument default, the filter's identity, and twenty probabilities over a triallelic record moved through six contamination estimates including both ends of the clamp, four population frequencies including infinity, a POPAF shorter and longer than the record and none at all, a normal-only record, two tumour samples for the weighted median, and five depth shapes. No contamination tables are read, so every sample takes the default estimate. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run PENDING."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/ContaminationFilterDump.java
+++ b/tools/readfilter-conformance/ContaminationFilterDump.java
@@ -1,0 +1,152 @@
+/*
+ * `ContaminationFilter`, taken from the reference.
+ *
+ * The eighth of the ten filters the `filter-mutect-calls` golden needs, and one of only two in the
+ * `NON_SOMATIC` error type. Six behaviours this is built to catch.
+ *
+ *   - THIS FILTER CAN ANSWER NaN. `depthsAndPosteriorsPerAllele` is sized from the record's
+ *     alleles, but every loop that fills it runs over `alleleFrequencies.length`, which is
+ *     `POPAF`'s. An allele the annotation does not cover keeps an EMPTY list, and an empty list is
+ *     `Double.NaN`, which `roundFinitePrecisionErrors` passes through unchanged because
+ *     `Math.min`/`Math.max` propagate NaN;
+ *   - A `POPAF` LONGER THAN THE RECORD IS AN ArrayIndexOutOfBoundsException, the same loop indexing
+ *     `altADs`, which is sized from the genotype's `AD`;
+ *   - THE CONTAMINATION IS CLAMPED ON BOTH SIDES: `Math.max(0, Math.min(fromFile, 1 - EPSILON))`,
+ *     where `EPSILON` is an INSTANCE field of `1.0e-10` and the comment says the clamp exists "to
+ *     handle file with contamination == 1";
+ *   - THE TWO CONTAMINATION HYPOTHESES ARE COMPARED BY MAXIMUM AND LOGGED ONCE:
+ *     `log(max(singleContaminant, manyContaminant))` picks the larger rather than summing, so which
+ *     hypothesis wins can change with the depth alone;
+ *   - THE PRIOR'S ALLELE INDEX IS THE LOOP'S, unlike `PolymeraseSlippageFilter`, which hard-codes
+ *     zero in the same call: each alternate gets its own indel length;
+ *   - AND THE ANSWER IS A WEIGHTED MEDIAN ACROSS SAMPLES, weighted by each sample's alternate depth,
+ *     so two tumour samples do not average.
+ *
+ * The dump passes no contamination tables, so every sample takes `defaultContamination`; a table
+ * naming a sample twice is an `IllegalStateException` out of `Collectors.toMap`, which needs files
+ * and is out of scope here.
+ *
+ * Output:
+ *
+ *     default\tcontaminationEstimate\t<value>
+ *     name\tcontamination\t<filterName>,<errorType>,<annotation>,<required annotations>
+ *     prob\t<label>\t<one error probability per alternate allele>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: ContaminationFilterDump
+ */
+
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.GenotypeBuilder;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.ContaminationFilter;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.M2FiltersArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.Mutect2FilteringEngine;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ContaminationFilterDump {
+
+    public static void main(final String[] args) throws Exception {
+        System.out.println("# ContaminationFilterDump: the cross-sample contamination filter");
+
+        final M2FiltersArgumentCollection arguments = new M2FiltersArgumentCollection();
+        System.out.printf("default\tcontaminationEstimate\t%s%n",
+                Double.toString(arguments.contaminationEstimate));
+
+        final ContaminationFilter filter = new ContaminationFilter(List.of(), 0.05);
+        System.out.printf("name\tcontamination\t%s,%s,%s,%s%n", filter.filterName(), filter.errorType(),
+                filter.phredScaledPosteriorAnnotationName().orElse("none"), "POPAF");
+
+        // A triallelic record with one tumour and one normal, and a population allele frequency for
+        // each alternate: POPAF is -log10, so 2.0 is a frequency of 0.01.
+        final VariantContext base = new VariantContextBuilder("dump", "chr1", 100, 100,
+                List.of(Allele.REF_A, Allele.ALT_C, Allele.ALT_G))
+                .attribute("POPAF", List.of(2.0, 3.0))
+                .genotypes(List.of(genotype("T1", new int[] {80, 20, 5}),
+                        genotype("N1", new int[] {90, 1, 0})))
+                .make();
+
+        // The contamination estimate, across its range and both ends of its clamp.
+        prob("contamination-default", base, arguments.contaminationEstimate);
+        prob("contamination-five-percent", base, 0.05);
+        prob("contamination-half", base, 0.5);
+        prob("contamination-one", base, 1.0);
+        prob("contamination-above-one", base, 2.0);
+        prob("contamination-negative", base, -0.5);
+
+        // The population frequencies: common, vanishingly rare, and certain.
+        prob("common-allele", new VariantContextBuilder(base)
+                .attribute("POPAF", List.of(0.5, 0.5)).make(), 0.05);
+        prob("rare-allele", new VariantContextBuilder(base)
+                .attribute("POPAF", List.of(9.0, 9.0)).make(), 0.05);
+        prob("frequency-of-one", new VariantContextBuilder(base)
+                .attribute("POPAF", List.of(0.0, 0.0)).make(), 0.05);
+        prob("infinite-popaf", new VariantContextBuilder(base)
+                .attribute("POPAF", List.of(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY))
+                .make(), 0.05);
+
+        // A POPAF shorter than the record's alternates: the second allele keeps an empty list.
+        prob("short-popaf", new VariantContextBuilder(base)
+                .attribute("POPAF", List.of(2.0)).make(), 0.05);
+        // And one longer than the genotype's AD.
+        prob("long-popaf", new VariantContextBuilder(base)
+                .attribute("POPAF", List.of(2.0, 3.0, 4.0)).make(), 0.05);
+        // No POPAF at all: the required-annotation check answers an empty list.
+        prob("no-popaf", new VariantContextBuilder(base).rmAttribute("POPAF").make(), 0.05);
+
+        // Only a normal sample: every allele's list is empty, so every allele is NaN.
+        prob("normal-only", new VariantContextBuilder(base)
+                .genotypes(List.of(genotype("N1", new int[] {90, 1, 0}))).make(), 0.05);
+
+        // Two tumour samples, whose posteriors are combined by a depth-weighted median rather than
+        // averaged.
+        prob("two-tumours", new VariantContextBuilder(base)
+                .genotypes(List.of(genotype("T1", new int[] {80, 20, 5}),
+                        genotype("T2", new int[] {40, 1, 30}),
+                        genotype("N1", new int[] {90, 1, 0}))).make(), 0.05);
+
+        // The depths the binomials read.
+        prob("no-alt-reads", withTumor(base, new int[] {100, 0, 0}), 0.05);
+        prob("all-alt-reads", withTumor(base, new int[] {0, 100, 0}), 0.05);
+        prob("shallow", withTumor(base, new int[] {4, 2, 1}), 0.05);
+        prob("deep", withTumor(base, new int[] {800, 200, 50}), 0.05);
+        // A depth at which the many-contaminant hypothesis overtakes the single one.
+        prob("one-alt-read-deep", withTumor(base, new int[] {999, 1, 0}), 0.05);
+    }
+
+    static Genotype genotype(final String sample, final int[] ad) {
+        return new GenotypeBuilder(sample, List.of(Allele.REF_A, Allele.ALT_C)).AD(ad).make();
+    }
+
+    static VariantContext withTumor(final VariantContext vc, final int[] ad) {
+        return new VariantContextBuilder(vc)
+                .genotypes(List.of(genotype("T1", ad), genotype("N1", new int[] {90, 1, 0}))).make();
+    }
+
+    /** A fresh engine per case, so one case's clustering model cannot reach the next. */
+    static Mutect2FilteringEngine engine() {
+        final Set<VCFHeaderLine> lines = new LinkedHashSet<>();
+        lines.add(new VCFHeaderLine("normal_sample", "N1"));
+        final VCFHeader header = new VCFHeader(lines, List.of("T1", "T2", "N1"));
+        return new Mutect2FilteringEngine(new M2FiltersArgumentCollection(), header,
+                new File("no-such-stats-file.tsv"));
+    }
+
+    static void prob(final String label, final VariantContext vc, final double contamination) {
+        final ContaminationFilter filter = new ContaminationFilter(List.of(), contamination);
+        try {
+            System.out.printf("prob\t%s\t%s%n", label, filter.errorProbabilities(vc, engine(), null));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+}


### PR DESCRIPTION
For #361, the eighth of #340's ten. 22 rows, no files.

What the run showed:

- **A filter can report NaN.** `short-popaf` answers `[0.006028219175187632, NaN]` and `normal-only`
  answers `[NaN, NaN]`. The list is sized from the record's alleles and filled from `POPAF`'s
  length, an uncovered allele keeps an empty list, and an empty list is `Double.NaN` straight
  through `roundFinitePrecisionErrors`, which propagates it. `ErrorProbabilities` counts that as a
  filter that ran.
- **A contamination of one and a contamination of two answer the same numbers**, the clamp making
  both `1 - 1e-10`.
- **Zero, negative and infinite inputs all collapse to `0.0`**: the binomial at `p = 0` is zero, its
  logarithm negative infinity, the log-odds positive infinity, and the posterior of error zero. The
  default contamination estimate is zero, so a run with no `--contamination-table` and no
  `--contamination-estimate` builds a filter that answers zero to everything.
- **A `POPAF` longer than the record is an `ArrayIndexOutOfBoundsException`**, not a truncation.

Golden-pending, so nothing is compared: the row count and eleven named behaviours are asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #10.
