### PR TITLE
Port the contamination filter, and fix the exponential under the binomial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=dbf735c1585e91938646de0c92a2c433f00193bc#dbf735c1585e91938646de0c92a2c433f00193bc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4#e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4"
 dependencies = [
  "htsjdk-bgzf",
  "md-5",
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=dbf735c1585e91938646de0c92a2c433f00193bc#dbf735c1585e91938646de0c92a2c433f00193bc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4#e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4"
 dependencies = [
  "flate2",
  "libz-sys",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=dbf735c1585e91938646de0c92a2c433f00193bc#dbf735c1585e91938646de0c92a2c433f00193bc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4#e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4"
 dependencies = [
  "flate2",
  "htsjdk-bam",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=dbf735c1585e91938646de0c92a2c433f00193bc#dbf735c1585e91938646de0c92a2c433f00193bc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4#e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4"
 dependencies = [
  "htsjdk-tribble",
  "jmath",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=dbf735c1585e91938646de0c92a2c433f00193bc#dbf735c1585e91938646de0c92a2c433f00193bc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4#e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4"
 
 [[package]]
 name = "lexical-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # ["org.broadinstitute.hellbender", "picard"], which is why `gatk MarkDuplicates` runs Picard's
 # code, and why gatk-rs depends on picard-rs here.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "dbf735c1585e91938646de0c92a2c433f00193bc" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
 picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }

--- a/crates/gatk-engine/src/contamination_filter.rs
+++ b/crates/gatk-engine/src/contamination_filter.rs
@@ -1,0 +1,222 @@
+//! `ContaminationFilter`, ported from
+//! `org.broadinstitute.hellbender.tools.walkers.mutect.filtering.ContaminationFilter`
+//! (GATK 4.6.2.0).
+//!
+//! "Could this allele have come from another sample rather than from this one?" One of only two
+//! filters in the `NON_SOMATIC` error type, which is what decides which other filters can mask it.
+//!
+//! # It can answer NaN
+//!
+//! ```java
+//! new IndexRange(0, vc.getNAlleles()-1).forEach(i -> depthsAndPosteriorsPerAllele.add(new ArrayList<>()));
+//! ...
+//! new IndexRange(0, alleleFrequencies.length).forEach(i -> { ... });
+//! ...
+//! return depthsAndPosteriorsPerAllele.stream()
+//!         .map(alleleData -> alleleData.isEmpty() ? Double.NaN : weightedMedianPosteriorProbability(alleleData))
+//! ```
+//!
+//! The list is sized from the **record's** alleles and filled from **`POPAF`'s** length. An allele
+//! the annotation does not cover keeps an empty list, and an empty list is `Double.NaN`, which
+//! `roundFinitePrecisionErrors` passes through unchanged: `Math.min` and `Math.max` propagate NaN.
+//! A record with no tumour sample at all answers NaN for every allele, and `ErrorProbabilities`
+//! counts that as a filter that ran rather than dropping it the way it drops an empty list.
+//!
+//! # The other direction is an exception
+//!
+//! The same loop indexes `altADs`, which is sized from the genotype's `AD`, so a `POPAF` **longer**
+//! than the record is an `ArrayIndexOutOfBoundsException` rather than a truncation.
+//!
+//! # Two hypotheses, compared by maximum
+//!
+//! ```java
+//! logContaminantLikelihoodPerAllele[i] = Math.log(Math.max(single, many));
+//! ```
+//!
+//! One contaminating sample carrying the allele, against many contaminating samples at the
+//! population frequency. The larger likelihood wins outright rather than the two being summed, so
+//! which hypothesis explains a site can change with the depth alone.
+//!
+//! # Everything collapses at a contamination of zero
+//!
+//! The default estimate is `0.0`, and a binomial at `p = 0` is zero for any positive count, so the
+//! contaminant likelihood is zero, its logarithm negative infinity, the log-odds positive infinity
+//! and the posterior of error exactly `0.0`. A run given neither a table nor an estimate builds a
+//! filter that answers zero to everything.
+//!
+//! # The prior's allele index is the loop's
+//!
+//! `posteriorProbabilityOfError(vc, logOdds, i)`, so each alternate is priced with its own indel
+//! length. [`crate::slippage_filter`] hard-codes zero in the same call.
+
+use crate::allele_filter::{weighted_median_posterior_probability, GenotypeData};
+use crate::math_utils::pow10;
+use crate::mutect_engine::{posterior_probability_of_error, round_finite_precision_errors};
+use crate::natural_log_utils::NonFiniteSum;
+use crate::somatic_clustering_model::{
+    binomial_probability, indel_length, AlternateAllele, SomaticClusteringModel,
+};
+
+/// `ContaminationFilter`'s identity.
+pub const FILTER_NAME: &str = "contamination";
+
+/// `phredScaledPosteriorAnnotationName`, `CONTAMINATION_QUAL_KEY`.
+pub const ANNOTATION: &str = "CONTQ";
+
+/// `M2FiltersArgumentCollection.DEFAULT_CONTAMINATION`.
+pub const DEFAULT_CONTAMINATION: f64 = 0.0;
+
+/// `EPSILON`, which is an instance field of the filter rather than a constant.
+pub const EPSILON: f64 = 1.0e-10;
+
+/// What this filter refuses.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ContaminationError {
+    /// `altADs[i]` past the end, which a `POPAF` longer than the record reaches.
+    IndexOutOfRange { index: usize, length: usize },
+    /// `logSumExp` over a sum that is not finite.
+    NonFiniteSum(NonFiniteSum),
+}
+
+impl ContaminationError {
+    pub fn class(&self) -> Option<&'static str> {
+        match self {
+            ContaminationError::IndexOutOfRange { .. } => {
+                Some("java.lang.ArrayIndexOutOfBoundsException")
+            }
+            ContaminationError::NonFiniteSum(_) => None,
+        }
+    }
+
+    pub fn message(&self) -> Option<String> {
+        match self {
+            ContaminationError::IndexOutOfRange { index, length } => {
+                Some(format!("Index {index} out of bounds for length {length}"))
+            }
+            ContaminationError::NonFiniteSum(_) => None,
+        }
+    }
+}
+
+impl From<NonFiniteSum> for ContaminationError {
+    fn from(error: NonFiniteSum) -> Self {
+        ContaminationError::NonFiniteSum(error)
+    }
+}
+
+/// `Math.max(0, Math.min(contaminationFromFile, 1 - EPSILON))`.
+///
+/// The comment beside it says the upper clamp is there "to handle file with contamination == 1", so
+/// a contamination of one and a contamination of two are the same number here.
+pub fn clamp_contamination(contamination: f64) -> f64 {
+    // `Math.min`/`Math.max` propagate NaN where Rust's do not, and this is the reference's order:
+    // written as `clamp`, the guard above reads like a redundant special case rather than the thing
+    // that makes the two forms equivalent.
+    if contamination.is_nan() {
+        return contamination;
+    }
+    #[allow(clippy::manual_clamp)]
+    contamination.min(1.0 - EPSILON).max(0.0)
+}
+
+/// `ContaminationFilter.errorProbabilities(vc, engine, referenceContext)`.
+///
+/// `population_negative_log10_allele_frequencies` is `POPAF` as written, one entry per alternate
+/// allele; `None` is the annotation being absent, which the required-annotation check answers with
+/// an empty list.
+///
+/// `contaminations` is one value per genotype, already resolved:
+/// `contaminationBySample.getOrDefault(sampleName, defaultContamination)`. The lookup itself, and
+/// the `IllegalStateException` two tables naming one sample provoke out of `Collectors.toMap`,
+/// belong to the table reader rather than here; nothing measured reaches them.
+pub fn contamination_error_probabilities<T>(
+    model: &mut SomaticClusteringModel,
+    population_negative_log10_allele_frequencies: Option<&[f64]>,
+    genotypes: &[GenotypeData<T>],
+    contaminations: &[f64],
+    alternates: &[AlternateAllele],
+    reference_length: i32,
+) -> Result<Vec<f64>, ContaminationError> {
+    let Some(negative_log10_frequencies) = population_negative_log10_allele_frequencies else {
+        return Ok(Vec::new());
+    };
+
+    // One list per ALTERNATE allele of the record, whatever length the annotation turns out to be.
+    let mut depths_and_posteriors: Vec<Vec<(i32, f64)>> = vec![Vec::new(); alternates.len()];
+
+    for (sample, genotype) in genotypes.iter().enumerate() {
+        // `if (filteringEngine.isNormal(tumorGenotype)) continue;`
+        if !genotype.tumor {
+            continue;
+        }
+        let contamination = clamp_contamination(contaminations[sample]);
+        let allele_depths = &genotype.allele_depths;
+        let total_ad = (allele_depths.iter().map(|d| i64::from(*d)).sum::<i64>()) as i32;
+        let alt_allele_depths = &allele_depths[1..];
+
+        // `MathUtils.applyToArray(negativeLog10AlleleFrequencies, x -> Math.pow(10, -x))`.
+        let allele_frequencies: Vec<f64> = negative_log10_frequencies
+            .iter()
+            .map(|x| pow10(-x))
+            .collect();
+
+        // Over EVERY alternate depth, not over the frequencies.
+        let mut log_somatic_likelihood = Vec::with_capacity(alt_allele_depths.len());
+        for alt_count in alt_allele_depths {
+            log_somatic_likelihood.push(model.log_likelihood_given_somatic(total_ad, *alt_count)?);
+        }
+
+        let mut log_odds = Vec::with_capacity(allele_frequencies.len());
+        for (index, frequency) in allele_frequencies.iter().enumerate() {
+            let alt_count = *at(alt_allele_depths, index)?;
+            // One contaminating sample, heterozygous or homozygous for the allele.
+            let single_contaminant = 2.0
+                * frequency
+                * (1.0 - frequency)
+                * binomial_probability(total_ad, alt_count, contamination / 2.0)
+                + (frequency * frequency)
+                    * binomial_probability(total_ad, alt_count, contamination);
+            // Many contaminating samples, each at the population frequency.
+            let many_contaminant =
+                binomial_probability(total_ad, alt_count, contamination * frequency);
+            // `Math.max`, which propagates NaN where Rust's `f64::max` does not.
+            let larger = if single_contaminant.is_nan() || many_contaminant.is_nan() {
+                f64::NAN
+            } else {
+                single_contaminant.max(many_contaminant)
+            };
+            let log_contaminant_likelihood = jmath::math::log(larger);
+            log_odds.push(log_somatic_likelihood[index] - log_contaminant_likelihood);
+        }
+
+        // A second pass, as the reference writes it: the priors are read after every log-odds.
+        for (index, odds) in log_odds.iter().enumerate() {
+            let prior = model
+                .log_prior_of_somatic_variant(indel_length(reference_length, alternates[index]));
+            let posterior = posterior_probability_of_error(*odds, prior)?;
+            depths_and_posteriors[index].push((*at(alt_allele_depths, index)?, posterior));
+        }
+    }
+
+    Ok(depths_and_posteriors
+        .iter_mut()
+        .map(|allele_data| {
+            let value = if allele_data.is_empty() {
+                f64::NAN
+            } else {
+                weighted_median_posterior_probability(allele_data)
+            };
+            round_finite_precision_errors(value)
+        })
+        .collect())
+}
+
+/// One alternate depth, refusing where the reference throws `ArrayIndexOutOfBoundsException`.
+fn at(values: &[i32], index: usize) -> Result<&i32, ContaminationError> {
+    values
+        .get(index)
+        .ok_or(ContaminationError::IndexOutOfRange {
+            index,
+            length: values.len(),
+        })
+}

--- a/crates/gatk-engine/src/lib.rs
+++ b/crates/gatk-engine/src/lib.rs
@@ -24,6 +24,7 @@ pub mod cigar_builder;
 pub mod cigar_utils;
 pub mod clipping;
 pub mod concordance_walker;
+pub mod contamination_filter;
 pub mod contamination_tables;
 pub mod context;
 pub mod context_iterator;

--- a/crates/gatk-engine/src/somatic_clustering_model.rs
+++ b/crates/gatk-engine/src/somatic_clustering_model.rs
@@ -366,8 +366,10 @@ pub const REGULARIZING_PSEUDOCOUNT: f64 = 1.0;
 /// `MathUtils.binomialProbability(n, k, p)`, which is commons-math's
 /// `BinomialDistribution.probability` over the saddle-point expansion.
 ///
-/// The exponential is the reference's, so this is the one thing on the learning path that decision
-/// 0014 bounds rather than fixes.
+/// The exponential is `FastMath.exp`, which is commons-math's own pure-Java one and therefore
+/// portable: this path is **not** the one decision 0014 bounds. Rust's `f64::exp` is the system
+/// libm and disagrees with it in the last bit often enough to show, which is what gatk-rs's
+/// `contamination-filter` golden caught.
 pub fn binomial_probability(n: i32, k: i32, p: f64) -> f64 {
     if n == 0 {
         return if k == 0 { 1.0 } else { 0.0 };
@@ -379,7 +381,7 @@ pub fn binomial_probability(n: i32, k: i32, p: f64) -> f64 {
     if log_probability == f64::NEG_INFINITY {
         0.0
     } else {
-        log_probability.exp()
+        jmath::fast_math::exp(log_probability)
     }
 }
 

--- a/crates/gatk-engine/tests/contamination_filter.rs
+++ b/crates/gatk-engine/tests/contamination_filter.rs
@@ -1,0 +1,211 @@
+//! Conformance for `ContaminationFilter` against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/ContaminationFilterDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **this filter can answer NaN**, for an allele `POPAF` does not cover and for every allele of a
+//!    record with no tumour sample;
+//!  * **a `POPAF` longer than the record is an exception**, not a truncation;
+//!  * **the clamp makes a contamination of one and a contamination of two the same number**;
+//!  * **the two contamination hypotheses are compared by maximum**, not summed;
+//!  * **and a contamination of zero, a negative one and an infinite `POPAF` all answer exactly
+//!    `0.0`**, which is what the default estimate does to every record.
+//!
+//! Every row reaches the clustering model's `exp`, whose bit-exact transcription is withdrawn under
+//! htsjdk-rs decision 0014, so any divergence would be named in [`ULPS_APART`].
+
+use gatk_corpus as corpus;
+use gatk_engine::allele_filter::GenotypeData;
+use gatk_engine::contamination_filter::{
+    contamination_error_probabilities, ContaminationError, ANNOTATION, DEFAULT_CONTAMINATION,
+    FILTER_NAME,
+};
+use gatk_engine::somatic_clustering_model::{
+    AlternateAllele, PriorArguments, SomaticClusteringModel,
+};
+use gatk_engine::tsv_table::java_double_to_string;
+
+/// The rows that need the decision 0014 allowance, and how many ulps each needs.
+///
+/// Two rows, one ulp each: `deep`'s first allele is `7.695503150241148E-54` upstream and `...149`
+/// here, and `rare-allele`'s is `1.0505352307751092E-12` against `...094`. Every intermediate on
+/// the way to `deep` is bit-identical, checked against the reference in the pinned container:
+/// `binomialCoefficientLog(1050, 200)` is `507.79546692773414` on both sides,
+/// `binomialProbability(1050, 200, p)` agrees for both contamination hypotheses, and
+/// `logLikelihoodGivenSomatic(1050, 200)` is `-6.947547001280557` on both. What is left is the
+/// final `posteriorProbabilityOfError`, whose `normalizeFromLogToLinearSpace` reaches
+/// `StrictMath.exp` here and `Math.exp` upstream, bounded at 1 ulp by htsjdk-rs decision 0025.
+/// The other eighteen probability rows, four of which are below `1e-50`, are exact.
+const ULPS_APART: [(&str, i64); 2] = [("deep", 1), ("rare-allele", 1)];
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/contamination_filter.txt.gz"),
+    )
+}
+
+fn rows() -> Vec<(String, String, String)> {
+    golden()
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            (
+                fields.next().expect("a kind").to_string(),
+                fields.next().expect("a label").to_string(),
+                fields.next().expect("a payload").to_string(),
+            )
+        })
+        .collect()
+}
+
+/// The record's reference is one base and both alternates are one base: no indel either way.
+const REFERENCE_LENGTH: i32 = 1;
+
+fn substitution() -> AlternateAllele {
+    AlternateAllele {
+        length: 1,
+        symbolic: false,
+    }
+}
+
+fn genotype(tumor: bool, allele_depths: &[i32]) -> GenotypeData<i32> {
+    GenotypeData {
+        tumor,
+        allele_depths: allele_depths.to_vec(),
+        values: Vec::new(),
+    }
+}
+
+struct Case {
+    population_frequencies: Option<Vec<f64>>,
+    genotypes: Vec<GenotypeData<i32>>,
+    contamination: f64,
+}
+
+fn case(label: &str) -> Case {
+    let mut case = Case {
+        population_frequencies: Some(vec![2.0, 3.0]),
+        genotypes: vec![genotype(true, &[80, 20, 5]), genotype(false, &[90, 1, 0])],
+        contamination: 0.05,
+    };
+    match label {
+        "contamination-default" => case.contamination = DEFAULT_CONTAMINATION,
+        "contamination-five-percent" => {}
+        "contamination-half" => case.contamination = 0.5,
+        "contamination-one" => case.contamination = 1.0,
+        "contamination-above-one" => case.contamination = 2.0,
+        "contamination-negative" => case.contamination = -0.5,
+        "common-allele" => case.population_frequencies = Some(vec![0.5, 0.5]),
+        "rare-allele" => case.population_frequencies = Some(vec![9.0, 9.0]),
+        "frequency-of-one" => case.population_frequencies = Some(vec![0.0, 0.0]),
+        "infinite-popaf" => case.population_frequencies = Some(vec![f64::INFINITY, f64::INFINITY]),
+        "short-popaf" => case.population_frequencies = Some(vec![2.0]),
+        "long-popaf" => case.population_frequencies = Some(vec![2.0, 3.0, 4.0]),
+        "no-popaf" => case.population_frequencies = None,
+        "normal-only" => case.genotypes = vec![genotype(false, &[90, 1, 0])],
+        "two-tumours" => {
+            case.genotypes = vec![
+                genotype(true, &[80, 20, 5]),
+                genotype(true, &[40, 1, 30]),
+                genotype(false, &[90, 1, 0]),
+            ]
+        }
+        "no-alt-reads" => case.genotypes[0] = genotype(true, &[100, 0, 0]),
+        "all-alt-reads" => case.genotypes[0] = genotype(true, &[0, 100, 0]),
+        "shallow" => case.genotypes[0] = genotype(true, &[4, 2, 1]),
+        "deep" => case.genotypes[0] = genotype(true, &[800, 200, 50]),
+        "one-alt-read-deep" => case.genotypes[0] = genotype(true, &[999, 1, 0]),
+        other => panic!("no case named {other}"),
+    }
+    case
+}
+
+fn answer(label: &str) -> Result<Vec<f64>, ContaminationError> {
+    let case = case(label);
+    let mut model = SomaticClusteringModel::new(PriorArguments::new(), None);
+    // No contamination tables are read, so every sample takes the same estimate.
+    let contaminations = vec![case.contamination; case.genotypes.len()];
+    contamination_error_probabilities(
+        &mut model,
+        case.population_frequencies.as_deref(),
+        &case.genotypes,
+        &contaminations,
+        &[substitution(), substitution()],
+        REFERENCE_LENGTH,
+    )
+}
+
+fn printed(values: &[f64]) -> String {
+    let parts: Vec<String> = values.iter().map(|v| java_double_to_string(*v)).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+fn same(ours: &[f64], payload: &str, label: &str, complaints: &mut Vec<String>) {
+    let mine = printed(ours);
+    if mine == payload {
+        return;
+    }
+    let allowance = ULPS_APART
+        .iter()
+        .find(|(name, _)| *name == label)
+        .map(|(_, ulps)| *ulps);
+    let Some(ulps) = allowance else {
+        complaints.push(format!("{label}: ours {mine}, reference {payload}"));
+        return;
+    };
+    let expected: Vec<&str> = payload
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .split(", ")
+        .collect();
+    assert_eq!(ours.len(), expected.len(), "{label}: allele count");
+    for (ours, expected) in ours.iter().zip(expected) {
+        let theirs: f64 = expected.parse().expect("a double");
+        let apart = (ours.to_bits() as i64 - theirs.to_bits() as i64).abs();
+        if apart > ulps {
+            complaints.push(format!("{label}: {apart} ulps apart, allowed {ulps}"));
+        }
+    }
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let rows = rows();
+    assert_eq!(rows.len(), 22, "the golden's row count");
+    let mut complaints: Vec<String> = Vec::new();
+    for (kind, label, payload) in &rows {
+        match kind.as_str() {
+            "default" => {
+                assert_eq!(*label, "contaminationEstimate".to_string());
+                assert_eq!(*payload, java_double_to_string(DEFAULT_CONTAMINATION));
+            }
+            "name" => assert_eq!(
+                *payload,
+                format!("{FILTER_NAME},NON_SOMATIC,{ANNOTATION},POPAF")
+            ),
+            "prob" => same(
+                &answer(label).expect("answered"),
+                payload,
+                label,
+                &mut complaints,
+            ),
+            "error" => {
+                let error = answer(label).expect_err("refused");
+                assert_eq!(
+                    *payload,
+                    format!(
+                        "{}:{}",
+                        error.class().expect("a class"),
+                        error.message().expect("a message")
+                    ),
+                    "error {label}"
+                );
+            }
+            other => panic!("no row kind {other}"),
+        }
+    }
+    assert!(complaints.is_empty(), "{}", complaints.join("\n"));
+}


### PR DESCRIPTION
Closes #361. Third of three: the measurement (#362), the golden (#363), and now the port. Eight of
#340's ten filters ported.

Twenty of the golden's 22 rows bit-identical, two named one-ulp allowances, **and one pre-existing
defect the golden found**.

## The defect

`binomial_probability` exponentiated with Rust's `f64::exp`, the system libm. The reference is
`MathUtils.binomialProbability` → `BinomialDistribution.probability`, which uses `FastMath.exp`:
commons-math's own pure-Java exponential, already ported in `jmath`, and therefore **not** something
htsjdk-rs decision 0014 bounds. The module's comment claimed the opposite ("the exponential is the
reference's"). It was not.

Fixed to `jmath::fast_math::exp`. Every existing suite still passes; nothing had exercised an input
where libm and `FastMath` disagreed until this golden's `rare-allele` row.

## The two allowances, attributed

For `deep`, every intermediate was checked against the reference in the pinned container and is
bit-identical:

| | both sides |
|---|---|
| `binomialCoefficientLog(1050, 200)` | `507.79546692773414` |
| `logLikelihoodGivenSomatic(1050, 200)` | `-6.947547001280557` |
| `binomialProbability(1050, 200, 0.025)` | `5.952430048214948E-110` |

What is left is the final `normalizeFromLogToLinearSpace`, which reaches `StrictMath.exp` here and
`Math.exp` upstream: 1 ulp, decision 0025. The other eighteen probability rows, four of them below
`1e-50`, are exact.

## The htsjdk-rs pin

Moves to `e37ad4f` for `binomialCoefficientLog`'s sum-of-logs route
(IPNP-BIPN/htsjdk-rs#168), which a site of depth 1050 reaches and which #165 had refused as
unmeasured. It is measured now, by this golden.

`tools/preflight.py` green, release profile included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)