### PR TITLE
Measure the strand-artifact E step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,10 @@ jobs:
             index: "30/30"
             slug: "normal-artifact-filter-remaining-hard-filters-slippage-filter-contamination-filter-haplotype-filter"
             suites: "normal-artifact-filter remaining-hard-filters slippage-filter contamination-filter haplotype-filter"
+          - group: golden-pending
+            index: "1/1"
+            slug: "strand-artifact-estep"
+            suites: "strand-artifact-estep"
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -3689,6 +3689,41 @@
           "why": "32 rows, no files: the argument default, the filter's identity, the accumulating and learned maps read by reflection before and after learning, twelve probabilities over one learned haplotype set covering the distance boundary in both directions and every way the phasing string can be absent, the two-tumour cases that expose which genotype is read, and nine accumulations that vary only in which filters are in the ErrorProbabilities and whether their names are the interned constants. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32138327423, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "strand-artifact-estep",
+      "status": "golden-pending",
+      "title": "The strand-artifact E step, whose counts come out of a string",
+      "harness": "tools/readfilter-conformance",
+      "tools": [],
+      "why": "StrandArtifactFilter's E step, calculateArtifactProbabilities and the strandArtifactProbability under it, at the initial parameters. The tenth and last of the ten filters the filter-mutect-calls golden needs, split in two because the M step needs a Brent optimizer nothing here has ported. THE STRAND COUNTS COME OUT OF A STRING: AS_SB_TABLE is split on | and then on , with brackets stripped and each field trimmed before Integer.parseInt, so a non-integer field is a NumberFormatException out of a filter, an empty field likewise, and A TABLE WITH ONE ENTRY IS DROPPED, sbs.size() <= 1 guarding the whole filter rather than one allele. TWO BRANCHES ANSWER A HARD ZERO RATHER THAN A PROBABILITY: an alternate with no reads on either strand, and an indel longer than LONGEST_STRAND_ARTIFACT_INDEL_SIZE = 4, both build an EStep with both responsibilities zero, and the filter still reports for that allele. THE SEQUENCING-ERROR PRIOR TAKES THREE STEPS IN THE INDEL SIZE, 1000 at zero, 5000 below three and 50000 from three to four, the size being Math.abs(ref.length() - alt.length()) so an insertion and a deletion of the same length take the same branch. THE TOTALS ARE OVER EVERY ALLELE INCLUDING THE REFERENCE while the responsibilities are per alternate. THE NORMALISATION IS IN LOG10 AND THE LIKELIHOODS ARE NATURAL, converted by multiplying by MathUtils.LOG10_E. AND binomialCoefficientLog APPEARS THREE TIMES IN ONE EXPRESSION in the no-artifact branch. WHAT THE RUN ADDED: the symbolic allele's data is removed BEFORE the strand totals are summed, so a record carrying one has the same totals as a record without it; a strand-artifact prior of one answers a forward responsibility of exactly 1.0 beside a reverse one of 1.3e-25, so the two sum to more than one; and a prior of zero answers two hard zeros, both artifact log priors being negative infinity.",
+      "compare": {
+        "mode": "lines"
+      },
+      "expect_rows": 50,
+      "expect_contains": [
+        "default\tinitialAlphaStrand\t1.0",
+        "default\tinitialBetaStrand\t20.0",
+        "default\tinitialStrandArtifactPrior\t0.001",
+        "name\tstrand-artifact\tstrand_bias,ARTIFACT,STRANDQ,AS_SB_TABLE",
+        "estep\tno-alt-reads\t0.0,0.0,50,50,0,0",
+        "estep\tfive-base-deletion\t0.0,0.0,70,50,20,0",
+        "prob\tone-entry-table\t[]",
+        "prob\tempty-table\t[]",
+        "prob\tno-table\t[]",
+        "error\tnon-integer-table\tjava.lang.NumberFormatException:For input string: \"twenty\"",
+        "error\tempty-field\tjava.lang.NumberFormatException:For input string: \"\"",
+        "estep\tsymbolic-alternate\t0.9049736688601909,3.468020378290341E-23,70,50,20,0",
+        "estep\tdirect-zero-prior\t0.0,0.0,50,50,20,0",
+        "estep\tdirect-prior-of-one\t1.0,1.296719061550773E-25,50,50,20,0"
+      ],
+      "cases": [
+        {
+          "dump": "StrandArtifactEStepDump",
+          "golden": null,
+          "why": "50 rows, no files: the three initial parameters, the filter's identity, the E steps and probabilities of eighteen records covering both strand-only hypotheses, a balanced site, the depth range, all four indel-size branches and the one past them, two alternates, a symbolic alternate and six shapes of the AS_SB_TABLE string, and six direct calls to the package-private strandArtifactProbability over the prior's range and an indel size the record cannot vary on its own. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run PENDING."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/StrandArtifactEStepDump.java
+++ b/tools/readfilter-conformance/StrandArtifactEStepDump.java
@@ -1,0 +1,185 @@
+/*
+ * `StrandArtifactFilter`'s E step, taken from the reference.
+ *
+ * The last of the ten filters the `filter-mutect-calls` golden needs, split in two: this is
+ * `calculateArtifactProbabilities` and the `strandArtifactProbability` under it, at the initial
+ * parameters. The M step needs a Brent optimizer and is measured separately.
+ *
+ * Six behaviours this is built to catch.
+ *
+ *   - THE STRAND COUNTS COME OUT OF A STRING. `AS_SB_TABLE` is split on `|` and then on `,`, with
+ *     brackets stripped and each field trimmed before `Integer.parseInt`. A non-integer field is a
+ *     `NumberFormatException` out of a filter, an empty annotation is an empty list, and A TABLE
+ *     WITH ONE ENTRY IS DROPPED: `sbs.size() <= 1` guards the whole filter, not one allele;
+ *   - TWO BRANCHES ANSWER A HARD ZERO RATHER THAN A PROBABILITY. An alternate with no reads on
+ *     either strand, and an indel longer than `LONGEST_STRAND_ARTIFACT_INDEL_SIZE = 4`, both build
+ *     an `EStep` with both responsibilities zero. The filter still reports for that allele;
+ *   - THE SEQUENCING-ERROR PRIOR TAKES THREE STEPS IN THE INDEL SIZE: 1000 at zero, 5000 below
+ *     three, 50000 from three to four, and the size is `Math.abs(ref.length() - alt.length())`, so
+ *     an insertion and a deletion of the same length take the same branch;
+ *   - THE TOTALS ARE OVER EVERY ALLELE INCLUDING THE REFERENCE while the responsibilities are per
+ *     alternate;
+ *   - THE NORMALISATION IS IN LOG10 AND THE LIKELIHOODS ARE NATURAL, converted by multiplying by
+ *     `MathUtils.LOG10_E` rather than by changing the base of the logarithm;
+ *   - AND `binomialCoefficientLog` APPEARS THREE TIMES IN ONE EXPRESSION in the no-artifact branch,
+ *     which is where a deep site reaches the sum-of-logs route.
+ *
+ * Output:
+ *
+ *     default\t<name>\t<value>
+ *     name\tstrand-artifact\t<filterName>,<errorType>,<annotation>,<required annotations>
+ *     estep\t<label>\t<forward>,<reverse>,<fwdCount>,<revCount>,<fwdAlt>,<revAlt>
+ *     prob\t<label>\t<one error probability per alternate allele>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: StrandArtifactEStepDump
+ */
+
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.M2FiltersArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.Mutect2FilteringEngine;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.StrandArtifactFilter;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class StrandArtifactEStepDump {
+
+    static final Allele REF = Allele.create("A", true);
+    static final Allele SNV = Allele.create("C", false);
+    static final Allele SNV2 = Allele.create("G", false);
+    static final Allele SYMBOLIC = Allele.create("<NON_REF>", false);
+
+    public static void main(final String[] args) throws Exception {
+        System.out.println("# StrandArtifactEStepDump: the strand-artifact filter's E step");
+
+        // The initial parameters, which are private fields.
+        System.out.println("default\tinitialAlphaStrand\t1.0");
+        System.out.println("default\tinitialBetaStrand\t20.0");
+        System.out.println("default\tinitialStrandArtifactPrior\t0.001");
+
+        final StrandArtifactFilter filter = new StrandArtifactFilter();
+        System.out.printf("name\tstrand-artifact\t%s,%s,%s,%s%n", filter.filterName(), filter.errorType(),
+                filter.phredScaledPosteriorAnnotationName().orElse("none"), "AS_SB_TABLE");
+
+        // A biallelic SNV whose alternate is balanced across the strands.
+        run("balanced", biallelic("50,50|10,10"));
+        // Forward only, and reverse only: the two artifact hypotheses in turn.
+        run("forward-only", biallelic("50,50|20,0"));
+        run("reverse-only", biallelic("50,50|0,20"));
+        // One read on one strand, which is where the prior dominates.
+        run("one-forward-read", biallelic("50,50|1,0"));
+        // No alternate reads at all: the hard zero.
+        run("no-alt-reads", biallelic("50,50|0,0"));
+        // Depth, which is what moves the beta binomial.
+        run("shallow", biallelic("5,5|3,0"));
+        run("deep", biallelic("2000,2000|400,0"));
+
+        // The indel-size branches of the sequencing-error prior.
+        run("snv", indel("A", "C", "50,50|20,0"));
+        run("one-base-deletion", indel("AA", "A", "50,50|20,0"));
+        run("two-base-insertion", indel("A", "AAA", "50,50|20,0"));
+        run("three-base-insertion", indel("A", "AAAA", "50,50|20,0"));
+        run("four-base-deletion", indel("AAAAA", "A", "50,50|20,0"));
+        // One past the longest strand-artifact indel: the other hard zero.
+        run("five-base-deletion", indel("AAAAAA", "A", "50,50|20,0"));
+
+        // Two alternates, each with its own strand counts, and totals over all three entries.
+        run("two-alternates", new VariantContextBuilder("dump", "chr1", 100, 100,
+                List.of(REF, SNV, SNV2))
+                .attribute("AS_SB_TABLE", "50,50|20,0|5,5").make());
+
+        // A symbolic alternate, whose data the filter removes.
+        run("symbolic-alternate", new VariantContextBuilder("dump", "chr1", 100, 100,
+                List.of(REF, SNV, SYMBOLIC))
+                .attribute("AS_SB_TABLE", "50,50|20,0|1,1").make());
+
+        // The table's own shapes.
+        run("one-entry-table", biallelic("50,50"));
+        run("empty-table", biallelic(""));
+        run("no-table", new VariantContextBuilder("dump", "chr1", 100, 100, List.of(REF, SNV)).make());
+        run("bracketed-table", biallelic("[50,50|20,0]"));
+        run("spaced-table", biallelic("50, 50 | 20, 0"));
+        run("non-integer-table", biallelic("50,50|twenty,0"));
+        run("empty-field", biallelic("50,50|,0"));
+
+        // `strandArtifactProbability` directly, which is package-private, over the prior and the
+        // indel size the record cannot vary independently.
+        direct("direct-default-prior", 0.001, 50, 50, 20, 0, 0);
+        direct("direct-high-prior", 0.5, 50, 50, 20, 0, 0);
+        direct("direct-zero-prior", 0.0, 50, 50, 20, 0, 0);
+        direct("direct-prior-of-one", 1.0, 50, 50, 20, 0, 0);
+        direct("direct-long-indel", 0.001, 50, 50, 20, 0, 3);
+        direct("direct-no-reads", 0.001, 0, 0, 0, 0, 0);
+    }
+
+    static VariantContext biallelic(final String table) {
+        final VariantContextBuilder builder =
+                new VariantContextBuilder("dump", "chr1", 100, 100, List.of(REF, SNV));
+        return builder.attribute("AS_SB_TABLE", table).make();
+    }
+
+    static VariantContext indel(final String ref, final String alt, final String table) {
+        final Allele reference = Allele.create(ref, true);
+        final Allele alternate = Allele.create(alt, false);
+        return new VariantContextBuilder("dump", "chr1", 100, 100 + ref.length() - 1,
+                List.of(reference, alternate))
+                .attribute("AS_SB_TABLE", table).make();
+    }
+
+    static Mutect2FilteringEngine engine() {
+        final Set<VCFHeaderLine> lines = new LinkedHashSet<>();
+        lines.add(new VCFHeaderLine("normal_sample", "N1"));
+        final VCFHeader header = new VCFHeader(lines, List.of("T1", "N1"));
+        return new Mutect2FilteringEngine(new M2FiltersArgumentCollection(), header,
+                new File("no-such-stats-file.tsv"));
+    }
+
+    /** Both the E steps and the probabilities they become, from one fresh filter. */
+    static void run(final String label, final VariantContext vc) {
+        final StrandArtifactFilter filter = new StrandArtifactFilter();
+        try {
+            for (final StrandArtifactFilter.EStep step : filter.calculateArtifactProbabilities(vc, engine())) {
+                System.out.printf("estep\t%s\t%s%n", label, render(step));
+            }
+            System.out.printf("prob\t%s\t%s%n", label, filter.errorProbabilities(vc, engine(), null));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+
+    /** `strandArtifactProbability`, which is package-private and `@VisibleForTesting`. */
+    static void direct(final String label, final double prior, final int forwardCount,
+                       final int reverseCount, final int forwardAltCount, final int reverseAltCount,
+                       final int indelSize) {
+        try {
+            final Method method = StrandArtifactFilter.class.getDeclaredMethod(
+                    "strandArtifactProbability", double.class, int.class, int.class, int.class,
+                    int.class, int.class);
+            method.setAccessible(true);
+            final StrandArtifactFilter.EStep step = (StrandArtifactFilter.EStep) method.invoke(
+                    new StrandArtifactFilter(), prior, forwardCount, reverseCount, forwardAltCount,
+                    reverseAltCount, indelSize);
+            System.out.printf("estep\t%s\t%s%n", label, render(step));
+        } catch (final Exception e) {
+            final Throwable cause = e.getCause() == null ? e : e.getCause();
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(cause.getMessage())));
+        }
+    }
+
+    static String render(final StrandArtifactFilter.EStep step) {
+        return Double.toString(step.getForwardArtifactResponsibility()) + ","
+                + Double.toString(step.getReverseArtifactResponsibility()) + ","
+                + step.getForwardCount() + "," + step.getReverseCount() + ","
+                + step.getForwardAltCount() + "," + step.getReverseAltCount();
+    }
+}


### PR DESCRIPTION
For #369, the tenth and last of #340's ten filters, split in two: this is the E step, at the initial
parameters. The M step needs a Brent optimizer and gets its own slice. 50 rows, no files.

What the run showed:

- **The symbolic allele's data is removed before the strand totals are summed.** `symbolic-alternate`
  has the same `70,50` totals as the record without it, so the removal is not merely cosmetic to the
  per-allele answer.
- **A strand-artifact prior of one answers a forward responsibility of exactly `1.0` beside a reverse
  one of `1.3E-25`**, so the two sum to more than one. A prior of zero answers two hard zeros, both
  artifact log priors being negative infinity.
- **An empty field in the table is a `NumberFormatException` on `""`**, not a zero:
  `AS_SB_TABLE=50,50|,0` throws.
- **A one-entry table drops the whole filter**, answering `[]` rather than a probability, which is
  the empty list `ErrorProbabilities` discards.

The eighteen records cover both strand-only hypotheses, a balanced site, the depth range, all four
indel-size branches and the one past them, two alternates, and six shapes of the annotation string;
six direct calls to the package-private `strandArtifactProbability` reach the prior's ends and an
indel size a record cannot vary on its own.

Golden-pending, so nothing is compared: the row count and fourteen named behaviours are asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #10.
