### PR TITLE
Port the strand-artifact M step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4#e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=9a66bab9c9859474393ced791ee742c3feba3fd7#9a66bab9c9859474393ced791ee742c3feba3fd7"
 dependencies = [
  "htsjdk-bgzf",
  "md-5",
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4#e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=9a66bab9c9859474393ced791ee742c3feba3fd7#9a66bab9c9859474393ced791ee742c3feba3fd7"
 dependencies = [
  "flate2",
  "libz-sys",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4#e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=9a66bab9c9859474393ced791ee742c3feba3fd7#9a66bab9c9859474393ced791ee742c3feba3fd7"
 dependencies = [
  "flate2",
  "htsjdk-bam",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4#e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=9a66bab9c9859474393ced791ee742c3feba3fd7#9a66bab9c9859474393ced791ee742c3feba3fd7"
 dependencies = [
  "htsjdk-tribble",
  "jmath",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4#e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=9a66bab9c9859474393ced791ee742c3feba3fd7#9a66bab9c9859474393ced791ee742c3feba3fd7"
 
 [[package]]
 name = "lexical-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # ["org.broadinstitute.hellbender", "picard"], which is why `gatk MarkDuplicates` runs Picard's
 # code, and why gatk-rs depends on picard-rs here.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "e37ad4f0cb92d30208aa9b9ccce7fc89dc93c6a4" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
 picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }

--- a/crates/gatk-engine/src/strand_artifact_filter.rs
+++ b/crates/gatk-engine/src/strand_artifact_filter.rs
@@ -6,8 +6,8 @@
 //! against each other for every alternate: a forward-strand artifact, a reverse-strand artifact, and
 //! neither. The filter reports the first two added together.
 //!
-//! The M step, which re-estimates the prior and the beta shape between passes by brute-force
-//! optimisation, needs a Brent optimiser and is not here.
+//! The M step re-estimates the prior and the beta shape between passes, the shape by brute-force
+//! single-parameter optimisation: see [`learn_parameters`].
 //!
 //! # The strand counts come out of a string
 //!
@@ -54,6 +54,7 @@
 //! show -- so [`calculate_artifact_probabilities`] takes the sizes already paired with the table and
 //! refuses to guess at the shifted case.
 
+use crate::allele_fraction_cluster::double_stream_sum;
 use crate::beta_binomial::{BetaBinomialDistribution, BetaBinomialError};
 use crate::math_utils::{log10_sum_log10, pow10};
 use crate::somatic_clustering_model::AlternateAllele;
@@ -239,6 +240,147 @@ pub fn calculate_artifact_probabilities(
         }
     }
     Ok(steps)
+}
+
+/// `ARTIFACT_PSEUDOCOUNT`.
+pub const ARTIFACT_PSEUDOCOUNT: f64 = 1.0;
+
+/// `NON_ARTIFACT_PSEUDOCOUNT`, a thousand times the artifact one.
+pub const NON_ARTIFACT_PSEUDOCOUNT: f64 = 1000.0;
+
+/// The threshold above which an accumulated `EStep` counts as a potential artifact.
+pub const POTENTIAL_ARTIFACT_THRESHOLD: f64 = 0.1;
+
+/// What one pass learned: the prior and the beta shape the next pass reads.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LearnedParameters {
+    pub strand_artifact_prior: f64,
+    pub alpha_strand: f64,
+    pub beta_strand: f64,
+}
+
+impl Default for LearnedParameters {
+    /// The parameters before any pass has run.
+    fn default() -> Self {
+        Self {
+            strand_artifact_prior: INITIAL_STRAND_ARTIFACT_PRIOR,
+            alpha_strand: INITIAL_ALPHA_STRAND,
+            beta_strand: INITIAL_BETA_STRAND,
+        }
+    }
+}
+
+/// `learnParameters`, over the `EStep`s a pass accumulated.
+///
+/// # Two sums over two different sets
+///
+/// ```java
+/// final List<EStep> potentialArtifacts = eSteps.stream().filter(e -> e.getArtifactProbability() > 0.1)...
+/// final double totalArtifacts = potentialArtifacts.stream()...sum();
+/// final double totalNonArtifacts = eSteps.stream().mapToDouble(e -> 1 - e.getArtifactProbability()).sum();
+/// ```
+///
+/// The artifact mass is over the sites that look like artifacts; the non-artifact mass is over
+/// **all** of them. Every one of these sums is `DoubleStream.sum`, which is Kahan-compensated, so a
+/// plain loop is a different double.
+///
+/// # The guess is the initial alpha, not the current one
+///
+/// `OptimizationUtils.max(objective, 0.01, 100, INITIAL_ALPHA_STRAND, 0.01, 0.01, 100)`. A pass that
+/// accumulated nothing therefore does not keep the previous pass's shape: the objective over an
+/// empty set is constant, and a constant objective answers the guess, which is `1.0`.
+///
+/// # The mean is fixed and only alpha is searched
+///
+/// `beta = (1 / mean - 1) * alpha` is recomputed inside the objective and again after it, from the
+/// same expression. The two are written out separately here for the same reason they are there.
+pub fn learn_parameters(e_steps: &[EStep]) -> LearnedParameters {
+    let potential_artifacts: Vec<&EStep> = e_steps
+        .iter()
+        .filter(|step| step.artifact_probability() > POTENTIAL_ARTIFACT_THRESHOLD)
+        .collect();
+
+    let total_artifacts = double_stream_sum(
+        &potential_artifacts
+            .iter()
+            .map(|step| step.artifact_probability())
+            .collect::<Vec<f64>>(),
+    );
+    let total_non_artifacts = double_stream_sum(
+        &e_steps
+            .iter()
+            .map(|step| 1.0 - step.artifact_probability())
+            .collect::<Vec<f64>>(),
+    );
+    let strand_artifact_prior = (total_artifacts + ARTIFACT_PSEUDOCOUNT)
+        / (total_artifacts + ARTIFACT_PSEUDOCOUNT + total_non_artifacts + NON_ARTIFACT_PSEUDOCOUNT);
+
+    let artifact_alt_count = double_stream_sum(
+        &potential_artifacts
+            .iter()
+            .map(|step| {
+                step.forward_artifact_responsibility * f64::from(step.forward_alt_count)
+                    + step.reverse_artifact_responsibility * f64::from(step.reverse_alt_count)
+            })
+            .collect::<Vec<f64>>(),
+    );
+    let artifact_depth = double_stream_sum(
+        &potential_artifacts
+            .iter()
+            .map(|step| {
+                step.forward_artifact_responsibility * f64::from(step.forward_count)
+                    + step.reverse_artifact_responsibility * f64::from(step.reverse_count)
+            })
+            .collect::<Vec<f64>>(),
+    );
+    let artifact_beta_mean = (artifact_alt_count + INITIAL_ALPHA_STRAND)
+        / (artifact_depth + INITIAL_ALPHA_STRAND + INITIAL_BETA_STRAND);
+
+    let objective = |alpha: f64| {
+        let beta = (1.0 / artifact_beta_mean - 1.0) * alpha;
+        double_stream_sum(
+            &potential_artifacts
+                .iter()
+                .map(|step| {
+                    step.forward_artifact_responsibility
+                        * artifact_strand_log_likelihood(
+                            step.forward_count,
+                            step.forward_alt_count,
+                            alpha,
+                            beta,
+                        )
+                        .expect("alpha is inside the search interval and beta is positive")
+                        + step.reverse_artifact_responsibility
+                            * artifact_strand_log_likelihood(
+                                step.reverse_count,
+                                step.reverse_alt_count,
+                                alpha,
+                                beta,
+                            )
+                            .expect("alpha is inside the search interval and beta is positive")
+                })
+                .collect::<Vec<f64>>(),
+        )
+    };
+
+    let alpha_strand = jmath::brent::maximize(
+        objective,
+        0.01,
+        100.0,
+        INITIAL_ALPHA_STRAND,
+        0.01,
+        0.01,
+        100,
+    )
+    .expect("the interval, the tolerances and the budget are the reference's constants")
+    .point;
+    let beta_strand = (1.0 / artifact_beta_mean - 1.0) * alpha_strand;
+
+    LearnedParameters {
+        strand_artifact_prior,
+        alpha_strand,
+        beta_strand,
+    }
 }
 
 /// `calculateErrorProbabilityForAlleles`: the two responsibilities added, or an empty list.
@@ -493,5 +635,45 @@ mod tests {
         )
         .expect("answered");
         assert_eq!(zero.artifact_probability(), 0.0);
+    }
+
+    /// A pass that accumulated nothing does not keep the previous pass's shape: the guess handed to
+    /// the optimiser is `INITIAL_ALPHA_STRAND`, and a constant objective answers the guess.
+    #[test]
+    fn an_empty_pass_returns_to_the_initial_shape() {
+        let learned = learn_parameters(&[]);
+        assert_eq!(learned.alpha_strand, INITIAL_ALPHA_STRAND);
+        assert_eq!(learned.beta_strand, INITIAL_BETA_STRAND);
+        // The prior is the two pseudocounts alone.
+        assert_eq!(
+            learned.strand_artifact_prior,
+            ARTIFACT_PSEUDOCOUNT / (ARTIFACT_PSEUDOCOUNT + NON_ARTIFACT_PSEUDOCOUNT)
+        );
+    }
+
+    /// The two mass sums are over different sets: a site below the threshold contributes to the
+    /// non-artifact mass and to nothing else.
+    #[test]
+    fn a_site_below_the_threshold_moves_the_prior_and_not_the_shape() {
+        let table = parse_strand_bias_table("50,50|10,10").expect("parsed");
+        let weak = calculate_artifact_probabilities(
+            &table,
+            &[0],
+            INITIAL_STRAND_ARTIFACT_PRIOR,
+            INITIAL_ALPHA_STRAND,
+            INITIAL_BETA_STRAND,
+        )
+        .expect("answered");
+        assert!(weak[0].artifact_probability() < POTENTIAL_ARTIFACT_THRESHOLD);
+
+        let learned = learn_parameters(&weak);
+        assert_eq!(
+            learned.alpha_strand, INITIAL_ALPHA_STRAND,
+            "no potential artifacts"
+        );
+        assert!(
+            learned.strand_artifact_prior < learn_parameters(&[]).strand_artifact_prior,
+            "and yet the prior moved"
+        );
     }
 }

--- a/crates/gatk-engine/tests/strand_artifact_mstep.rs
+++ b/crates/gatk-engine/tests/strand_artifact_mstep.rs
@@ -1,0 +1,223 @@
+//! Conformance for `StrandArtifactFilter`'s M step and the Brent optimiser under it, against
+//! GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/StrandArtifactMStepDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **the optimiser's fifteen cases are analytic**, so they pin Brent's trajectory rather than one
+//!    caller's use of it: the bounds are never reached, a flat objective answers the guess, and a
+//!    NaN objective stops at its second point;
+//!  * **the tolerances and the budget are refusals**, with messages whose numbers are formatted;
+//!  * **a second pass with nothing accumulated does not keep the first pass's shape**, the guess
+//!    being `INITIAL_ALPHA_STRAND` rather than the current alpha;
+//!  * **the two mass sums are over different sets**, the artifact one over the sites above `0.1` and
+//!    the non-artifact one over all of them.
+//!
+//! Every row is compared and every row is bit-identical, `DoubleStream.sum`'s compensation and the
+//! beta binomial included.
+
+use gatk_corpus as corpus;
+use gatk_engine::strand_artifact_filter::{
+    calculate_artifact_probabilities, learn_parameters, parse_strand_bias_table, EStep,
+    LearnedParameters, INITIAL_ALPHA_STRAND, INITIAL_BETA_STRAND, INITIAL_STRAND_ARTIFACT_PRIOR,
+};
+use gatk_engine::tsv_table::java_double_to_string;
+use jmath::brent::{maximize, BrentError};
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/strand_artifact_mstep.txt.gz"),
+    )
+}
+
+fn rows() -> Vec<(String, String, String)> {
+    golden()
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            (
+                fields.next().expect("a kind").to_string(),
+                fields.next().expect("a label").to_string(),
+                fields.next().expect("a payload").to_string(),
+            )
+        })
+        .collect()
+}
+
+/// Every arm of the match below hands back a different closure type, so each is boxed.
+fn boxed(objective: impl Fn(f64) -> f64 + 'static) -> Box<dyn Fn(f64) -> f64> {
+    Box::new(objective)
+}
+
+/// One optimiser case: its objective and the seven arguments the dump passed.
+fn optimise(label: &str) -> Result<(f64, f64), BrentError> {
+    let quadratic_at_three = |x: f64| -(x - 3.0) * (x - 3.0);
+    let (objective, min, max, guess, relative, absolute, evaluations) = match label {
+        "quadratic-at-three" => (boxed(quadratic_at_three), 0.01, 100.0, 1.0, 0.01, 0.01, 100),
+        "quadratic-at-fifty" => (
+            boxed(|x: f64| -(x - 50.0) * (x - 50.0)),
+            0.01,
+            100.0,
+            1.0,
+            0.01,
+            0.01,
+            100,
+        ),
+        "maximum-at-the-lower-bound" => (boxed(|x: f64| -x), 0.01, 100.0, 1.0, 0.01, 0.01, 100),
+        "maximum-at-the-upper-bound" => (boxed(|x: f64| x), 0.01, 100.0, 1.0, 0.01, 0.01, 100),
+        "flat" => (boxed(|_| 1.0), 0.01, 100.0, 1.0, 0.01, 0.01, 100),
+        "two-maxima" => (boxed(f64::sin), 0.01, 20.0, 1.0, 0.01, 0.01, 100),
+        "guess-at-the-minimum" => (
+            boxed(quadratic_at_three),
+            0.01,
+            100.0,
+            0.01,
+            0.01,
+            0.01,
+            100,
+        ),
+        "guess-at-the-maximum" => (
+            boxed(quadratic_at_three),
+            0.01,
+            100.0,
+            100.0,
+            0.01,
+            0.01,
+            100,
+        ),
+        "tight-tolerance" => (
+            boxed(quadratic_at_three),
+            0.01,
+            100.0,
+            1.0,
+            1e-10,
+            1e-10,
+            1000,
+        ),
+        "reversed-interval" => (boxed(quadratic_at_three), 100.0, 0.01, 1.0, 0.01, 0.01, 100),
+        "too-few-evaluations" => (boxed(quadratic_at_three), 0.01, 100.0, 1.0, 0.01, 0.01, 3),
+        "relative-tolerance-too-small" => (
+            boxed(quadratic_at_three),
+            0.01,
+            100.0,
+            1.0,
+            1e-17,
+            0.01,
+            100,
+        ),
+        "absolute-tolerance-zero" => (boxed(quadratic_at_three), 0.01, 100.0, 1.0, 0.01, 0.0, 100),
+        "guess-outside-the-interval" => (
+            boxed(quadratic_at_three),
+            0.01,
+            100.0,
+            200.0,
+            0.01,
+            0.01,
+            100,
+        ),
+        "nan-objective" => (boxed(|_| f64::NAN), 0.01, 100.0, 1.0, 0.01, 0.01, 100),
+        other => panic!("no optimiser case named {other}"),
+    };
+    maximize(objective, min, max, guess, relative, absolute, evaluations)
+        .map(|pair| (pair.point, pair.value))
+}
+
+/// The strand tables one learning case accumulated.
+fn tables(label: &str) -> Vec<&'static str> {
+    match label {
+        "no-data" => vec![],
+        "one-strong-artifact" | "learned-twice" => vec!["50,50|20,0"],
+        "one-weak-site" => vec!["50,50|10,10"],
+        "strong-and-weak" => vec!["50,50|20,0", "50,50|10,10"],
+        "two-strong-artifacts" => vec!["50,50|20,0", "50,50|0,30"],
+        "every-site-weak" => vec!["50,50|10,10", "50,50|9,11"],
+        "deep-artifact" => vec!["2000,2000|400,0"],
+        other => panic!("no learning case named {other}"),
+    }
+}
+
+/// `accumulateDataForLearning` over one biallelic SNV per table, at the initial parameters.
+fn accumulate(label: &str) -> Vec<EStep> {
+    let mut steps = Vec::new();
+    for table in tables(label) {
+        let parsed = parse_strand_bias_table(table).expect("parsed");
+        steps.extend(
+            calculate_artifact_probabilities(
+                &parsed,
+                &[0],
+                INITIAL_STRAND_ARTIFACT_PRIOR,
+                INITIAL_ALPHA_STRAND,
+                INITIAL_BETA_STRAND,
+            )
+            .expect("answered"),
+        );
+    }
+    steps
+}
+
+fn render(learned: &LearnedParameters) -> String {
+    format!(
+        "{},{},{}",
+        java_double_to_string(learned.strand_artifact_prior),
+        java_double_to_string(learned.alpha_strand),
+        java_double_to_string(learned.beta_strand)
+    )
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let rows = rows();
+    assert_eq!(rows.len(), 32, "the golden's row count");
+    for (kind, label, payload) in &rows {
+        match kind.as_str() {
+            "opt" => {
+                let (_, expected) = payload.rsplit_once('=').expect("an answer");
+                let (point, value) = optimise(label).expect("optimised");
+                assert_eq!(
+                    format!(
+                        "{},{}",
+                        java_double_to_string(point),
+                        java_double_to_string(value)
+                    ),
+                    expected,
+                    "opt {label}"
+                );
+            }
+            "accumulated" => {
+                // `learned-twice-after` is the list after a pass, which `learnParameters` clears.
+                let expected: usize = payload.parse().expect("a count");
+                let ours = if label.ends_with("-after") {
+                    0
+                } else {
+                    accumulate(label).len()
+                };
+                assert_eq!(ours, expected, "accumulated {label}");
+            }
+            "learned" => {
+                let steps = if label.ends_with("-second") {
+                    // The second pass starts from an empty list.
+                    Vec::new()
+                } else {
+                    accumulate(label.trim_end_matches("-first"))
+                };
+                assert_eq!(
+                    render(&learn_parameters(&steps)),
+                    *payload,
+                    "learned {label}"
+                );
+            }
+            "error" => {
+                let error = optimise(label).expect_err("refused");
+                assert_eq!(
+                    *payload,
+                    format!("{}:{}", error.class(), error.message()),
+                    "error {label}"
+                );
+            }
+            other => panic!("no row kind {other}"),
+        }
+    }
+}


### PR DESCRIPTION
Closes #373. Third of three: the measurement (#374), the golden (#375), and now the port, with
`jmath::brent` from IPNP-BIPN/htsjdk-rs#169 underneath.

**All ten of #340's Mutect filters are now ported.** Every one of this golden's 32 rows is
bit-identical, no allowance, through the Brent optimiser and `DoubleStream.sum`'s compensation.

What the port keeps:

- **The guess is `INITIAL_ALPHA_STRAND`, not the current alpha.** A pass that accumulated nothing
  does not keep the previous pass's shape: the objective over an empty set is constant, and a
  constant objective answers the guess. A second pass with no data silently discards what the first
  learned, and the golden runs exactly that.
- **The two mass sums are over different sets.** `totalArtifacts` is over the sites above `0.1`;
  `totalNonArtifacts` is over all of them. A weak site moves the prior and not the shape.
- **Every sum is `DoubleStream.sum`**, Kahan-compensated with the compensation *added* at the end.
- **`beta = (1 / mean - 1) * alpha` is computed twice** from the same expression, inside the
  objective and after it. Written out twice here for the same reason it is there.

The htsjdk-rs pin moves to `9a66bab`.

`tools/preflight.py` green, release profile included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)