### PR TITLE
Measure the filter list a mode builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,10 @@ jobs:
             index: "31/31"
             slug: "strand-artifact-estep-strand-artifact-mstep"
             suites: "strand-artifact-estep strand-artifact-mstep"
+          - group: golden-pending
+            index: "1/1"
+            slug: "filter-list-by-mode"
+            suites: "filter-list-by-mode"
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -3759,6 +3759,37 @@
           "why": "32 rows, no files: fifteen calls to OptimizationUtils.max over analytic objectives, covering the filter's own tolerances and evaluation budget, a maximum on each bound, a flat function, two maxima in one interval, the guess on each bound, a tolerance ten million times tighter, and all five refusals; and eight learning passes over accumulated E steps, from none at all to two strong artifacts, plus one filter learned twice. The optimiser's cases are analytic so the golden pins the search trajectory rather than only the filter's use of it. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32144200296, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "filter-list-by-mode",
+      "status": "golden-pending",
+      "title": "The filter list a mode builds, and the getter that remembers its first answer",
+      "harness": "tools/readfilter-conformance",
+      "tools": [],
+      "why": "Mutect2FilteringEngine.buildFiltersList and the mode-dependent getters on M2FiltersArgumentCollection: which filters a run builds is decided once, at construction, from two boolean flags, and neither the engine nor its stats file will say which -- which is what the filter-mutect-calls golden could not reach. THE LIST IS BUILT IN ONE ORDER AND THAT ORDER IS THE ENGINE'S, ErrorProbabilities collecting it into a LinkedHashMap so the construction order is the iteration order downstream. MITOCHONDRIAL MODE DROPS SIX FILTERS AND ADDS NONE, MICROBIAL MODE DROPS THE SAME SIX AND ADDS ONE BACK, so PolymeraseSlippageFilter sits SIXTEENTH by default and LAST in microbial mode. THE COMMENT CLAIMS A CONDITION THE CODE DOES NOT HAVE: \"Normal Artifact Filter doesn't apply to mitochondria because we are not comparing tumor and normal\" sits directly above an unguarded filters.add(new NormalArtifactFilter(...)), and the filter is built in every mode. getMinMedianMappingQuality() WRITES TO THE FIELD IT READS, memoising on first call. getLogSnvPrior() COMPARES AGAINST THE DEFAULT BY VALUE. WHAT THE RUN ADDED: the memoisation is observable -- a collection asked once with microbial unset answers 30 and goes on answering 30 after the flag is set, while the same collection with the flag set first answers 20; and passing the default prior explicitly under mitochondrial mode yields the MITOCHONDRIAL prior, -5.756462732485115 rather than -13.815510557964275, so an explicit argument and an absent one are indistinguishable. ReadOrientationFilter needs a tar.gz of artifact priors, a fixture rather than an argument, and its branch is recorded here rather than exercised.",
+      "compare": {
+        "mode": "lines"
+      },
+      "expect_rows": 21,
+      "expect_contains": [
+        "list\tdefault\t18=TumorEvidenceFilter,BaseQualityFilter,MappingQualityFilter,DuplicatedAltReadFilter,StrandArtifactFilter,ContaminationFilter,StrictStrandBiasFilter,ReadPositionFilter,MinAlleleFractionFilter,NormalArtifactFilter,NRatioFilter,PanelOfNormalsFilter,ClusteredEventsFilter,MultiallelicFilter,FragmentLengthFilter,PolymeraseSlippageFilter,FilteredHaplotypeFilter,GermlineFilter",
+        "list\tmitochondria\t12=TumorEvidenceFilter,BaseQualityFilter,MappingQualityFilter,DuplicatedAltReadFilter,StrandArtifactFilter,ContaminationFilter,StrictStrandBiasFilter,ReadPositionFilter,MinAlleleFractionFilter,NormalArtifactFilter,NRatioFilter,PanelOfNormalsFilter",
+        "list\tmicrobial\t13=TumorEvidenceFilter,BaseQualityFilter,MappingQualityFilter,DuplicatedAltReadFilter,StrandArtifactFilter,ContaminationFilter,StrictStrandBiasFilter,ReadPositionFilter,MinAlleleFractionFilter,NormalArtifactFilter,NRatioFilter,PanelOfNormalsFilter,PolymeraseSlippageFilter",
+        "argument\tmapping-quality-asked-first\tminMedianMappingQuality=30",
+        "argument\tmapping-quality-asked-again\tminMedianMappingQuality=30",
+        "argument\tmapping-quality-flag-set-first\tminMedianMappingQuality=20",
+        "argument\tpriors-default\tlogSnvPrior=-13.815510557964275",
+        "argument\tpriors-mitochondria\tlogSnvPrior=-5.756462732485115",
+        "argument\tpriors-explicitly-the-default\tlogSnvPrior=-5.756462732485115",
+        "argument\tpriors-explicitly-other\tlogSnvPrior=-12.0"
+      ],
+      "cases": [
+        {
+          "dump": "FilterListByModeDump",
+          "golden": null,
+          "why": "21 rows, no files: the filter list under each of the four combinations of the two mode flags, read off the engine's private list by reflection and printed in construction order; seven readings of the memoising mapping-quality getter, including the pair that shows it keeps its first answer; and five pairs of somatic priors, including the one where passing the default explicitly is indistinguishable from not passing it. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run PENDING."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/FilterListByModeDump.java
+++ b/tools/readfilter-conformance/FilterListByModeDump.java
@@ -1,0 +1,129 @@
+/*
+ * `Mutect2FilteringEngine.buildFiltersList` and the mode-dependent getters on
+ * `M2FiltersArgumentCollection`, taken from the reference.
+ *
+ * Which filters a run builds is decided once, at construction, from two boolean flags, and neither
+ * the engine nor its stats file will say which. Five behaviours this is built to catch.
+ *
+ *   - THE LIST IS BUILT IN ONE ORDER AND THAT ORDER IS THE ENGINE'S. `ErrorProbabilities` collects
+ *     it into a `LinkedHashMap`, so the construction order is the iteration order downstream;
+ *   - MITOCHONDRIAL MODE DROPS SIX FILTERS AND ADDS NONE; MICROBIAL MODE DROPS THE SAME SIX AND ADDS
+ *     ONE BACK, so `PolymeraseSlippageFilter` sits in a DIFFERENT POSITION in microbial mode than in
+ *     the default one;
+ *   - THE COMMENT CLAIMS A CONDITION THE CODE DOES NOT HAVE. "Normal Artifact Filter doesn't apply
+ *     to mitochondria because we are not comparing tumor and normal" sits directly above an
+ *     unguarded `filters.add(new NormalArtifactFilter(...))`;
+ *   - `getMinMedianMappingQuality()` WRITES TO THE FIELD IT READS. It memoises on first call, so a
+ *     collection asked once before `microbial` is set keeps the non-microbial default for ever;
+ *   - AND `getLogSnvPrior()` COMPARES AGAINST THE DEFAULT BY VALUE, so passing the default
+ *     explicitly is indistinguishable from not passing it and silently yields the mitochondrial
+ *     prior instead.
+ *
+ * `ReadOrientationFilter` needs a tar.gz of artifact priors, which is a fixture rather than an
+ * argument; the branch is recorded here and not exercised.
+ *
+ * Output:
+ *
+ *     list\t<label>\t<count>=<class,class,...>
+ *     argument\t<label>\t<name>=<value>
+ *
+ * Usage: FilterListByModeDump
+ */
+
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.M2FiltersArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.Mutect2Filter;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.Mutect2FilteringEngine;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class FilterListByModeDump {
+
+    public static void main(final String[] args) throws Exception {
+        System.out.println("# FilterListByModeDump: which filters a mode builds");
+
+        list("default", false, false);
+        list("mitochondria", true, false);
+        list("microbial", false, true);
+        list("both-modes", true, true);
+
+        // The mode-dependent getters, each on its own fresh collection.
+        argument("mapping-quality-default", fresh(false, false), "minMedianMappingQuality");
+        argument("mapping-quality-mitochondria", fresh(true, false), "minMedianMappingQuality");
+        argument("mapping-quality-microbial", fresh(false, true), "minMedianMappingQuality");
+        // Set explicitly: the memoising getter leaves it alone.
+        final M2FiltersArgumentCollection explicit = fresh(false, true);
+        explicit.minMedianMappingQuality = 42;
+        argument("mapping-quality-explicit", explicit, "minMedianMappingQuality");
+
+        // THE GETTER REMEMBERS: asked before the flag is set, it keeps the first answer.
+        final M2FiltersArgumentCollection remembered = fresh(false, false);
+        System.out.printf("argument\tmapping-quality-asked-first\tminMedianMappingQuality=%d%n",
+                remembered.getMinMedianMappingQuality());
+        remembered.microbial = true;
+        System.out.printf("argument\tmapping-quality-asked-again\tminMedianMappingQuality=%d%n",
+                remembered.getMinMedianMappingQuality());
+        // And the other way round, which does take the microbial default.
+        final M2FiltersArgumentCollection setFirst = fresh(false, false);
+        setFirst.microbial = true;
+        System.out.printf("argument\tmapping-quality-flag-set-first\tminMedianMappingQuality=%d%n",
+                setFirst.getMinMedianMappingQuality());
+
+        // The priors, whose mitochondrial values are chosen by comparing against the default.
+        priors("priors-default", fresh(false, false));
+        priors("priors-mitochondria", fresh(true, false));
+        priors("priors-microbial", fresh(false, true));
+        // Explicitly the default value, under mitochondrial mode: indistinguishable from unset.
+        final M2FiltersArgumentCollection explicitPriors = fresh(true, false);
+        explicitPriors.logSNVPrior = fresh(false, false).logSNVPrior;
+        explicitPriors.logIndelPrior = fresh(false, false).logIndelPrior;
+        priors("priors-explicitly-the-default", explicitPriors);
+        // And explicitly something else, which is kept.
+        final M2FiltersArgumentCollection otherPriors = fresh(true, false);
+        otherPriors.logSNVPrior = -12.0;
+        otherPriors.logIndelPrior = -13.0;
+        priors("priors-explicitly-other", otherPriors);
+    }
+
+    static M2FiltersArgumentCollection fresh(final boolean mitochondria, final boolean microbial) {
+        final M2FiltersArgumentCollection arguments = new M2FiltersArgumentCollection();
+        arguments.mitochondria = mitochondria;
+        arguments.microbial = microbial;
+        return arguments;
+    }
+
+    @SuppressWarnings("unchecked")
+    static void list(final String label, final boolean mitochondria, final boolean microbial)
+            throws Exception {
+        final Set<VCFHeaderLine> lines = new LinkedHashSet<>();
+        lines.add(new VCFHeaderLine("normal_sample", "N1"));
+        final VCFHeader header = new VCFHeader(lines, List.of("T1", "N1"));
+        final Mutect2FilteringEngine engine = new Mutect2FilteringEngine(
+                fresh(mitochondria, microbial), header, new File("no-such-stats-file.tsv"));
+        final Field field = Mutect2FilteringEngine.class.getDeclaredField("filters");
+        field.setAccessible(true);
+        final List<Mutect2Filter> filters = (List<Mutect2Filter>) field.get(engine);
+        final String names = filters.stream().map(f -> f.getClass().getSimpleName())
+                .collect(Collectors.joining(","));
+        System.out.printf("list\t%s\t%d=%s%n", label, filters.size(), names);
+    }
+
+    static void argument(final String label, final M2FiltersArgumentCollection arguments,
+                         final String name) {
+        System.out.printf("argument\t%s\t%s=%d%n", label, name,
+                arguments.getMinMedianMappingQuality());
+    }
+
+    static void priors(final String label, final M2FiltersArgumentCollection arguments) {
+        System.out.printf("argument\t%s\tlogSnvPrior=%s%n", label,
+                Double.toString(arguments.getLogSnvPrior()));
+        System.out.printf("argument\t%s\tlogIndelPrior=%s%n", label,
+                Double.toString(arguments.getLogIndelPrior()));
+    }
+}


### PR DESCRIPTION
For #377. All ten filters are ported; this is the decision that says which of them a run makes, and
#340's golden was explicit that it could not be read out of the engine or the stats file.

21 rows, no files. The engine's private `filters` list is read by reflection and printed in
construction order, which is the order everything downstream iterates.

| mode | filters |
|---|---|
| default | 18 |
| mitochondria | 12 |
| microbial | 13 |
| both | 13 |

What the run showed:

- **`PolymeraseSlippageFilter` moves.** Sixteenth by default, last in microbial mode, because the two
  modes drop the same six and microbial adds that one back at the end.
- **`NormalArtifactFilter` is in the mitochondrial list**, directly under a comment saying it does
  not apply to mitochondria. The `add` has no guard.
- **The mapping-quality getter remembers its first answer.** Asked once with `microbial` unset it
  answers `30`, and goes on answering `30` after the flag is set; the same collection with the flag
  set first answers `20`. It writes to the field it reads.
- **Passing the default prior explicitly is indistinguishable from not passing it.**
  `getLogSnvPrior()` is `mitochondria && logSNVPrior == DEFAULT_LOG_SNV_PRIOR`, so
  `--log-snv-prior -13.815510557964275` under mitochondrial mode silently yields
  `-5.756462732485115`.

Golden-pending, so nothing is compared: the row count and ten named behaviours are asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #10.
