### PR TITLE
Port the filter list a mode builds

### DIFF
--- a/crates/gatk-engine/src/mutect_filter_list.rs
+++ b/crates/gatk-engine/src/mutect_filter_list.rs
@@ -20,12 +20,12 @@
 //! becomes a `##FILTER` line whether or not the filter runs. `MUTECT_AS_FILTER_NAMES` is one entry
 //! and becomes an `##INFO` line instead.
 //!
-//! # What is not here
+//! # Which filters a run builds
 //!
-//! Which filters a run builds. `buildFiltersList` guards six of them with `if (!mitochondria)` and
-//! one with an argument, and neither the engine nor its stats file will say so: the stats file names
-//! only the filters that **fired**. That is measured by running the tool end to end, in its own
-//! slice.
+//! `buildFiltersList` guards six of them with `if (!MTFAC.mitochondria && !MTFAC.microbial)`, adds
+//! one back under `if (MTFAC.microbial)`, and one more under an argument. Neither the engine nor its
+//! stats file will say which were built: the stats file names only the filters that **fired**. See
+//! [`build_filters_list`], which is measured against the `filter-list-by-mode` golden.
 
 pub use crate::error_probabilities::ErrorType;
 
@@ -298,6 +298,139 @@ pub fn filter_line(name: &str) -> Option<String> {
         .map(|(_, description)| format!("FILTER=<ID={name},Description=\"{description}\">"))
 }
 
+/// `M2FiltersArgumentCollection.DEFAULT_MIN_MEDIAN_MAPPING_QUALITY`.
+pub const DEFAULT_MIN_MEDIAN_MAPPING_QUALITY: i32 = 30;
+
+/// `DEFAULT_MIN_MEDIAN_MAPPING_QUALITY_FOR_MICROBIAL`.
+pub const DEFAULT_MIN_MEDIAN_MAPPING_QUALITY_FOR_MICROBIAL: i32 = 20;
+
+/// The sentinel `minMedianMappingQuality` carries until it is asked for.
+pub const UNSET_MIN_MEDIAN_MAPPING_QUALITY: i32 = -1;
+
+/// `DEFAULT_LOG_SNV_PRIOR`, `MathUtils.log10ToLog(-6)`.
+pub fn default_log_snv_prior() -> f64 {
+    crate::allele_likelihoods::log10_to_log(-6.0)
+}
+
+/// `DEFAULT_LOG_INDEL_PRIOR`, `MathUtils.log10ToLog(-7)`.
+pub fn default_log_indel_prior() -> f64 {
+    crate::allele_likelihoods::log10_to_log(-7.0)
+}
+
+/// `DEFAULT_LOG_SNV_PRIOR_FOR_MITO`, `MathUtils.log10ToLog(-2.5)`.
+pub fn default_log_snv_prior_for_mito() -> f64 {
+    crate::allele_likelihoods::log10_to_log(-2.5)
+}
+
+/// `DEFAULT_LOG_INDEL_PRIOR_FOR_MITO`, `MathUtils.log10ToLog(-3.75)`.
+pub fn default_log_indel_prior_for_mito() -> f64 {
+    crate::allele_likelihoods::log10_to_log(-3.75)
+}
+
+/// `ReadOrientationFilter`, which is not in [`FILTERS`] because it is built only when a tar.gz of
+/// artifact priors is supplied.
+pub const READ_ORIENTATION_FILTER_CLASS: &str = "ReadOrientationFilter";
+
+/// As much of `M2FiltersArgumentCollection` as decides which filters exist and how two of them are
+/// configured.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FilterArguments {
+    pub mitochondria: bool,
+    pub microbial: bool,
+    /// `minMedianMappingQuality`, [`UNSET_MIN_MEDIAN_MAPPING_QUALITY`] until asked for.
+    pub min_median_mapping_quality: i32,
+    pub log_snv_prior: f64,
+    pub log_indel_prior: f64,
+    /// Whether `readOrientationPriorTarGzs` is non-empty.
+    pub read_orientation_priors: bool,
+}
+
+impl Default for FilterArguments {
+    fn default() -> Self {
+        Self {
+            mitochondria: false,
+            microbial: false,
+            min_median_mapping_quality: UNSET_MIN_MEDIAN_MAPPING_QUALITY,
+            log_snv_prior: default_log_snv_prior(),
+            log_indel_prior: default_log_indel_prior(),
+            read_orientation_priors: false,
+        }
+    }
+}
+
+impl FilterArguments {
+    /// `getMinMedianMappingQuality()`, which **writes to the field it reads**.
+    ///
+    /// It takes `&mut self` for that reason. The memoisation is observable: a collection asked once
+    /// while `microbial` is unset answers `30` and goes on answering `30` after the flag is set,
+    /// where the same collection with the flag set first answers `20`.
+    pub fn min_median_mapping_quality(&mut self) -> i32 {
+        if self.min_median_mapping_quality == UNSET_MIN_MEDIAN_MAPPING_QUALITY {
+            self.min_median_mapping_quality = if self.microbial {
+                DEFAULT_MIN_MEDIAN_MAPPING_QUALITY_FOR_MICROBIAL
+            } else {
+                DEFAULT_MIN_MEDIAN_MAPPING_QUALITY
+            };
+        }
+        self.min_median_mapping_quality
+    }
+
+    /// `getLogSnvPrior()`, which compares against the default **by value**.
+    ///
+    /// So passing the default explicitly under mitochondrial mode is indistinguishable from not
+    /// passing it, and yields the mitochondrial prior.
+    pub fn log_snv_prior(&self) -> f64 {
+        if self.mitochondria && self.log_snv_prior == default_log_snv_prior() {
+            default_log_snv_prior_for_mito()
+        } else {
+            self.log_snv_prior
+        }
+    }
+
+    /// `getLogIndelPrior()`, the same shape.
+    pub fn log_indel_prior(&self) -> f64 {
+        if self.mitochondria && self.log_indel_prior == default_log_indel_prior() {
+            default_log_indel_prior_for_mito()
+        } else {
+            self.log_indel_prior
+        }
+    }
+}
+
+/// `buildFiltersList`: the classes a run constructs, in construction order.
+///
+/// That order is the engine's: `ErrorProbabilities` collects the list into a `LinkedHashMap`, so it
+/// is the iteration order everywhere downstream.
+///
+/// Eighteen by default, twelve in mitochondrial mode, thirteen in microbial. The two modes drop the
+/// same six; microbial adds `PolymeraseSlippageFilter` back **at the end**, so that filter is
+/// sixteenth by default and last in microbial mode.
+///
+/// `NormalArtifactFilter` is built in every mode, directly under a comment saying it does not apply
+/// to mitochondria. The `add` has no guard.
+///
+/// The `ReadOrientationFilter` branch needs a tar.gz of artifact priors, which is a fixture rather
+/// than an argument; no golden exercises it, and it is written here rather than refused because it
+/// is a list membership with an unambiguous position, not an arithmetic path.
+pub fn build_filters_list(arguments: &FilterArguments) -> Vec<&'static str> {
+    // The first twelve, unconditionally, in the reference's order.
+    let mut classes: Vec<&'static str> = FILTERS[..12].iter().map(|f| f.class).collect();
+
+    if arguments.read_orientation_priors {
+        classes.push(READ_ORIENTATION_FILTER_CLASS);
+    }
+
+    if !arguments.mitochondria && !arguments.microbial {
+        classes.extend(FILTERS[12..].iter().map(|f| f.class));
+    }
+
+    if arguments.microbial {
+        classes.push("PolymeraseSlippageFilter");
+    }
+
+    classes
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -345,5 +478,72 @@ mod tests {
             assert!(MUTECT_FILTER_NAMES.contains(&name));
             assert!(!FILTERS.iter().any(|f| f.filter_name == name));
         }
+    }
+
+    /// The three lists, and where the slippage filter sits in each.
+    #[test]
+    fn the_mode_decides_the_list_and_the_order() {
+        let default = build_filters_list(&FilterArguments::default());
+        assert_eq!(default.len(), 18);
+        assert_eq!(
+            default[15], "PolymeraseSlippageFilter",
+            "sixteenth by default"
+        );
+
+        let mitochondria = build_filters_list(&FilterArguments {
+            mitochondria: true,
+            ..FilterArguments::default()
+        });
+        assert_eq!(mitochondria.len(), 12);
+        assert!(!mitochondria.contains(&"PolymeraseSlippageFilter"));
+        // The comment above the `add` says this one does not apply to mitochondria. It is here.
+        assert!(mitochondria.contains(&"NormalArtifactFilter"));
+
+        let microbial = build_filters_list(&FilterArguments {
+            microbial: true,
+            ..FilterArguments::default()
+        });
+        assert_eq!(microbial.len(), 13);
+        assert_eq!(
+            microbial[12], "PolymeraseSlippageFilter",
+            "and last in microbial mode"
+        );
+    }
+
+    /// The getter writes to the field it reads, so the order of calls decides the answer.
+    #[test]
+    fn the_mapping_quality_getter_remembers_its_first_answer() {
+        let mut asked_first = FilterArguments::default();
+        assert_eq!(asked_first.min_median_mapping_quality(), 30);
+        asked_first.microbial = true;
+        assert_eq!(
+            asked_first.min_median_mapping_quality(),
+            30,
+            "the flag came too late"
+        );
+
+        let mut set_first = FilterArguments {
+            microbial: true,
+            ..FilterArguments::default()
+        };
+        assert_eq!(set_first.min_median_mapping_quality(), 20);
+    }
+
+    /// Passing the default explicitly is indistinguishable from not passing it.
+    #[test]
+    fn an_explicit_default_prior_is_the_mitochondrial_one() {
+        let explicit = FilterArguments {
+            mitochondria: true,
+            log_snv_prior: default_log_snv_prior(),
+            ..FilterArguments::default()
+        };
+        assert_eq!(explicit.log_snv_prior(), default_log_snv_prior_for_mito());
+
+        let other = FilterArguments {
+            mitochondria: true,
+            log_snv_prior: -12.0,
+            ..FilterArguments::default()
+        };
+        assert_eq!(other.log_snv_prior(), -12.0);
     }
 }

--- a/crates/gatk-engine/tests/filter_list_by_mode.rs
+++ b/crates/gatk-engine/tests/filter_list_by_mode.rs
@@ -1,0 +1,137 @@
+//! Conformance for `buildFiltersList` and the mode-dependent argument getters against
+//! GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/FilterListByModeDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **eighteen filters by default, twelve in mitochondrial mode, thirteen in microbial**, and the
+//!    slippage filter moves to the end of the microbial list;
+//!  * **`NormalArtifactFilter` is in the mitochondrial list**, under a comment saying it is not;
+//!  * **the mapping-quality getter remembers its first answer**, because it writes to the field it
+//!    reads;
+//!  * **and passing the default prior explicitly is indistinguishable from not passing it.**
+//!
+//! Every row is compared and every row is bit-identical.
+
+use gatk_corpus as corpus;
+use gatk_engine::mutect_filter_list::{build_filters_list, FilterArguments};
+use gatk_engine::tsv_table::java_double_to_string;
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/filter_list_by_mode.txt.gz"),
+    )
+}
+
+fn rows() -> Vec<(String, String, String)> {
+    golden()
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            (
+                fields.next().expect("a kind").to_string(),
+                fields.next().expect("a label").to_string(),
+                fields.next().expect("a payload").to_string(),
+            )
+        })
+        .collect()
+}
+
+fn arguments(mitochondria: bool, microbial: bool) -> FilterArguments {
+    FilterArguments {
+        mitochondria,
+        microbial,
+        ..FilterArguments::default()
+    }
+}
+
+fn mode(label: &str) -> FilterArguments {
+    match label {
+        "default" => arguments(false, false),
+        "mitochondria" => arguments(true, false),
+        "microbial" => arguments(false, true),
+        "both-modes" => arguments(true, true),
+        other => panic!("no mode named {other}"),
+    }
+}
+
+/// The `argument` rows, each label naming what the dump did to the collection first.
+fn argument_value(label: &str, name: &str) -> String {
+    match name {
+        "minMedianMappingQuality" => {
+            let mut collection = match label {
+                "mapping-quality-default" => arguments(false, false),
+                "mapping-quality-mitochondria" => arguments(true, false),
+                "mapping-quality-microbial" => arguments(false, true),
+                "mapping-quality-explicit" => FilterArguments {
+                    min_median_mapping_quality: 42,
+                    ..arguments(false, true)
+                },
+                // The pair that shows the memoisation: asked before the flag is set, and again
+                // after.
+                "mapping-quality-asked-first" | "mapping-quality-asked-again" => {
+                    let mut remembered = arguments(false, false);
+                    remembered.min_median_mapping_quality();
+                    if label.ends_with("-again") {
+                        remembered.microbial = true;
+                    }
+                    remembered
+                }
+                "mapping-quality-flag-set-first" => arguments(false, true),
+                other => panic!("no mapping-quality case named {other}"),
+            };
+            collection.min_median_mapping_quality().to_string()
+        }
+        "logSnvPrior" | "logIndelPrior" => {
+            let collection = match label {
+                "priors-default" => arguments(false, false),
+                "priors-mitochondria" => arguments(true, false),
+                "priors-microbial" => arguments(false, true),
+                // Exactly the default, passed explicitly, under mitochondrial mode.
+                "priors-explicitly-the-default" => arguments(true, false),
+                "priors-explicitly-other" => FilterArguments {
+                    log_snv_prior: -12.0,
+                    log_indel_prior: -13.0,
+                    ..arguments(true, false)
+                },
+                other => panic!("no prior case named {other}"),
+            };
+            java_double_to_string(if name == "logSnvPrior" {
+                collection.log_snv_prior()
+            } else {
+                collection.log_indel_prior()
+            })
+        }
+        other => panic!("no argument named {other}"),
+    }
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let rows = rows();
+    assert_eq!(rows.len(), 21, "the golden's row count");
+    for (kind, label, payload) in &rows {
+        match kind.as_str() {
+            "list" => {
+                let classes = build_filters_list(&mode(label));
+                assert_eq!(
+                    format!("{}={}", classes.len(), classes.join(",")),
+                    *payload,
+                    "list {label}"
+                );
+            }
+            "argument" => {
+                let (name, expected) = payload.split_once('=').expect("a value");
+                assert_eq!(
+                    argument_value(label, name),
+                    expected,
+                    "argument {label} {name}"
+                );
+            }
+            other => panic!("no row kind {other}"),
+        }
+    }
+}


### PR DESCRIPTION
Closes #377. Third of three: the measurement (#378), the golden (#379), and now the port. All 21
rows bit-identical.

With this, #340 has both halves of what it needs from the engine's construction: the ten filters and
the decision that says which of them exist.

- **Eighteen by default, twelve in mitochondrial mode, thirteen in microbial**, and
  `PolymeraseSlippageFilter` is sixteenth by default and **last** in microbial mode.
- **`NormalArtifactFilter` is in the mitochondrial list**, under a comment saying it is not. The
  `add` has no guard, so the port has none.
- **`min_median_mapping_quality` takes `&mut self`**, because `getMinMedianMappingQuality()` writes
  to the field it reads. A collection asked once with `microbial` unset answers `30` for ever after.
- **An explicit default prior is the mitochondrial prior.** The getter compares by value.

`ReadOrientationFilter`'s branch needs a fixture rather than an argument, so no golden reaches it. It
is written rather than refused: a list membership with an unambiguous position is not an arithmetic
path, and refusing to build a list would be worse than useless. The module records that it is
unmeasured.

`tools/preflight.py` green, release profile included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)