### PR TITLE
Port what a non-final pass records

### DIFF
--- a/crates/gatk-engine/src/accumulate_data.rs
+++ b/crates/gatk-engine/src/accumulate_data.rs
@@ -1,0 +1,221 @@
+//! `Mutect2FilteringEngine.accumulateData` and the pass schedule `FilterMutectCalls` drives it with,
+//! ported from `org.broadinstitute.hellbender.tools.walkers.mutect.filtering` (GATK 4.6.2.0).
+//!
+//! # Four passes, not two
+//!
+//! ```java
+//! private static final int NUMBER_OF_LEARNING_PASSES = 2;
+//! protected int numberOfPasses() { return NUMBER_OF_LEARNING_PASSES + 2; }
+//! ```
+//!
+//! Passes 0, 1 and 2 all accumulate; only 0 and 1 learn parameters afterwards. Pass 2 accumulates a
+//! whole traversal's worth of data and uses it **only** to relearn the threshold, the filters'
+//! parameters being deliberately frozen: "it's important for filter parameters to stay the same and
+//! only learn the threshold in the final pass so that the final threshold used corresponds exactly
+//! to the filters". Pass 3 applies the filters and writes.
+//!
+//! # A record whose only alternate is `<NON_REF>` is skipped
+//!
+//! ```java
+//! if (vc.getAlleles().stream().noneMatch(a -> a.isNonReference() && !a.isNonRefAllele())) {
+//!     return;
+//! }
+//! ```
+//!
+//! `isNonReference()` is true of `<NON_REF>` as well, so the guard reads "no alternate other than
+//! `<NON_REF>`". A GVCF-mode site contributes to neither the clustering model nor the threshold, and
+//! a record with no alternate at all is skipped by the same test. A symbolic alternate that is
+//! **not** `<NON_REF>` is not skipped, and still accumulates nothing: the symbolic removal inside
+//! `ErrorProbabilities` has already emptied every list. Two records reach the same three zeroes by
+//! different routes.
+//!
+//! # The three accumulators do not move together
+//!
+//! `record` drops an alternate whose artifact or non-somatic probability is an obvious artifact,
+//! counting the first case, while the threshold calculator is fed the combined probabilities
+//! regardless. A triallelic record whose two alternates are both obvious artifacts accumulates no
+//! clustering data, two probabilities and two obvious artifacts.
+//!
+//! # A record with no `TLOD` is a refusal
+//!
+//! The reference dereferences `tumorLogOdds.length` inside `record`, which is a
+//! `NullPointerException` rather than a skip: a VCF missing that annotation crashes a non-final
+//! pass. One difference the golden cannot see: by the time it throws, `record` has already zeroed
+//! the symbolic entries of the caller's depth array. This port refuses before calling `record`, so
+//! the caller's array is untouched.
+
+use crate::somatic_clustering_model::{AlternateAllele, RecordError, SomaticClusteringModel};
+
+/// `FilterMutectCalls.NUMBER_OF_LEARNING_PASSES`.
+pub const NUMBER_OF_LEARNING_PASSES: i32 = 2;
+
+/// `numberOfPasses()`: the learning passes, one for the threshold, and one for calling.
+pub const NUMBER_OF_PASSES: i32 = NUMBER_OF_LEARNING_PASSES + 2;
+
+/// What `nthPassApply` does in pass `n`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PassAction {
+    /// `filteringEngine.accumulateData(...)`, for `n <= NUMBER_OF_LEARNING_PASSES`.
+    Accumulate,
+    /// `vcfWriter.add(filteringEngine.applyFiltersAndAccumulateOutputStats(...))`.
+    ApplyAndWrite,
+}
+
+/// What `afterNthPass` does after pass `n`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AfterPassAction {
+    /// `learnParameters()`, for `n < NUMBER_OF_LEARNING_PASSES`.
+    LearnParameters,
+    /// `learnThreshold()` alone, at `n == NUMBER_OF_LEARNING_PASSES`: the filters are frozen.
+    LearnThresholdOnly,
+    /// `writeFilteringStats(...)`.
+    WriteFilteringStats,
+}
+
+/// `nthPassApply`'s schedule. `None` is the `ShouldNeverReachHereException`.
+pub fn action_for_pass(pass: i32) -> Option<PassAction> {
+    if pass < 0 {
+        None
+    } else if pass <= NUMBER_OF_LEARNING_PASSES {
+        Some(PassAction::Accumulate)
+    } else if pass == NUMBER_OF_LEARNING_PASSES + 1 {
+        Some(PassAction::ApplyAndWrite)
+    } else {
+        None
+    }
+}
+
+/// `afterNthPass`'s schedule. `None` is the `ShouldNeverReachHereException`.
+pub fn action_after_pass(pass: i32) -> Option<AfterPassAction> {
+    if pass < 0 {
+        None
+    } else if pass < NUMBER_OF_LEARNING_PASSES {
+        Some(AfterPassAction::LearnParameters)
+    } else if pass == NUMBER_OF_LEARNING_PASSES {
+        Some(AfterPassAction::LearnThresholdOnly)
+    } else if pass == NUMBER_OF_LEARNING_PASSES + 1 {
+        Some(AfterPassAction::WriteFilteringStats)
+    } else {
+        None
+    }
+}
+
+/// One alternate allele, as the accumulation guard and the clustering model each see it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AccumulationAllele {
+    pub allele: AlternateAllele,
+    /// `Allele.isNonRefAllele()`, which is true of `<NON_REF>` alone and not of every symbolic
+    /// allele.
+    pub non_ref: bool,
+}
+
+/// What the accumulation refuses.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AccumulateError {
+    /// The `NullPointerException` on `tumorLogOdds.length` when the record has no `TLOD`.
+    NoTumorLogOdds,
+    /// What `record` itself refuses.
+    Record(RecordError),
+}
+
+impl AccumulateError {
+    pub fn class(&self) -> &'static str {
+        match self {
+            AccumulateError::NoTumorLogOdds => "java.lang.NullPointerException",
+            AccumulateError::Record(_) => "java.lang.IllegalArgumentException",
+        }
+    }
+
+    pub fn message(&self) -> String {
+        match self {
+            AccumulateError::NoTumorLogOdds => {
+                "Cannot read the array length because \"tumorLogOdds\" is null".to_string()
+            }
+            AccumulateError::Record(_) => {
+                "tumorADs must have one entry per allele including the ref allele".to_string()
+            }
+        }
+    }
+}
+
+impl From<RecordError> for AccumulateError {
+    fn from(error: RecordError) -> Self {
+        AccumulateError::Record(error)
+    }
+}
+
+/// `accumulateData`, without the filters' own accumulation, which each filter owns.
+///
+/// `combined_probabilities` is `errorProbabilities.getCombinedErrorProbabilities()`; the artifact and
+/// non-somatic lists are the other two the model reads. `tumor_allele_depths` is written through, as
+/// the reference writes through the array it is handed.
+///
+/// Returns `false` when the guard skipped the record without touching anything.
+#[allow(clippy::too_many_arguments)]
+pub fn accumulate_data(
+    model: &mut SomaticClusteringModel,
+    accumulated_error_probabilities: &mut Vec<f64>,
+    alternates: &[AccumulationAllele],
+    tumor_allele_depths: &mut [i32],
+    tumor_log_odds: Option<&[f64]>,
+    artifact_probabilities: &[f64],
+    non_somatic_probabilities: &[f64],
+    combined_probabilities: &[f64],
+    reference_length: i32,
+) -> Result<bool, AccumulateError> {
+    // `noneMatch(a -> a.isNonReference() && !a.isNonRefAllele())`: no alternate other than
+    // `<NON_REF>`, which a record with no alternate at all also satisfies.
+    if !alternates.iter().any(|alternate| !alternate.non_ref) {
+        return Ok(false);
+    }
+
+    let Some(tumor_log_odds) = tumor_log_odds else {
+        return Err(AccumulateError::NoTumorLogOdds);
+    };
+
+    let alleles: Vec<AlternateAllele> = alternates.iter().map(|a| a.allele).collect();
+    model.record(
+        tumor_allele_depths,
+        tumor_log_odds,
+        artifact_probabilities,
+        non_somatic_probabilities,
+        &alleles,
+        reference_length,
+    )?;
+    // `thresholdCalculator.addCombinedErrorProbabilites(...)`, spelled as the reference spells it.
+    accumulated_error_probabilities.extend_from_slice(combined_probabilities);
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The schedule, which is the thing a driver is most likely to get wrong.
+    #[test]
+    fn three_passes_accumulate_and_only_two_of_them_learn() {
+        assert_eq!(NUMBER_OF_PASSES, 4);
+        for pass in 0..=2 {
+            assert_eq!(
+                action_for_pass(pass),
+                Some(PassAction::Accumulate),
+                "pass {pass}"
+            );
+        }
+        assert_eq!(action_for_pass(3), Some(PassAction::ApplyAndWrite));
+        assert_eq!(action_for_pass(4), None, "past the last pass");
+
+        assert_eq!(action_after_pass(0), Some(AfterPassAction::LearnParameters));
+        assert_eq!(action_after_pass(1), Some(AfterPassAction::LearnParameters));
+        // The third accumulating pass learns the threshold ALONE: the filters stay as they were.
+        assert_eq!(
+            action_after_pass(2),
+            Some(AfterPassAction::LearnThresholdOnly)
+        );
+        assert_eq!(
+            action_after_pass(3),
+            Some(AfterPassAction::WriteFilteringStats)
+        );
+        assert_eq!(action_after_pass(4), None);
+    }
+}

--- a/crates/gatk-engine/src/lib.rs
+++ b/crates/gatk-engine/src/lib.rs
@@ -5,6 +5,7 @@
 //! restricts itself to. A tool given the wrong interval reads the wrong data and every number it
 //! produces is wrong in a way no downstream comparison can attribute.
 
+pub mod accumulate_data;
 pub mod activity_profile;
 pub mod alignment_state;
 pub mod alignment_utils;

--- a/crates/gatk-engine/tests/accumulate_data.rs
+++ b/crates/gatk-engine/tests/accumulate_data.rs
@@ -1,0 +1,221 @@
+//! Conformance for `accumulateData` and the pass schedule against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/AccumulateDataDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **four passes, not two**, three of which accumulate and only two of which learn parameters;
+//!  * **a record whose only alternate is `<NON_REF>` is skipped**, as is one with no alternate;
+//!  * **a record with no `TLOD` is a refusal**, not a skip;
+//!  * **and the three accumulators do not move together**: a triallelic record whose alternates are
+//!    both obvious artifacts accumulates no clustering data, two probabilities and two obvious
+//!    artifacts.
+//!
+//! # What the golden pins here, and what it does not
+//!
+//! The `accumulated` rows are **counts**, not values: the clustering model's data size, the
+//! threshold calculator's probability count, and the obvious-artifact count. Those counts name which
+//! branch each alternate took, and this test supplies probabilities on that branch. What it does not
+//! do is recompute the probabilities the eighteen real filters produced for these records, which
+//! needs the engine assembled around them; that is its own slice. So this compares the control flow
+//! exactly and the arithmetic not at all, which is what the golden holds.
+
+use gatk_corpus as corpus;
+use gatk_engine::accumulate_data::{
+    accumulate_data, action_after_pass, action_for_pass, AccumulationAllele, AfterPassAction,
+    PassAction, NUMBER_OF_LEARNING_PASSES, NUMBER_OF_PASSES,
+};
+use gatk_engine::somatic_clustering_model::{
+    AlternateAllele, PriorArguments, SomaticClusteringModel,
+};
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/accumulate_data.txt.gz"),
+    )
+}
+
+fn rows() -> Vec<(String, String, String)> {
+    golden()
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            (
+                fields.next().expect("a kind").to_string(),
+                fields.next().expect("a label").to_string(),
+                fields.next().expect("a payload").to_string(),
+            )
+        })
+        .collect()
+}
+
+fn substitution() -> AccumulationAllele {
+    AccumulationAllele {
+        allele: AlternateAllele {
+            length: 1,
+            symbolic: false,
+        },
+        non_ref: false,
+    }
+}
+
+fn non_ref() -> AccumulationAllele {
+    AccumulationAllele {
+        allele: AlternateAllele {
+            length: 0,
+            symbolic: true,
+        },
+        non_ref: true,
+    }
+}
+
+/// `<DEL>`: symbolic, and **not** `<NON_REF>`, so the guard does not skip it.
+fn symbolic_deletion() -> AccumulationAllele {
+    AccumulationAllele {
+        allele: AlternateAllele {
+            length: 0,
+            symbolic: true,
+        },
+        non_ref: false,
+    }
+}
+
+/// One record's arguments. The probabilities are on the branch the golden's counts name.
+struct Case {
+    alternates: Vec<AccumulationAllele>,
+    depths: Vec<i32>,
+    tumor_log_odds: Option<Vec<f64>>,
+    artifact: Vec<f64>,
+    non_somatic: Vec<f64>,
+    combined: Vec<f64>,
+}
+
+fn case(label: &str) -> Case {
+    match label {
+        "real-alternate" | "three-records" => Case {
+            alternates: vec![substitution()],
+            depths: vec![80, 20],
+            tumor_log_odds: Some(vec![46.05]),
+            artifact: vec![0.0],
+            non_somatic: vec![0.0],
+            combined: vec![0.0],
+        },
+        // Both alternates were obvious artifacts: no data, two probabilities, two counted.
+        "two-alternates" => Case {
+            alternates: vec![substitution(), substitution()],
+            depths: vec![80, 20, 5],
+            tumor_log_odds: Some(vec![46.05, 13.8]),
+            artifact: vec![0.95, 0.95],
+            non_somatic: vec![0.0, 0.0],
+            combined: vec![0.95, 0.95],
+        },
+        "only-non-ref" => Case {
+            alternates: vec![non_ref()],
+            depths: vec![80, 20],
+            tumor_log_odds: Some(vec![46.05]),
+            artifact: vec![0.0],
+            non_somatic: vec![0.0],
+            combined: vec![0.0],
+        },
+        "alternate-and-non-ref" => Case {
+            alternates: vec![substitution(), non_ref()],
+            depths: vec![80, 20, 0],
+            tumor_log_odds: Some(vec![46.05, 0.0]),
+            artifact: vec![0.0, 0.0],
+            non_somatic: vec![0.0, 0.0],
+            // `ErrorProbabilities` removed the symbolic allele's entry before the threshold saw it.
+            combined: vec![0.0],
+        },
+        // Not skipped by the guard, and the symbolic removal left nothing to accumulate.
+        "symbolic-not-non-ref" => Case {
+            alternates: vec![symbolic_deletion()],
+            depths: vec![80, 20],
+            tumor_log_odds: Some(vec![46.05]),
+            artifact: vec![0.0],
+            non_somatic: vec![0.0],
+            combined: Vec::new(),
+        },
+        "reference-only" => Case {
+            alternates: Vec::new(),
+            depths: vec![80],
+            tumor_log_odds: Some(Vec::new()),
+            artifact: Vec::new(),
+            non_somatic: Vec::new(),
+            combined: Vec::new(),
+        },
+        "no-tlod" => Case {
+            alternates: vec![substitution()],
+            depths: vec![80, 20],
+            tumor_log_odds: None,
+            artifact: vec![0.0],
+            non_somatic: vec![0.0],
+            combined: vec![0.0],
+        },
+        other => panic!("no case named {other}"),
+    }
+}
+
+/// The three counts one label produces, as the dump prints them.
+fn counts(label: &str) -> Result<String, String> {
+    let mut model = SomaticClusteringModel::new(PriorArguments::new(), None);
+    let mut probabilities = Vec::new();
+    // `three-records` puts the same record through one engine three times.
+    let times = if label == "three-records" { 3 } else { 1 };
+    for _ in 0..times {
+        let case = case(label);
+        let mut depths = case.depths.clone();
+        accumulate_data(
+            &mut model,
+            &mut probabilities,
+            &case.alternates,
+            &mut depths,
+            case.tumor_log_odds.as_deref(),
+            &case.artifact,
+            &case.non_somatic,
+            &case.combined,
+            1,
+        )
+        .map_err(|error| format!("{}:{}", error.class(), error.message()))?;
+    }
+    Ok(format!(
+        "{},{},{}",
+        model.accumulated(),
+        probabilities.len(),
+        model.obvious_artifact_count()
+    ))
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let rows = rows();
+    assert_eq!(rows.len(), 12, "the golden's row count");
+    for (kind, label, payload) in &rows {
+        match kind.as_str() {
+            "passes" => {
+                let ours = match label.as_str() {
+                    "numberOfPasses" => NUMBER_OF_PASSES,
+                    "learningPasses" => NUMBER_OF_LEARNING_PASSES,
+                    // The passes that accumulate: 0 through NUMBER_OF_LEARNING_PASSES inclusive.
+                    "accumulatingPasses" => (0..NUMBER_OF_PASSES)
+                        .filter(|pass| action_for_pass(*pass) == Some(PassAction::Accumulate))
+                        .count() as i32,
+                    // The pass that applies and writes.
+                    "applyingPass" => (0..NUMBER_OF_PASSES)
+                        .find(|pass| action_for_pass(*pass) == Some(PassAction::ApplyAndWrite))
+                        .expect("one pass applies"),
+                    other => panic!("no schedule value named {other}"),
+                };
+                assert_eq!(ours.to_string(), *payload, "passes {label}");
+            }
+            "accumulated" => assert_eq!(counts(label).expect("accumulated"), *payload, "{label}"),
+            "error" => assert_eq!(counts(label).expect_err("refused"), *payload, "{label}"),
+            other => panic!("no row kind {other}"),
+        }
+    }
+    // The schedule the golden's four numbers summarise, in full.
+    assert_eq!(
+        action_after_pass(2),
+        Some(AfterPassAction::LearnThresholdOnly)
+    );
+}


### PR DESCRIPTION
Closes #385. Third of three: the measurement (#386), the golden (#387), and now the port.

**Four passes, not two.** The two schedules are separate: `action_for_pass` says three passes
accumulate and the fourth applies, `action_after_pass` says only two learn parameters and the third
learns the **threshold alone**, so "the final threshold used corresponds exactly to the filters".

- **`AccumulationAllele` carries `non_ref` beside `symbolic`**, because the skip guard is
  `isNonReference() && !isNonRefAllele()` and `<DEL>` is symbolic without being `<NON_REF>`. A port
  that keyed the guard on "symbolic" would skip records the reference accumulates.
- **A record with no `TLOD` is a refusal**, not a skip. One difference the golden cannot see and the
  module names: the reference has already zeroed the symbolic entries of the caller's depth array
  when it dereferences the null; this port refuses first.

**What this test pins, and what it does not.** The golden's `accumulated` rows are *counts* — the
clustering data size, the threshold probability count, the obvious-artifact count. Counts name which
branch each alternate took, and the test supplies probabilities on that branch. It does **not**
recompute what the eighteen real filters answered for these records: that needs the engine assembled
around them, which is the next slice. So the control flow is compared exactly and the arithmetic not
at all, which is what the golden holds. Said in the test's own docs too, not only here.

`tools/preflight.py` green, release profile included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)