### PR TITLE
Measure the germline filter's wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,10 @@ jobs:
             index: "32/32"
             slug: "engine-assembly"
             suites: "engine-assembly"
+          - group: golden-pending
+            index: "1/1"
+            slug: "germline-wrapper"
+            suites: "germline-wrapper"
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -3891,6 +3891,39 @@
           "why": "155 rows, no files: eight records through a real engine, each printing every filter that answered in construction order, the two error-type maxima the engine exposes, the combined probability and the applied result. The records are a fully annotated biallelic site in default and mitochondrial mode, two alternates, a symbolic alternate beside a real one, a bare record with no annotations at all, a site in the panel of normals, a site with weak evidence and a site with a poor alternate base quality. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32161185422, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "germline-wrapper",
+      "status": "golden-pending",
+      "title": "The germline filter's wrapper, the last unported filter body",
+      "harness": "tools/readfilter-conformance",
+      "tools": [],
+      "why": "GermlineFilter.calculateErrorProbability and the two helpers it calls. The core germlineProbability is measured by the germline-probability suite; this is the layer that reads the record and decides what to hand it, and it is the last filter body the engine assembly still needs. TWO EARLY RETURNS BRACKET THE POPULATION FREQUENCY: below 1e-10 the answer is 0 and above 1 - 1e-10 it is 1, the frequency being Math.pow(10, -POPAF[maxLodIndex]), so a POPAF of 0 means an allele fixed in the population and answers a hard one. maxLodIndex IS CHOSEN FROM TLOD AND THEN INDEXES THREE ARRAYS with three conventions: POPAF per alternate, the depth array with + 1, and the weighted allele fractions per alternate. A TOTAL DEPTH OF ZERO ANSWERS 0, per a comment about GGA mode. THE GERMLINE HOM-ALT HYPOTHESIS IS SWITCHED OFF BY A VALUE, NOT A FLAG: an alternate allele fraction below 0.9 sets its log odds to negative infinity. THE NORMAL'S LOG ODDS ENTER NEGATED, and a record with no NLOD uses 0 rather than skipping the normal. AND WITH NO TUMOUR SEGMENTATION TABLE every sample's minor allele fraction is 0.5. WHAT THE RUN ADDED: the hom-alt switch is worth six orders of magnitude on one hundredth of allele fraction -- 2.418139476470768E-8 at 0.89 and 0.02912628351537378 at 0.9 -- so a port that rounded the comparison would be wrong by more than a rounding. And weightedAverageOfTumorAFs is a depth-weighted average that a second tumour sample moves to 0.33333333333333337 while the minor allele fraction stays 0.5, the two helpers weighting the same depths for different purposes.",
+      "compare": {
+        "mode": "lines"
+      },
+      "expect_rows": 18,
+      "expect_contains": [
+        "name\tgermline\tgermline,NON_SOMATIC,GERMQ,TLOD,POPAF",
+        "prob\tfixed-in-the-population\t[1.0]",
+        "prob\tbelow-the-epsilon\t[0.0]",
+        "prob\thom-alt-off\t[2.418139476470768E-8]",
+        "prob\thom-alt-on\t[0.02912628351537378]",
+        "prob\tno-nlod\t[2.536898466486791E-7]",
+        "prob\tsecond-allele-wins\t[0.962441621948459, 0.962441621948459]",
+        "prob\tno-depth\t[0.0]",
+        "prob\tno-tlod\t[0.0]",
+        "prob\tno-popaf\t[0.0]",
+        "weightedaf\ttwo-tumours\t[0.33333333333333337]",
+        "maf\ttwo-tumours\t0.5"
+      ],
+      "cases": [
+        {
+          "dump": "GermlineWrapperDump",
+          "golden": null,
+          "why": "18 rows, no files: the filter's identity, thirteen probabilities over records covering a rare and a common population allele, both ends of the frequency brackets, both sides of the hom-alt switch, a normal saying germline and saying somatic and saying nothing, two alternates where the second wins the log odds, a record with no depth, and both missing required annotations; and the two helpers over one tumour sample and two. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run PENDING."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/GermlineWrapperDump.java
+++ b/tools/readfilter-conformance/GermlineWrapperDump.java
@@ -1,0 +1,179 @@
+/*
+ * `GermlineFilter.calculateErrorProbability` and the two helpers it calls, taken from the reference.
+ *
+ * The core `germlineProbability` is measured by the `germline-probability` suite; this is the layer
+ * that reads the record and decides what to hand it. Six behaviours it is built to catch.
+ *
+ *   - TWO EARLY RETURNS BRACKET THE POPULATION FREQUENCY: below 1e-10 the answer is 0 and above
+ *     1 - 1e-10 it is 1, and the frequency is `Math.pow(10, -POPAF[maxLodIndex])`, so a POPAF of 0
+ *     means an allele fixed in the population and answers a hard one;
+ *   - `maxLodIndex` IS CHOSEN FROM `TLOD` AND THEN INDEXES THREE ARRAYS with three conventions:
+ *     `POPAF` per alternate, the depth array with `+ 1`, and the weighted allele fractions per
+ *     alternate;
+ *   - A TOTAL DEPTH OF ZERO ANSWERS 0, per a comment about GGA mode;
+ *   - THE GERMLINE HOM-ALT HYPOTHESIS IS SWITCHED OFF BY A VALUE, NOT A FLAG: an alternate allele
+ *     fraction below 0.9 sets its log odds to negative infinity;
+ *   - THE NORMAL'S LOG ODDS ENTER NEGATED, and a record with no `NLOD` uses 0 rather than skipping
+ *     the normal;
+ *   - AND WITH NO TUMOUR SEGMENTATION TABLE every sample's minor allele fraction is 0.5, so the
+ *     helper is a depth-weighted average of one repeated constant whose denominator is the
+ *     tumour-only depth sum.
+ *
+ * Output:
+ *
+ *     prob\t<label>\t<one probability per alternate allele>
+ *     weightedaf\t<label>\t<weightedAverageOfTumorAFs>
+ *     maf\t<label>\t<computeMinorAlleleFraction>
+ *     name\tgermline\t<filterName>,<errorType>,<annotation>,<required annotations>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: GermlineWrapperDump
+ */
+
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.GenotypeBuilder;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.GermlineFilter;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.M2FiltersArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.Mutect2FilteringEngine;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class GermlineWrapperDump {
+
+    static final Allele REF = Allele.create("A", true);
+    static final Allele ALT_C = Allele.create("C", false);
+    static final Allele ALT_G = Allele.create("G", false);
+
+    public static void main(final String[] args) throws Exception {
+        System.out.println("# GermlineWrapperDump: the germline filter's wrapper");
+
+        final GermlineFilter filter = new GermlineFilter(List.of());
+        System.out.printf("name\tgermline\t%s,%s,%s,%s%n", filter.filterName(), filter.errorType(),
+                filter.phredScaledPosteriorAnnotationName().orElse("none"), "TLOD,POPAF");
+
+        // A biallelic record with a rare population allele and a low tumour allele fraction.
+        prob("rare-allele", record(List.of(REF, ALT_C), List.of(20.0), List.of(6.0),
+                List.of(-4.0), new int[] {80, 20}, new double[] {0.2}));
+        // A common population allele.
+        prob("common-allele", record(List.of(REF, ALT_C), List.of(20.0), List.of(1.0),
+                List.of(-4.0), new int[] {80, 20}, new double[] {0.2}));
+        // Fixed in the population: `POPAF` of zero is a frequency of one.
+        prob("fixed-in-the-population", record(List.of(REF, ALT_C), List.of(20.0), List.of(0.0),
+                List.of(-4.0), new int[] {80, 20}, new double[] {0.2}));
+        // Vanishingly rare: below the epsilon, the answer is a hard zero.
+        prob("below-the-epsilon", record(List.of(REF, ALT_C), List.of(20.0), List.of(400.0),
+                List.of(-4.0), new int[] {80, 20}, new double[] {0.2}));
+
+        // The hom-alt hypothesis, switched off below an allele fraction of 0.9 and on above it.
+        prob("hom-alt-off", record(List.of(REF, ALT_C), List.of(20.0), List.of(6.0),
+                List.of(-4.0), new int[] {10, 80}, new double[] {0.89}));
+        prob("hom-alt-on", record(List.of(REF, ALT_C), List.of(20.0), List.of(6.0),
+                List.of(-4.0), new int[] {10, 80}, new double[] {0.9}));
+
+        // The normal's log odds, present and absent.
+        prob("normal-says-germline", record(List.of(REF, ALT_C), List.of(20.0), List.of(6.0),
+                List.of(-8.0), new int[] {80, 20}, new double[] {0.2}));
+        prob("normal-says-somatic", record(List.of(REF, ALT_C), List.of(20.0), List.of(6.0),
+                List.of(8.0), new int[] {80, 20}, new double[] {0.2}));
+        prob("no-nlod", record(List.of(REF, ALT_C), List.of(20.0), List.of(6.0),
+                null, new int[] {80, 20}, new double[] {0.2}));
+
+        // Two alternates, where the second wins the tumour log odds.
+        prob("second-allele-wins", record(List.of(REF, ALT_C, ALT_G), List.of(6.0, 20.0),
+                List.of(6.0, 2.0), List.of(-4.0, -4.0), new int[] {60, 20, 20},
+                new double[] {0.2, 0.2}));
+
+        // No depth at all.
+        prob("no-depth", record(List.of(REF, ALT_C), List.of(20.0), List.of(6.0),
+                List.of(-4.0), new int[] {0, 0}, new double[] {0.0}));
+
+        // The missing required annotations.
+        prob("no-tlod", stripped(List.of(REF, ALT_C), "TLOD"));
+        prob("no-popaf", stripped(List.of(REF, ALT_C), "POPAF"));
+
+        // The two helpers, on the record every case above is a variation of.
+        final VariantContext base = record(List.of(REF, ALT_C), List.of(20.0), List.of(6.0),
+                List.of(-4.0), new int[] {80, 20}, new double[] {0.2});
+        helpers("one-tumour", base);
+        // Two tumour samples with different depths and fractions: both helpers weight by depth.
+        helpers("two-tumours", twoTumours());
+    }
+
+    static Genotype tumour(final String sample, final int[] ad, final double[] alleleFractions) {
+        return new GenotypeBuilder(sample, List.of(REF, REF)).AD(ad)
+                .attribute("AF", alleleFractions).make();
+    }
+
+    static VariantContext record(final List<Allele> alleles, final List<Double> tumorLog10Odds,
+                                 final List<Double> populationAf, final List<Double> normalLog10Odds,
+                                 final int[] tumorDepths, final double[] alleleFractions) {
+        final VariantContextBuilder builder =
+                new VariantContextBuilder("dump", "chr1", 100, 100, alleles)
+                        .attribute("TLOD", tumorLog10Odds)
+                        .attribute("POPAF", populationAf)
+                        .genotypes(List.of(tumour("T1", tumorDepths, alleleFractions),
+                                new GenotypeBuilder("N1", List.of(REF, REF))
+                                        .AD(new int[] {90, 1}).make()));
+        if (normalLog10Odds != null) {
+            builder.attribute("NLOD", normalLog10Odds);
+        }
+        return builder.make();
+    }
+
+    static VariantContext stripped(final List<Allele> alleles, final String key) {
+        return new VariantContextBuilder(record(alleles, List.of(20.0), List.of(6.0),
+                List.of(-4.0), new int[] {80, 20}, new double[] {0.2})).rmAttribute(key).make();
+    }
+
+    static VariantContext twoTumours() {
+        return new VariantContextBuilder("dump", "chr1", 100, 100, List.of(REF, ALT_C))
+                .attribute("TLOD", List.of(20.0))
+                .attribute("POPAF", List.of(6.0))
+                .attribute("NLOD", List.of(-4.0))
+                .genotypes(List.of(tumour("T1", new int[] {80, 20}, new double[] {0.2}),
+                        tumour("T2", new int[] {20, 30}, new double[] {0.6}),
+                        new GenotypeBuilder("N1", List.of(REF, REF)).AD(new int[] {90, 1}).make()))
+                .make();
+    }
+
+    static Mutect2FilteringEngine engine() {
+        final Set<VCFHeaderLine> lines = new LinkedHashSet<>();
+        lines.add(new VCFHeaderLine("normal_sample", "N1"));
+        final VCFHeader header = new VCFHeader(lines, List.of("T1", "T2", "N1"));
+        return new Mutect2FilteringEngine(new M2FiltersArgumentCollection(), header,
+                new File("no-such-stats-file.tsv"));
+    }
+
+    static void prob(final String label, final VariantContext vc) {
+        final GermlineFilter filter = new GermlineFilter(List.of());
+        try {
+            System.out.printf("prob\t%s\t%s%n", label, filter.errorProbabilities(vc, engine(), null));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+
+    /** `weightedAverageOfTumorAFs`, which is public, and the private minor allele fraction. */
+    static void helpers(final String label, final VariantContext vc) throws Exception {
+        final Mutect2FilteringEngine engine = engine();
+        System.out.printf("weightedaf\t%s\t%s%n", label,
+                Arrays.toString(engine.weightedAverageOfTumorAFs(vc)));
+        final int[] alleleCounts = engine.sumADsOverSamples(vc, true, false);
+        final Method method = GermlineFilter.class.getDeclaredMethod("computeMinorAlleleFraction",
+                VariantContext.class, Mutect2FilteringEngine.class, int[].class);
+        method.setAccessible(true);
+        final double maf = (double) method.invoke(new GermlineFilter(List.of()), vc, engine, alleleCounts);
+        System.out.printf("maf\t%s\t%s%n", label, Double.toString(maf));
+    }
+}


### PR DESCRIPTION
For #392. The last filter body #389's engine assembly needs: the core `germlineProbability` is
already golden, this is the layer that reads the record. 18 rows, no files.

**The hom-alt switch is worth six orders of magnitude on one hundredth of allele fraction.**
`2.418139476470768E-8` at `0.89`, `0.02912628351537378` at `0.9`. The hypothesis is switched off by
setting its log odds to negative infinity rather than by skipping the term, so a port that rounded
that comparison would be wrong by far more than a rounding.

Also measured:

- **A `POPAF` of zero means an allele fixed in the population** and answers a hard `1.0`; below
  `1e-10` the answer is a hard `0.0`.
- **`maxLodIndex` is chosen from `TLOD` and then indexes three arrays with three conventions**:
  `POPAF` per alternate, the depths with `+ 1`, the weighted fractions per alternate.
- **A record with no `NLOD` uses zero** rather than skipping the normal, and the odds enter negated.
- **The two helpers weight the same depths for different purposes**: a second tumour sample moves
  `weightedAverageOfTumorAFs` to `0.33333333333333337` while the minor allele fraction stays `0.5`.

Golden-pending, so nothing is compared: the row count and twelve named behaviours are asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #10.
