### PR TITLE
Port the germline filter's wrapper

### DIFF
--- a/crates/gatk-engine/src/germline_filter.rs
+++ b/crates/gatk-engine/src/germline_filter.rs
@@ -33,9 +33,12 @@
 //! prior of one therefore answers `0.0` whatever the odds say, and a prior of negative infinity
 //! answers `1.0`.
 
+use crate::allele_filter::{sum_ads_over_samples, AlleleDepthTooShort, GenotypeData};
+use crate::math_utils::{max_element_index, pow10};
 use crate::natural_log_utils::{
     log1mexp, log_sum_exp, normalize_from_log_to_linear_space, NonFiniteSum,
 };
+use crate::somatic_clustering_model::{indel_length, AlternateAllele, SomaticClusteringModel};
 
 /// `germlineProbability`.
 ///
@@ -69,6 +72,222 @@ pub fn germline_probability(
     let normalized = normalize_from_log_to_linear_space(&[log_prob_germline, log_prob_somatic])?;
     // The FIRST entry: germline.
     Ok(normalized[0])
+}
+
+/// `GermlineFilter`'s identity.
+pub const FILTER_NAME: &str = "germline";
+
+/// `phredScaledPosteriorAnnotationName`, `GERMLINE_QUAL_KEY`.
+pub const ANNOTATION: &str = "GERMQ";
+
+/// `GermlineFilter.EPSILON`, which brackets the population frequency.
+pub const EPSILON: f64 = 1.0e-10;
+
+/// `MIN_ALLELE_FRACTION_FOR_GERMLINE_HOM_ALT`, below which the hom-alt hypothesis is switched off by
+/// a value rather than by a flag.
+pub const MIN_ALLELE_FRACTION_FOR_GERMLINE_HOM_ALT: f64 = 0.9;
+
+/// `NaturalLogUtils.LOG_ONE_HALF`.
+fn log_one_half() -> f64 {
+    jmath::math::log(0.5)
+}
+
+/// What the wrapper refuses.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GermlineError {
+    /// A genotype's `AD` shorter than the record's allele count.
+    AlleleDepth(AlleleDepthTooShort),
+    /// `MathUtils.addToArrayInPlace`: the arrays must have the same length, and a genotype with no
+    /// `AF` supplies a one-element default whatever the record's allele count is.
+    ArrayLengthsDiffer,
+    /// `logSumExp` or the normalisation over a sum that is not finite.
+    NonFiniteSum(NonFiniteSum),
+}
+
+impl GermlineError {
+    pub fn class(&self) -> &'static str {
+        match self {
+            GermlineError::AlleleDepth(_) => "java.lang.ArrayIndexOutOfBoundsException",
+            GermlineError::ArrayLengthsDiffer => "java.lang.IllegalArgumentException",
+            GermlineError::NonFiniteSum(_) => "java.lang.IllegalArgumentException",
+        }
+    }
+}
+
+impl From<AlleleDepthTooShort> for GermlineError {
+    fn from(error: AlleleDepthTooShort) -> Self {
+        GermlineError::AlleleDepth(error)
+    }
+}
+
+impl From<NonFiniteSum> for GermlineError {
+    fn from(error: NonFiniteSum) -> Self {
+        GermlineError::NonFiniteSum(error)
+    }
+}
+
+/// `Mutect2FilteringEngine.weightedAverageOfTumorAFs`.
+///
+/// The weights are the tumour genotypes' total depths, and the division by their sum comes last, so
+/// a record with no tumour depth divides by zero rather than refusing.
+pub fn weighted_average_of_tumor_afs<T>(
+    genotypes: &[GenotypeData<T>],
+    allele_fractions: &[Vec<f64>],
+    alternate_count: usize,
+) -> Result<Vec<f64>, GermlineError> {
+    let mut total_weight = 0.0;
+    let mut averages = vec![0.0; alternate_count];
+    for (index, genotype) in genotypes.iter().enumerate() {
+        if !genotype.tumor {
+            continue;
+        }
+        let weight: f64 = genotype.allele_depths.iter().map(|d| f64::from(*d)).sum();
+        total_weight += weight;
+        // `getAttributeAsDoubleArray(g, AF, () -> new double[] {0.0}, 0.0)`: a genotype with no `AF`
+        // supplies ONE zero, whatever the record's allele count is.
+        let sample: Vec<f64> = if allele_fractions[index].is_empty() {
+            vec![0.0]
+        } else {
+            allele_fractions[index].clone()
+        };
+        // `MathArrays.scaleInPlace` then `MathUtils.addToArrayInPlace`, which validates the lengths.
+        if sample.len() != averages.len() {
+            return Err(GermlineError::ArrayLengthsDiffer);
+        }
+        for (average, fraction) in averages.iter_mut().zip(&sample) {
+            *average += weight * fraction;
+        }
+    }
+    for average in averages.iter_mut() {
+        *average *= 1.0 / total_weight;
+    }
+    Ok(averages)
+}
+
+/// `GermlineFilter.computeMinorAlleleFraction`.
+///
+/// With no tumour segmentation table every sample's minor allele fraction is `0.5`, so this is a
+/// depth-weighted average of one repeated constant. `minor_allele_fractions` is one value per
+/// genotype, `0.5` where no segment overlaps the record; the denominator is the tumour-only depth
+/// sum the caller already computed.
+pub fn compute_minor_allele_fraction<T>(
+    genotypes: &[GenotypeData<T>],
+    minor_allele_fractions: &[f64],
+    allele_counts: &[i32],
+) -> f64 {
+    let mut weighted_sum = 0.0;
+    for (index, genotype) in genotypes.iter().enumerate() {
+        if !genotype.tumor {
+            continue;
+        }
+        let depth: f64 = genotype.allele_depths.iter().map(|d| f64::from(*d)).sum();
+        weighted_sum += minor_allele_fractions[index] * depth;
+    }
+    let total: f64 = allele_counts.iter().map(|d| f64::from(*d)).sum();
+    weighted_sum / total
+}
+
+/// `BinomialDistribution.logProbability(x)`.
+fn binomial_log_probability(trials: i32, x: i32, p: f64) -> f64 {
+    if trials == 0 {
+        return if x == 0 { 0.0 } else { f64::NEG_INFINITY };
+    }
+    if x < 0 || x > trials {
+        return f64::NEG_INFINITY;
+    }
+    jmath::saddle_point::log_binomial_probability(x, trials, p, 1.0 - p)
+}
+
+/// `GermlineFilter.calculateErrorProbability`, with `Mutect2VariantFilter`'s copy around it.
+///
+/// `tumor_log_10_odds` is `TLOD` and `population_negative_log10_af` is `POPAF`, both `None` when the
+/// annotation is absent, which the required-annotation check answers with `0.0` per allele.
+/// `normal_log_10_odds` is `NLOD`, absent meaning zero rather than a skip.
+#[allow(clippy::too_many_arguments)]
+pub fn germline_error_probabilities<T>(
+    model: &mut SomaticClusteringModel,
+    tumor_log_10_odds: Option<&[f64]>,
+    population_negative_log10_af: Option<&[f64]>,
+    normal_log_10_odds: Option<&[f64]>,
+    genotypes: &[GenotypeData<T>],
+    allele_fractions: &[Vec<f64>],
+    minor_allele_fractions: &[f64],
+    alternates: &[AlternateAllele],
+    reference_length: i32,
+) -> Result<Vec<f64>, GermlineError> {
+    let alternate_count = alternates.len();
+    let (Some(tumor_log_10_odds), Some(population_negative_log10_af)) =
+        (tumor_log_10_odds, population_negative_log10_af)
+    else {
+        return Ok(vec![0.0; alternate_count]);
+    };
+
+    // `getTumorLogOdds` converts to natural log before the maximum is taken.
+    let somatic_log_odds: Vec<f64> = tumor_log_10_odds
+        .iter()
+        .map(|value| crate::allele_likelihoods::log10_to_log(*value))
+        .collect();
+    let max_lod_index = max_element_index(&somatic_log_odds, 0, somatic_log_odds.len());
+
+    // `Math.pow(10, -POPAF[maxLodIndex])`, and the two brackets around it.
+    let population_af = pow10(-population_negative_log10_af[max_lod_index]);
+    if population_af < EPSILON {
+        return Ok(vec![0.0; alternate_count]);
+    } else if population_af > 1.0 - EPSILON {
+        return Ok(vec![1.0; alternate_count]);
+    }
+
+    let allele_counts = sum_ads_over_samples(alternate_count + 1, genotypes, true, false)?;
+    let total_count: i32 = allele_counts.iter().sum();
+    if total_count == 0 {
+        return Ok(vec![0.0; alternate_count]);
+    }
+    // The depth array carries the reference, so the alternate needs `+ 1`; the weighted fractions do
+    // not, so they take the index as it is.
+    let alt_count = allele_counts[max_lod_index + 1];
+    let alt_allele_fraction =
+        weighted_average_of_tumor_afs(genotypes, allele_fractions, alternate_count)?[max_lod_index];
+
+    let maf = compute_minor_allele_fraction(genotypes, minor_allele_fractions, &allele_counts);
+
+    // Alt minor and alt major, added and halved in log space.
+    let log_germline_likelihood = log_one_half()
+        + log_sum_exp(&[
+            binomial_log_probability(total_count, alt_count, maf),
+            binomial_log_probability(total_count, alt_count, 1.0 - maf),
+        ])?;
+    let log_somatic_likelihood = model.log_likelihood_given_somatic(total_count, alt_count)?;
+    let log_odds_of_germline_het_vs_somatic = log_germline_likelihood - log_somatic_likelihood;
+    // Switched off by a value, not by a flag.
+    let log_odds_of_germline_hom_alt_vs_somatic =
+        if alt_allele_fraction < MIN_ALLELE_FRACTION_FOR_GERMLINE_HOM_ALT {
+            f64::NEG_INFINITY
+        } else {
+            0.0
+        };
+
+    // `NLOD` is log10 and is converted; absent, it is zero rather than a skip.
+    let normal_lod = match normal_log_10_odds {
+        Some(odds) => crate::allele_likelihoods::log10_to_log(odds[max_lod_index]),
+        None => 0.0,
+    };
+
+    let prior = model
+        .log_prior_of_somatic_variant(indel_length(reference_length, alternates[max_lod_index]));
+    // The minus sign is the reference's: `NLOD` is the odds of the allele NOT being in the normal.
+    let probability = germline_probability(
+        -normal_lod,
+        log_odds_of_germline_het_vs_somatic,
+        log_odds_of_germline_hom_alt_vs_somatic,
+        population_af,
+        prior,
+    )?;
+    Ok(vec![
+        crate::mutect_engine::round_finite_precision_errors(
+            probability
+        );
+        alternate_count
+    ])
 }
 
 #[cfg(test)]

--- a/crates/gatk-engine/tests/germline_wrapper.rs
+++ b/crates/gatk-engine/tests/germline_wrapper.rs
@@ -1,0 +1,261 @@
+//! Conformance for `GermlineFilter.calculateErrorProbability` against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/GermlineWrapperDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **the hom-alt switch is worth six orders of magnitude on one hundredth of allele fraction**;
+//!  * **two early returns bracket the population frequency**, and a `POPAF` of zero is a hard one;
+//!  * **one index, three conventions**: `POPAF` per alternate, the depths with `+ 1`, the weighted
+//!    fractions per alternate;
+//!  * **a record with no `NLOD` uses zero** rather than skipping the normal;
+//!  * **and the two helpers weight the same depths for different purposes.**
+//!
+//! Every row reaches the clustering model's `exp`, so a divergence would be named in
+//! [`ULPS_APART`].
+
+use gatk_corpus as corpus;
+use gatk_engine::allele_filter::GenotypeData;
+use gatk_engine::germline_filter::{
+    compute_minor_allele_fraction, germline_error_probabilities, weighted_average_of_tumor_afs,
+    ANNOTATION, FILTER_NAME,
+};
+use gatk_engine::somatic_clustering_model::{
+    AlternateAllele, PriorArguments, SomaticClusteringModel,
+};
+use gatk_engine::tsv_table::java_double_to_string;
+
+/// The rows that need the decision 0014 allowance, and how many ulps each needs.
+///
+/// Two rows, one ulp each. Both go through `germlineProbability`, whose
+/// `normalizeFromLogToLinearSpace` reaches `StrictMath.exp` here and `Math.exp` upstream, bounded at
+/// 1 ulp by htsjdk-rs decision 0025. The other eleven probabilities are exact, including the two
+/// hard brackets and the pair either side of the hom-alt switch, which is what the suite is for.
+const ULPS_APART: [(&str, i64); 2] = [("rare-allele", 1), ("normal-says-somatic", 1)];
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/germline_wrapper.txt.gz"),
+    )
+}
+
+fn rows() -> Vec<(String, String, String)> {
+    golden()
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            (
+                fields.next().expect("a kind").to_string(),
+                fields.next().expect("a label").to_string(),
+                fields.next().expect("a payload").to_string(),
+            )
+        })
+        .collect()
+}
+
+fn substitution() -> AlternateAllele {
+    AlternateAllele {
+        length: 1,
+        symbolic: false,
+    }
+}
+
+fn tumour(depths: &[i32]) -> GenotypeData<i32> {
+    GenotypeData {
+        tumor: true,
+        allele_depths: depths.to_vec(),
+        values: Vec::new(),
+    }
+}
+
+fn normal(depths: &[i32]) -> GenotypeData<i32> {
+    GenotypeData {
+        tumor: false,
+        allele_depths: depths.to_vec(),
+        values: Vec::new(),
+    }
+}
+
+/// One record's arguments, as the dump built them.
+struct Case {
+    tumor_log_10_odds: Option<Vec<f64>>,
+    population_af: Option<Vec<f64>>,
+    normal_log_10_odds: Option<Vec<f64>>,
+    genotypes: Vec<GenotypeData<i32>>,
+    allele_fractions: Vec<Vec<f64>>,
+    alternates: Vec<AlternateAllele>,
+}
+
+/// The dump's `record(...)`: one tumour and one normal, one alternate.
+fn biallelic(
+    population_af: f64,
+    normal_log_10_odds: Option<f64>,
+    tumor_depths: &[i32],
+    allele_fraction: f64,
+) -> Case {
+    Case {
+        tumor_log_10_odds: Some(vec![20.0]),
+        population_af: Some(vec![population_af]),
+        normal_log_10_odds: normal_log_10_odds.map(|value| vec![value]),
+        genotypes: vec![tumour(tumor_depths), normal(&[90, 1])],
+        allele_fractions: vec![vec![allele_fraction], Vec::new()],
+        alternates: vec![substitution()],
+    }
+}
+
+fn case(label: &str) -> Case {
+    match label {
+        "rare-allele" | "one-tumour" => biallelic(6.0, Some(-4.0), &[80, 20], 0.2),
+        "common-allele" => biallelic(1.0, Some(-4.0), &[80, 20], 0.2),
+        "fixed-in-the-population" => biallelic(0.0, Some(-4.0), &[80, 20], 0.2),
+        "below-the-epsilon" => biallelic(400.0, Some(-4.0), &[80, 20], 0.2),
+        "hom-alt-off" => biallelic(6.0, Some(-4.0), &[10, 80], 0.89),
+        "hom-alt-on" => biallelic(6.0, Some(-4.0), &[10, 80], 0.9),
+        "normal-says-germline" => biallelic(6.0, Some(-8.0), &[80, 20], 0.2),
+        "normal-says-somatic" => biallelic(6.0, Some(8.0), &[80, 20], 0.2),
+        "no-nlod" => biallelic(6.0, None, &[80, 20], 0.2),
+        "no-depth" => biallelic(6.0, Some(-4.0), &[0, 0], 0.0),
+        "second-allele-wins" => Case {
+            tumor_log_10_odds: Some(vec![6.0, 20.0]),
+            population_af: Some(vec![6.0, 2.0]),
+            normal_log_10_odds: Some(vec![-4.0, -4.0]),
+            genotypes: vec![tumour(&[60, 20, 20]), normal(&[90, 1, 0])],
+            allele_fractions: vec![vec![0.2, 0.2], Vec::new()],
+            alternates: vec![substitution(), substitution()],
+        },
+        "no-tlod" => Case {
+            tumor_log_10_odds: None,
+            ..biallelic(6.0, Some(-4.0), &[80, 20], 0.2)
+        },
+        "no-popaf" => Case {
+            population_af: None,
+            ..biallelic(6.0, Some(-4.0), &[80, 20], 0.2)
+        },
+        "two-tumours" => Case {
+            genotypes: vec![tumour(&[80, 20]), tumour(&[20, 30]), normal(&[90, 1])],
+            allele_fractions: vec![vec![0.2], vec![0.6], Vec::new()],
+            ..biallelic(6.0, Some(-4.0), &[80, 20], 0.2)
+        },
+        other => panic!("no case named {other}"),
+    }
+}
+
+/// The filter's answer, as `Mutect2VariantFilter` copies it to every alternate.
+fn probabilities(label: &str) -> Vec<f64> {
+    let case = case(label);
+    let mut model = SomaticClusteringModel::new(PriorArguments::new(), None);
+    // No tumour segmentation table, so every sample's minor allele fraction is 0.5.
+    let minor = vec![0.5; case.genotypes.len()];
+    germline_error_probabilities(
+        &mut model,
+        case.tumor_log_10_odds.as_deref(),
+        case.population_af.as_deref(),
+        case.normal_log_10_odds.as_deref(),
+        &case.genotypes,
+        &case.allele_fractions,
+        &minor,
+        &case.alternates,
+        1,
+    )
+    .expect("answered")
+}
+
+fn printed(values: &[f64]) -> String {
+    let parts: Vec<String> = values.iter().map(|v| java_double_to_string(*v)).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+/// Compare as text, with the decision 0014 allowance named row by row; every divergence is
+/// reported rather than panicked on, so one run names them all.
+fn same(ours: &str, payload: &str, label: &str, complaints: &mut Vec<String>) {
+    if ours == payload {
+        return;
+    }
+    let allowance = ULPS_APART
+        .iter()
+        .find(|(name, _)| *name == label)
+        .map(|(_, ulps)| *ulps);
+    let ours_values: Vec<&str> = ours
+        .trim_matches(|c| c == '[' || c == ']')
+        .split(", ")
+        .collect();
+    let theirs: Vec<&str> = payload
+        .trim_matches(|c| c == '[' || c == ']')
+        .split(", ")
+        .collect();
+    if ours_values.len() != theirs.len() {
+        complaints.push(format!("{label}: ours {ours}, reference {payload}"));
+        return;
+    }
+    let mut worst = 0i64;
+    for (ours, expected) in ours_values.iter().zip(&theirs) {
+        if ours == expected {
+            continue;
+        }
+        let (a, b): (f64, f64) = (
+            ours.parse().expect("a double"),
+            expected.parse().expect("a double"),
+        );
+        worst = worst.max((a.to_bits() as i64 - b.to_bits() as i64).abs());
+    }
+    match allowance {
+        Some(ulps) if worst <= ulps => {}
+        _ => complaints.push(format!(
+            "{label}: {worst} ulps apart (ours {ours}, reference {payload})"
+        )),
+    }
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let rows = rows();
+    assert_eq!(rows.len(), 18, "the golden's row count");
+    let mut complaints: Vec<String> = Vec::new();
+    for (kind, label, payload) in &rows {
+        match kind.as_str() {
+            "name" => assert_eq!(
+                *payload,
+                format!("{FILTER_NAME},NON_SOMATIC,{ANNOTATION},TLOD,POPAF")
+            ),
+            "prob" => same(
+                &printed(&probabilities(label)),
+                payload,
+                label,
+                &mut complaints,
+            ),
+            "weightedaf" => {
+                let case = case(label);
+                let ours = weighted_average_of_tumor_afs(
+                    &case.genotypes,
+                    &case.allele_fractions,
+                    case.alternates.len(),
+                )
+                .expect("averaged");
+                // `Arrays.toString(double[])`, which is the same shape as a list's.
+                same(&printed(&ours), payload, label, &mut complaints);
+            }
+            "maf" => {
+                let case = case(label);
+                let minor = vec![0.5; case.genotypes.len()];
+                let allele_counts = gatk_engine::allele_filter::sum_ads_over_samples(
+                    case.alternates.len() + 1,
+                    &case.genotypes,
+                    true,
+                    false,
+                )
+                .expect("summed");
+                let ours = compute_minor_allele_fraction(&case.genotypes, &minor, &allele_counts);
+                same(
+                    &java_double_to_string(ours),
+                    payload,
+                    label,
+                    &mut complaints,
+                );
+            }
+            other => panic!("no row kind {other}"),
+        }
+    }
+    assert!(complaints.is_empty(), "{}", complaints.join("\n"));
+}


### PR DESCRIPTION
Closes #392. Third of three: the measurement (#393), the golden (#394), and now the port. The last
filter body #389's engine assembly needed.

Sixteen of eighteen rows bit-identical; two named one-ulp allowances, both through
`germlineProbability`'s `normalizeFromLogToLinearSpace`, which reaches `StrictMath.exp` here and
`Math.exp` upstream (htsjdk-rs decision 0025).

**The pair either side of the hom-alt switch is exact**, which is what matters most here:
`2.418139476470768E-8` at an allele fraction of `0.89` and `0.02912628351537378` at `0.9`. The
hypothesis is switched off by setting its log odds to negative infinity, not by skipping the term.

Also kept as measured:

- **Both frequency brackets**, exact, and a `POPAF` of zero answering a hard `1.0`.
- **One index, three conventions**: `POPAF` per alternate, the depths with `+ 1`, the weighted
  fractions per alternate.
- **`weightedAverageOfTumorAFs` divides by the total weight last**, so no tumour depth divides by
  zero rather than refusing, and a genotype with no `AF` supplies *one* zero whatever the record's
  allele count is — which `addToArrayInPlace` then refuses on a multiallelic record. The port
  reproduces both.

`tools/preflight.py` green, release profile included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)