### PR TITLE
Drop the pin nothing resolved, and make the gate notice next time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,15 +64,27 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --release
 
-      - name: The ports below are pinned by revision, not by branch
+      - name: The ports below are pinned by revision, and every revision resolves
         # GATK's build.gradle pins picardVersion and htsjdkVersion. A floating dependency would let
         # the layer underneath change under a byte-identity claim without anything failing.
+        #
+        # Checking the FORM of the pin is not enough. `picard-analysis` carried htsjdk-rs's SHA on a
+        # picard-rs URL for months and nothing noticed, because no crate depended on it: cargo never
+        # resolved the pin, so it never had to exist. Every revision named in Cargo.toml must also
+        # appear in Cargo.lock, which is cargo's own record of having resolved it.
         run: |
           if grep -E '^(htsjdk|picard|jmath)[a-z-]* = \{ git' Cargo.toml | grep -qv 'rev = "'; then
             echo "a dependency is not pinned to a revision"
             exit 1
           fi
-          grep -c 'rev = "' Cargo.toml
+          revisions=$(grep -oE 'rev = "[0-9a-f]+"' Cargo.toml | grep -oE '[0-9a-f]+' | sort -u)
+          for revision in $revisions; do
+            if ! grep -q "$revision" Cargo.lock; then
+              echo "revision $revision is pinned in Cargo.toml and resolved nowhere in Cargo.lock"
+              exit 1
+            fi
+          done
+          echo "$revisions" | wc -l
 
 # The jobs below this line are generated from tools/conformance/manifest.json by
 # tools/conformance/generate_ci.py. Edit the manifest, not this file: the `guard` job

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,11 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 #
 # The direction is upstream's: Main.getPackageList() returns
 # ["org.broadinstitute.hellbender", "picard"], which is why `gatk MarkDuplicates` runs Picard's
-# code, and why gatk-rs depends on picard-rs here.
+# code, and why gatk-rs will depend on picard-rs when a crate here needs it. There is no
+# `picard-analysis` line yet on purpose: one stood here for months carrying htsjdk-rs's SHA on
+# picard-rs's URL, and nothing noticed, because no crate depended on it and cargo therefore never
+# resolved it. A pin nothing resolves is a pin nothing checks, so the line arrives with its first
+# caller.
 [workspace.dependencies]
 htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
 htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
@@ -24,4 +28,3 @@ htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66ba
 htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
 htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
 jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
-picard-analysis = { git = "https://github.com/IPNP-BIPN/picard-rs", rev = "d0abc933b84337868ab26af8fb9e53ce48d50351" }

--- a/tools/conformance/ci.template.yml
+++ b/tools/conformance/ci.template.yml
@@ -64,15 +64,27 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --release
 
-      - name: The ports below are pinned by revision, not by branch
+      - name: The ports below are pinned by revision, and every revision resolves
         # GATK's build.gradle pins picardVersion and htsjdkVersion. A floating dependency would let
         # the layer underneath change under a byte-identity claim without anything failing.
+        #
+        # Checking the FORM of the pin is not enough. `picard-analysis` carried htsjdk-rs's SHA on a
+        # picard-rs URL for months and nothing noticed, because no crate depended on it: cargo never
+        # resolved the pin, so it never had to exist. Every revision named in Cargo.toml must also
+        # appear in Cargo.lock, which is cargo's own record of having resolved it.
         run: |
           if grep -E '^(htsjdk|picard|jmath)[a-z-]* = \{ git' Cargo.toml | grep -qv 'rev = "'; then
             echo "a dependency is not pinned to a revision"
             exit 1
           fi
-          grep -c 'rev = "' Cargo.toml
+          revisions=$(grep -oE 'rev = "[0-9a-f]+"' Cargo.toml | grep -oE '[0-9a-f]+' | sort -u)
+          for revision in $revisions; do
+            if ! grep -q "$revision" Cargo.lock; then
+              echo "revision $revision is pinned in Cargo.toml and resolved nowhere in Cargo.lock"
+              exit 1
+            fi
+          done
+          echo "$revisions" | wc -l
 
 # {{ORACLE_JOBS}}
 

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -67,9 +67,16 @@ def main():
     if not arguments.fast:
         # CI tests in release. A debug-only run has passed while release failed before.
         step("cargo test --release", ["cargo", "test", "--workspace", "--release"])
-    step("The ports below are pinned by revision, not by branch",
+    step("The ports below are pinned by revision, and every revision resolves",
          'if grep -E \'^(htsjdk|picard|jmath)[a-z-]* = \\{ git\' Cargo.toml | grep -qv \'rev = "\'; '
-         'then echo "a dependency is not pinned to a revision"; exit 1; fi', shell=True)
+         'then echo "a dependency is not pinned to a revision"; exit 1; fi; '
+         # Checking the form of the pin is not enough: one pin named the wrong repository's SHA for
+         # months because no crate depended on it, so cargo never resolved it. Cargo.lock is cargo's
+         # own record of having resolved a revision.
+         'for revision in $(grep -oE \'rev = "[0-9a-f]+"\' Cargo.toml | grep -oE \'[0-9a-f]+\' | sort -u); do '
+         'if ! grep -q "$revision" Cargo.lock; then '
+         'echo "revision $revision is pinned in Cargo.toml and resolved nowhere in Cargo.lock"; exit 1; fi; done',
+         shell=True)
 
     # dashboard
     step("docs/STATUS.md is generated, not written",


### PR DESCRIPTION
Closes #352.

`picard-analysis` carried htsjdk-rs's forty hex digits on picard-rs's URL. It had been wrong for
months and nothing noticed, because no crate declared the dependency: cargo never resolved the pin,
so it never had to exist, and `Cargo.lock` had no entry for it at all.

**The line is removed rather than repinned.** A pin nothing resolves is a pin nothing checks. The
comment above it stays — the direction is real, `Main.getPackageList()` returns
`["org.broadinstitute.hellbender", "picard"]`, which is why `gatk MarkDuplicates` runs Picard's code
— and now says that the line arrives with its first caller.

**The gate now checks that every pinned revision appears in `Cargo.lock`.** Checking the *form* of the
pin passed on a revision naming the wrong repository; `Cargo.lock` is cargo's own record of having
resolved one. A workspace dependency no crate uses fails the gate instead of rotting in it.
`tools/preflight.py` carries the same check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)