### PR TITLE
Measure String.format("%.Nf"), which is not the exact expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,10 @@ jobs:
             index: "32/32"
             slug: "engine-assembly-germline-wrapper"
             suites: "engine-assembly germline-wrapper"
+          - group: golden-pending
+            index: "1/1"
+            slug: "string-format"
+            suites: "string-format"
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -1726,6 +1726,39 @@
       ]
     },
     {
+      "id": "string-format",
+      "status": "golden-pending",
+      "title": "String.format(\"%.Nf\") over the shortest digits, not the exact expansion",
+      "harness": "tools/readfilter-conformance",
+      "tools": [],
+      "why": "java.util.Formatter's %f conversion, which gatk_engine::java_format::format_decimals ports. IT IS NOT THE EXACT DECIMAL EXPANSION OF THE DOUBLE. The Formatter takes the digits Double.toString would produce -- the shortest that round-trip -- and pads or rounds THOSE to the requested scale. A VALUE WHOSE SHORTEST FORM ENDS IN 5 THEREFORE ROUNDS UP EVEN WHEN ITS EXACT EXPANSION DOES NOT: 2.675 is 2.67499999999999982... exactly, and Java prints 2.68 where a formatter working from the expansion prints 2.67, which is what C's printf prints. A LARGE VALUE IS PADDED WITH ZEROS, NOT EXPANDED: 1e300 is a one and three hundred zeros, not the 1000000000000000052504760255204420248704... the double actually is. THE ROUNDING IS HALF_UP ON THOSE DIGITS, not half-even, so 0.0625 at three places is 0.063 where Rust's own formatter answers 0.062. AND THE THREE NON-FINITE SPELLINGS HAVE NO SIGN ON NaN. Each value's Double.toString is printed beside its formattings, so the golden shows which digits the conversion started from.",
+      "compare": {
+        "mode": "lines"
+      },
+      "expect_rows": 54,
+      "expect_contains": [
+        "tostring\ttwo-point-six-seven-five\t2.675",
+        "format\ttwo-point-six-seven-five\t2=2.68",
+        "format\tone-sixteenth\t3=0.063",
+        "format\tone-point-zero-zero-five\t2=1.01",
+        "format\tone-e-twenty-one\t0=1000000000000000000000",
+        "format\tnegative-zero\t2=-0.00",
+        "format\tnegative\t2=-2.68",
+        "format\tnan\t2=NaN",
+        "format\tinfinity\t2=Infinity",
+        "format\tnegative-infinity\t2=-Infinity",
+        "format\tnine-nine-nine\t2=10.00",
+        "format\tmin-normal\t3=0.000"
+      ],
+      "cases": [
+        {
+          "dump": "StringFormatDump",
+          "golden": null,
+          "why": "54 rows, no files: twenty values, each with its Double.toString beside one to five formattings. The values are the four ties where the shortest digits and the exact expansion disagree, five magnitudes from 1e21 to Double.MIN_VALUE, the three percentages ClipReads prints, two carries that run the whole way up, zero and negative zero, a negative tie, and the three non-finite spellings. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run PENDING."
+        }
+      ]
+    },
+    {
       "id": "allele-pseudo-depth",
       "status": "oracle-backed",
       "title": "DD and DF, the annotation G1.9 was opened for",

--- a/tools/readfilter-conformance/StringFormatDump.java
+++ b/tools/readfilter-conformance/StringFormatDump.java
@@ -1,0 +1,67 @@
+/*
+ * `String.format("%.Nf", x)`, taken from the reference.
+ *
+ * Not the exact decimal expansion of the double. `java.util.Formatter` takes the digits
+ * `Double.toString` would produce -- the shortest that round-trip -- and pads or rounds THOSE to the
+ * requested scale. Four consequences this is built to catch.
+ *
+ *   - A VALUE WHOSE SHORTEST FORM ENDS IN 5 ROUNDS UP EVEN WHEN ITS EXACT EXPANSION DOES NOT.
+ *     `2.675` is `2.67499999999999982...` exactly, and Java prints `2.68` where a formatter working
+ *     from the expansion prints `2.67`. C's printf prints `2.67`;
+ *   - A LARGE VALUE IS PADDED WITH ZEROS, NOT EXPANDED. `1e300` is a one and three hundred zeros,
+ *     not the 1000000000000000052504760255204420248704... the double actually is;
+ *   - THE ROUNDING IS HALF_UP ON THOSE DIGITS, not half-even, so `0.0625` at three places is
+ *     `0.063` where Rust's own formatter answers `0.062`;
+ *   - AND THE THREE NON-FINITE SPELLINGS HAVE NO SIGN ON NaN.
+ *
+ * Output:
+ *
+ *     format\t<label>\t<places>=<formatted>
+ *     tostring\t<label>\t<Double.toString>
+ *
+ * Usage: StringFormatDump
+ */
+
+import java.util.List;
+
+public class StringFormatDump {
+
+    public static void main(final String[] args) {
+        System.out.println("# StringFormatDump: String.format(\"%.Nf\") over the shortest digits");
+
+        // The ties, where the shortest digits and the exact expansion disagree.
+        value("two-point-six-seven-five", 2.675, List.of(0, 1, 2, 3, 6));
+        value("one-sixteenth", 0.0625, List.of(2, 3, 4, 6));
+        value("eight-thousandths", 0.008, List.of(1, 2, 3));
+        value("one-point-zero-zero-five", 1.005, List.of(2, 3));
+        // Magnitudes, where the padding shows.
+        value("one-e-twenty-one", 1e21, List.of(0, 3));
+        value("one-e-three-hundred", 1e300, List.of(3));
+        value("max-value", Double.MAX_VALUE, List.of(3));
+        value("min-normal", Double.MIN_NORMAL, List.of(3, 320));
+        value("min-value", Double.MIN_VALUE, List.of(3, 330));
+        // The ordinary cases two ported tools reach.
+        value("two-sevenths-percent", 100.0 * 2.0 / 7.0, List.of(2));
+        value("ten-sixty-fifths-percent", 100.0 * 10.0 / 65.0, List.of(2));
+        value("all-of-it", 100.0 * 7.0 / 7.0, List.of(2));
+        // Carries that run the whole way up.
+        value("nine-nine-nine", 9.999, List.of(2));
+        value("zero-nine-nine-nine", 0.999, List.of(2));
+        // Zero and its sign.
+        value("zero", 0.0, List.of(0, 2));
+        value("negative-zero", -0.0, List.of(2));
+        value("negative", -2.675, List.of(2));
+        // The non-finite spellings.
+        value("nan", Double.NaN, List.of(2));
+        value("infinity", Double.POSITIVE_INFINITY, List.of(2));
+        value("negative-infinity", Double.NEGATIVE_INFINITY, List.of(2));
+    }
+
+    static void value(final String label, final double value, final List<Integer> places) {
+        System.out.printf("tostring\t%s\t%s%n", label, Double.toString(value));
+        for (final int scale : places) {
+            System.out.printf("format\t%s\t%d=%s%n", label, scale,
+                    String.format("%." + scale + "f", value));
+        }
+    }
+}


### PR DESCRIPTION
For #262, which was filed from a probe rather than from a golden. 54 rows, no files.

**`java.util.Formatter` does not print the exact decimal expansion of the double.** It takes the
digits `Double.toString` would produce — the shortest that round-trip — and pads or rounds *those*.

The consequence the port gets wrong is not only the large magnitudes #262 named:

| value | Java | the port today |
|---|---|---|
| `2.675` at 2 places | `2.68` | `2.67` |
| `1.005` at 2 places | `1.01` | `1.00` |
| `1e300` at 3 places | a one and 300 zeros | the exact `...052504760255204420248704...` |

`2.675` is `2.67499999999999982...` exactly, so a formatter working from the expansion rounds down.
C's printf prints `2.67` too. Java prints `2.68` because it never sees those digits.

Each value's `Double.toString` is printed beside its formattings, so the golden shows which digits the
conversion started from and not only where it ended.

Golden-pending, so nothing is compared: the row count and twelve named behaviours are asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #9.
