### PR TITLE
Round the shortest digits, not the exact expansion

### DIFF
--- a/crates/gatk-annotation/src/rank_sum.rs
+++ b/crates/gatk-annotation/src/rank_sum.rs
@@ -161,10 +161,11 @@ pub fn annotate<A: RankSumTest>(
 
 /// `String.format("%.3f", value)` for the values a Z score can take.
 ///
-/// Java's `%f` rounds HALF_UP on the *decimal* expansion of the double, which is not Rust's
-/// `{:.3}` (round-half-to-even on the same expansion). They differ on a value whose fourth decimal
-/// is exactly 5 and whose expansion terminates there, which a Z score can be: `0.0625` prints
-/// `0.063` in Java and `0.062` in Rust.
+/// Java's `%f` rounds HALF_UP on the digits `Double.toString` would produce, which is neither Rust's
+/// `{:.3}` (half-to-even on the *exact expansion*) nor a half-up rounding of that expansion. Two
+/// values a Z score can take show both differences: `0.0625` prints `0.063` in Java and `0.062` in
+/// Rust, and `1.2345` prints `1.235` in Java where a half-up rounding of the expansion, which is
+/// `1.23449999999999993...`, prints `1.234`. The `string-format` golden pins both.
 pub(crate) fn format_three_decimals(value: f64) -> String {
     format_decimals(value, 3)
 }
@@ -330,7 +331,9 @@ mod tests {
         assert_eq!(format_three_decimals(0.0625), "0.063");
         assert_eq!(format_three_decimals(-0.0625), "-0.063");
         assert_eq!(format_three_decimals(1.2344), "1.234");
-        assert_eq!(format_three_decimals(1.2345), "1.234");
+        // The double is `1.23449999999999993...`, and Java rounds the shortest digits
+        // `1.2345`, not that expansion.
+        assert_eq!(format_three_decimals(1.2345), "1.235");
         assert_eq!(format_three_decimals(0.0), "0.000");
         assert_eq!(format_three_decimals(-1.0), "-1.000");
         assert_eq!(format_three_decimals(9.9999), "10.000");

--- a/crates/gatk-engine/src/java_format.rs
+++ b/crates/gatk-engine/src/java_format.rs
@@ -6,6 +6,20 @@
 //! terminates the expansion, which is a value a ratio can easily take: `0.0625` prints `0.063` in
 //! Java and `0.062` in Rust.
 //!
+//! # It rounds the shortest digits, not the exact expansion
+//!
+//! `Formatter` does not see the double's exact decimal expansion. It takes the digits
+//! `Double.toString` would produce -- the shortest that round-trip -- and pads or rounds THOSE to the
+//! requested scale. So a value whose shortest form ends in a five rounds **up** even where its exact
+//! expansion would round down: `2.675` is `2.67499999999999982...` exactly, and Java prints `2.68`
+//! at two places where C's printf prints `2.67`. And a large value is padded with zeros rather than
+//! expanded: `1e300` is a one and three hundred zeros, not the
+//! `1000000000000000052504760255204420248704...` the double actually is.
+//!
+//! This port worked from the exact expansion until the `string-format` golden was measured, which is
+//! what #262 was filed about. It goes through [`crate::tsv_table::java_double_to_string`] now, which
+//! is the same `Double.toString` the reference's formatter starts from.
+//!
 //! The three non-finite spellings are Java's too: `NaN`, `Infinity`, `-Infinity`, with no sign on
 //! `NaN`. `ClipReads` reaches all three through `(100.0 * n) / 0` when its `--read` argument names
 //! no read at all.
@@ -21,8 +35,9 @@ pub fn format_decimals(value: f64, places: usize) -> String {
     if value.is_infinite() {
         return if value > 0.0 { "Infinity" } else { "-Infinity" }.to_string();
     }
-    // The exact decimal expansion of the double, then a half-up rounding of it.
-    let text = format!("{:.*}", 30, value.abs());
+    // The digits `Double.toString` produces, laid out as a plain decimal with one more fraction
+    // digit than the scale asks for, then a half-up rounding of THOSE.
+    let text = plain_decimal(value.abs(), places + 1);
     let (whole, fraction) = text.split_once('.').expect("a decimal point");
     let mut digits: Vec<u8> = whole
         .bytes()
@@ -50,7 +65,53 @@ pub fn format_decimals(value: f64, places: usize) -> String {
     let whole: String = digits[..split].iter().map(|d| (d + b'0') as char).collect();
     let fraction: String = digits[split..].iter().map(|d| (d + b'0') as char).collect();
     let sign = if value.is_sign_negative() { "-" } else { "" };
+    // `%.0f` prints no point at all, which is `Formatter`'s doing and not the digits'.
+    if places == 0 {
+        return format!("{sign}{whole}");
+    }
     format!("{sign}{whole}.{fraction}")
+}
+
+/// `Double.toString(value)` laid out as a plain decimal, with at least `places` fraction digits.
+///
+/// `Double.toString` answers `1.0E300` for a large value and `4.9E-324` for a tiny one; the exponent
+/// is applied by moving the point and padding with zeros, which is what `FormattedFloatingDecimal`
+/// does and is why a large value prints as a one and three hundred zeros.
+fn plain_decimal(value: f64, places: usize) -> String {
+    let shortest = crate::tsv_table::java_double_to_string(value);
+    let (mantissa, exponent) = match shortest.split_once('E') {
+        Some((mantissa, exponent)) => (mantissa, exponent.parse::<i32>().expect("an exponent")),
+        None => (shortest.as_str(), 0),
+    };
+    let point = mantissa
+        .find('.')
+        .expect("Double.toString always has a point");
+    let digits: String = mantissa.chars().filter(|c| *c != '.').collect();
+    // Where the point sits once the exponent has moved it.
+    let position = point as i32 + exponent;
+
+    let (mut whole, mut fraction) = if position <= 0 {
+        ("0".to_string(), "0".repeat((-position) as usize) + &digits)
+    } else if position as usize >= digits.len() {
+        (
+            digits.clone() + &"0".repeat(position as usize - digits.len()),
+            String::new(),
+        )
+    } else {
+        (
+            digits[..position as usize].to_string(),
+            digits[position as usize..].to_string(),
+        )
+    };
+    if whole.is_empty() {
+        whole = "0".to_string();
+    }
+    // `Double.toString`'s trailing `.0` is a digit like any other, and the padding is the
+    // formatter's.
+    while fraction.len() < places {
+        fraction.push('0');
+    }
+    format!("{whole}.{fraction}")
 }
 
 #[cfg(test)]

--- a/crates/gatk-engine/tests/string_format.rs
+++ b/crates/gatk-engine/tests/string_format.rs
@@ -1,0 +1,118 @@
+//! Conformance for `String.format("%.Nf")` against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/StringFormatDump.java`.
+//!
+//! # What this suite is for
+//!
+//!  * **the conversion rounds the shortest digits, not the exact expansion**, so `2.675` at two
+//!    places is `2.68` where C's printf answers `2.67`;
+//!  * **a large value is padded with zeros rather than expanded**;
+//!  * **the rounding is HALF_UP on those digits**, not half-even;
+//!  * **and the three non-finite spellings carry no sign on `NaN`.**
+//!
+//! Every row is compared. One is a **named divergence** rather than a match, and it is not this
+//! conversion's: `Double.toString(4.9E-324)` is `4.9E-324` in the reference and `5.0E-324` here,
+//! because the pre-JDK19 `FloatingDecimal` does not always emit the shortest digits and
+//! [`java_double_to_string`] does. `tsv_table`'s own module note already says so; this golden is the
+//! first to catch one, and #399 tracks it. The formattings of that value agree anyway, both being
+//! zeros at every scale below the point where the digits appear -- and at 330 places, where they do
+//! appear, the formatting differs by exactly those digits: `...4900000` upstream and `...5000000`
+//! here. That is the best evidence in the suite that the conversion passes `Double.toString`'s digits
+//! through rather than looking at the value: it reproduces the reference's mistake wherever the
+//! digits it is handed are the reference's.
+
+use gatk_corpus as corpus;
+use gatk_engine::java_format::format_decimals;
+use gatk_engine::tsv_table::java_double_to_string;
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/string_format.txt.gz"),
+    )
+}
+
+fn rows() -> Vec<(String, String, String)> {
+    golden()
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            (
+                fields.next().expect("a kind").to_string(),
+                fields.next().expect("a label").to_string(),
+                fields.next().expect("a payload").to_string(),
+            )
+        })
+        .collect()
+}
+
+fn value(label: &str) -> f64 {
+    match label {
+        "two-point-six-seven-five" => 2.675,
+        "one-sixteenth" => 0.0625,
+        "eight-thousandths" => 0.008,
+        "one-point-zero-zero-five" => 1.005,
+        "one-e-twenty-one" => 1e21,
+        "one-e-three-hundred" => 1e300,
+        "max-value" => f64::MAX,
+        "min-normal" => f64::MIN_POSITIVE,
+        "min-value" => 5e-324,
+        "two-sevenths-percent" => 100.0 * 2.0 / 7.0,
+        "ten-sixty-fifths-percent" => 100.0 * 10.0 / 65.0,
+        "all-of-it" => 100.0 * 7.0 / 7.0,
+        "nine-nine-nine" => 9.999,
+        "zero-nine-nine-nine" => 0.999,
+        "zero" => 0.0,
+        "negative-zero" => -0.0,
+        "negative" => -2.675,
+        "nan" => f64::NAN,
+        "infinity" => f64::INFINITY,
+        "negative-infinity" => f64::NEG_INFINITY,
+        other => panic!("no value named {other}"),
+    }
+}
+
+#[test]
+fn every_row_matches_the_golden() {
+    let rows = rows();
+    assert_eq!(rows.len(), 54, "the golden's row count");
+    for (kind, label, payload) in &rows {
+        match kind.as_str() {
+            // `Double.toString`, which is what the conversion starts from.
+            // The one row where the reference and the port differ, for a reason that belongs to
+            // `Double.toString` and not to this conversion. See the module note and #399.
+            "tostring" if label == "min-value" => {
+                assert_eq!(*payload, "4.9E-324", "the reference's digits");
+                assert_eq!(
+                    java_double_to_string(value(label)),
+                    "5.0E-324",
+                    "and the port's, which are the shortest"
+                );
+            }
+            "tostring" => assert_eq!(
+                java_double_to_string(value(label)),
+                *payload,
+                "tostring {label}"
+            ),
+            // Same cause as the row above: the digits handed in are the port's, not the
+            // reference's, and the formatting differs by exactly those digits.
+            "format" if label == "min-value" && payload.starts_with("330=") => {
+                assert!(payload.ends_with("4900000"), "the reference's digits");
+                assert!(
+                    format_decimals(value(label), 330).ends_with("5000000"),
+                    "and the port's"
+                );
+            }
+            "format" => {
+                let (places, expected) = payload.split_once('=').expect("a formatting");
+                let places: usize = places.parse().expect("a scale");
+                assert_eq!(
+                    format_decimals(value(label), places),
+                    expected,
+                    "format {label} at {places}"
+                );
+            }
+            other => panic!("no row kind {other}"),
+        }
+    }
+}


### PR DESCRIPTION
Closes #262. Third of three: the measurement (#398), the golden (#400), and now the fix.

**The difference is wider than #262 reported.** It filed two large magnitudes; the golden shows the
ordinary range is affected too, because `java.util.Formatter` never sees the double's exact expansion:

| value | Java | before |
|---|---|---|
| `2.675` at 2 | `2.68` | `2.67` |
| `1.005` at 2 | `1.01` | `1.00` |
| `1.2345` at 3 | `1.235` | `1.234` |
| `1e300` at 3 | a one and 300 zeros | the exact `...052504760255204420248704...` |

`2.675` is `2.67499999999999982...` exactly, so a half-up rounding of the expansion rounds down. C's
printf prints `2.67` too. Java prints `2.68` because it rounds the shortest digits.

**`rank_sum`'s unit test asserted the old behaviour.** It said `1.2345` prints `1.234` and its doc said
the rounding was on the expansion. Both are corrected and now point at the golden rather than at
reasoning.

**One row of the golden is a named divergence, and it is not this conversion's.**
`Double.toString(4.9E-324)` is `4.9E-324` upstream and `5.0E-324` here: the pre-JDK19
`FloatingDecimal` does not always emit the shortest digits, which `tsv_table`'s module note already
said. The conformance test asserts **both** sides so it cannot drift, and #399 tracks it. Its
consequence is the best evidence in the suite that the conversion passes the digits through rather
than looking at the value: at 330 places the formatting differs by exactly those digits.

`tools/preflight.py` green, release profile included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)