### PR TITLE
Measure the contamination model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,10 @@ jobs:
             index: "33/33"
             slug: "kernel-segmentation"
             suites: "kernel-segmentation"
+          - group: golden-pending
+            index: "1/1"
+            slug: "contamination-model"
+            suites: "contamination-model"
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4044,6 +4044,23 @@
           "why": "131 rows, no files: three data series -- a step function with two changes, a flat series with none, and a ramp where every point differs from the last -- each decomposed at a six-point kernel approximation, giving six singular values and thirty-six U entries printed as raw bits; and five changepoint runs over the same series, including the same series at a lenient and a strict penalty. The dimension is small on purpose: the question is which bits differ, not how many there are. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32183086474, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "contamination-model",
+      "status": "golden-pending",
+      "title": "The contamination model and the tool around it",
+      "harness": "tools/readfilter-conformance",
+      "tools": [],
+      "why": "CalculateContamination is the last unblocked member of the reporting-walker archetype and the decomposition under it is already ported and pinned by kernel-segmentation. This measures everything above it. THE COVERAGE FILTER USES A MEDIAN AND A MEAN, the low threshold a ratio of the median and the high threshold a ratio of the mean, both computed after dropping sites at or below MIN_COVERAGE. THE MODEL ITERATES THREE TIMES between minor allele fractions and contamination, feeding the previous contamination back in, so a port that solved once lands somewhere else. THE LOH SEARCH WALKS THE THRESHOLD DOWN in steps of 0.04 and stops at the first threshold keeping more than a quarter of the sites, so the answer depends on the order of the walk. THE STRATEGY CASCADE IS THREE STRATEGIES OVER ONE LOOP, hom alt above 0.25, hom ref down to 0.20, then the unscrupulous hom ref, returning the first estimate whose standard error is small enough relative to the estimate. THE STANDARD ERROR IS A BINARY SEARCH and the closed formula is only its fallback. THE UNSCRUPULOUS STRATEGY GOES THROUGH A PERCENTILE, so its threshold is commons-math's interpolation rather than a sorted index. AND THE SEGMENTATION IS PER CONTIG, so a contig with too few het sites for the window is one segment rather than none. The sites are built from a formula with integer counts so a port rebuilds exactly the same input.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "ContaminationModelDump",
+          "golden": null
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/ContaminationModelDump.java
+++ b/tools/readfilter-conformance/ContaminationModelDump.java
@@ -1,0 +1,193 @@
+/*
+ * ContaminationModel and the tool around it, taken from the reference.
+ *
+ * The last unblocked member of the reporting-walker archetype. The decomposition under it is
+ * already ported and pinned by `kernel-segmentation`; this measures everything above it, from the
+ * coverage filter the tool applies to the contamination estimate and its standard error.
+ *
+ * Seven behaviours this is built to catch.
+ *
+ *   - THE COVERAGE FILTER USES A MEDIAN AND A MEAN, not one or the other: the low threshold is a
+ *     ratio of the MEDIAN and the high threshold a ratio of the MEAN, and both are computed AFTER
+ *     dropping sites at or below MIN_COVERAGE, so an uncovered site that would have moved the
+ *     median is already gone;
+ *   - THE MODEL ITERATES THREE TIMES between minor allele fractions and contamination, each round
+ *     feeding the previous contamination back in, so a port that solved once lands somewhere else;
+ *   - THE LOH SEARCH WALKS THE THRESHOLD DOWN in steps of 0.04 and stops at the FIRST threshold
+ *     keeping more than a quarter of the sites, so the answer depends on the order of the walk and
+ *     not only on the sites;
+ *   - THE STRATEGY CASCADE IS THREE STRATEGIES OVER ONE LOOP: hom alt above 0.25, hom ref down to
+ *     0.20, then the unscrupulous hom ref, and it returns the first estimate whose standard error
+ *     is small enough relative to the estimate itself;
+ *   - THE STANDARD ERROR IS A BINARY SEARCH, not the closed formula: the formula is only the
+ *     fallback for when the search fails to bracket a zero;
+ *   - THE UNSCRUPULOUS STRATEGY GOES THROUGH A PERCENTILE, so its threshold is commons-math's
+ *     interpolation of the 90th percentile and not a sorted index;
+ *   - AND THE SEGMENTATION IS PER CONTIG, so a contig with too few het sites for the window is one
+ *     segment rather than none.
+ *
+ * The sites are built from a formula rather than read from a file, so a port can rebuild exactly
+ * the same input: no rounding, no RNG, integer counts throughout. The `sites` rows carry them so a
+ * port that built a different corpus fails on the corpus rather than on the model.
+ *
+ * Output:
+ *
+ *     sites\t<label>\t<index>=<contig>,<start>,<ref>,<alt>,<other>,<allele frequency bits>
+ *     coverage\t<label>\t<the starts that survive, comma separated>
+ *     segments\t<label>\t<index>=<contig>,<start>,<end>,<site count>
+ *     maf\t<label>\t<index>=<contig>,<start>,<end>,<minor allele fraction bits>
+ *     contamination\t<label>\t<estimate bits>,<standard error bits>
+ *
+ * Usage: ContaminationModelDump
+ */
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.broadinstitute.hellbender.tools.walkers.contamination.ContaminationModel;
+import org.broadinstitute.hellbender.tools.walkers.contamination.ContaminationSegmenter;
+import org.broadinstitute.hellbender.tools.walkers.contamination.MinorAlleleFractionRecord;
+import org.broadinstitute.hellbender.tools.walkers.contamination.PileupSummary;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ContaminationModelDump {
+
+    /** `CalculateContamination.MIN_COVERAGE`. */
+    static final int MIN_COVERAGE = 10;
+    /** `CalculateContamination.DEFAULT_LOW_COVERAGE_RATIO_THRESHOLD`. */
+    static final double LOW_COVERAGE_RATIO_THRESHOLD = 1.0 / 2;
+    /** `CalculateContamination.DEFAULT_HIGH_COVERAGE_RATIO_THRESHOLD`. */
+    static final double HIGH_COVERAGE_RATIO_THRESHOLD = 3.0;
+
+    public static void main(final String[] args) throws Exception {
+        System.out.println("# ContaminationModelDump: the contamination model and the tool around it");
+
+        final List<PileupSummary> tumor = new ArrayList<>();
+        tumor.addAll(sites("chr1", 200, true));
+        tumor.addAll(sites("chr2", 150, false));
+        final List<PileupSummary> normal = new ArrayList<>();
+        normal.addAll(sites("chr1", 200, false));
+
+        print("tumor", tumor);
+        print("normal", normal);
+
+        // The coverage filter, which is the first thing the tool does to either table.
+        final List<PileupSummary> filteredTumor = filterSitesByCoverage(tumor);
+        final List<PileupSummary> filteredNormal = filterSitesByCoverage(normal);
+        coverage("tumor", filteredTumor);
+        coverage("normal", filteredNormal);
+
+        // The segmentation, which is where the decomposition is reached.
+        segments("tumor", ContaminationSegmenter.findSegments(filteredTumor));
+        segments("normal", ContaminationSegmenter.findSegments(filteredNormal));
+
+        // Tumour only: one model, used both to genotype and to segment.
+        final ContaminationModel tumorModel = new ContaminationModel(filteredTumor);
+        maf("tumor-only", tumorModel.segmentationRecords());
+        contamination("tumor-only", tumorModel.calculateContaminationFromHoms(filteredTumor));
+
+        // Matched normal: the normal genotypes, the tumour segments.
+        final ContaminationModel normalModel = new ContaminationModel(filteredNormal);
+        maf("matched-normal", normalModel.segmentationRecords());
+        contamination("matched-normal", normalModel.calculateContaminationFromHoms(filteredTumor));
+
+        // A short table, below the window the segmenter needs, so the whole contig is one segment.
+        final List<PileupSummary> short_ = sites("chr3", 40, false);
+        print("short", short_);
+        final List<PileupSummary> filteredShort = filterSitesByCoverage(short_);
+        coverage("short", filteredShort);
+        segments("short", ContaminationSegmenter.findSegments(filteredShort));
+        final ContaminationModel shortModel = new ContaminationModel(filteredShort);
+        maf("short", shortModel.segmentationRecords());
+        contamination("short", shortModel.calculateContaminationFromHoms(filteredShort));
+    }
+
+    /**
+     * The corpus, from a formula. Every count is an integer computed by integer arithmetic, so
+     * there is no rounding rule for a port to disagree with.
+     *
+     * The genotype cycles hom ref, het, het, hom alt, het. When `loh` is set the second half of the
+     * contig has its hets at a minor allele fraction of a quarter rather than a half, which is the
+     * loss of heterozygosity the segmenter is supposed to find.
+     */
+    static List<PileupSummary> sites(final String contig, final int count, final boolean loh) {
+        final List<PileupSummary> sites = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            final int position = 1000 + 100 * i;
+            final double alleleFrequency = 0.05 + (i % 19) * 0.05;
+            final int depth = 50 + (i % 7) * 5;
+            final int other = i % 4 == 0 ? 1 : 0;
+            final int alt;
+            switch (i % 5) {
+                case 0:
+                    alt = 1 + i % 2;                       // hom ref, with a little error
+                    break;
+                case 3:
+                    alt = depth - other - (i % 2);         // hom alt
+                    break;
+                default:
+                    alt = (loh && i >= count / 2) ? (depth - other) / 4 : (depth - other) / 2;
+                    break;
+            }
+            final int ref = depth - alt - other;
+            sites.add(new PileupSummary(contig, position, ref, alt, other, alleleFrequency));
+        }
+        return sites;
+    }
+
+    /** `CalculateContamination.filterSitesByCoverage`, reached by reflection so it is the reference's. */
+    @SuppressWarnings("unchecked")
+    static List<PileupSummary> filterSitesByCoverage(final List<PileupSummary> sites) throws Exception {
+        final Class<?> tool = Class.forName(
+                "org.broadinstitute.hellbender.tools.walkers.contamination.CalculateContamination");
+        final Object instance = tool.getDeclaredConstructor().newInstance();
+        final Method method = tool.getDeclaredMethod("filterSitesByCoverage", List.class);
+        method.setAccessible(true);
+        return (List<PileupSummary>) method.invoke(instance, sites);
+    }
+
+    static void print(final String label, final List<PileupSummary> sites) {
+        for (int i = 0; i < sites.size(); i++) {
+            final PileupSummary site = sites.get(i);
+            System.out.printf("sites\t%s\t%d=%s,%d,%d,%d,%d,%016x%n", label, i, site.getContig(),
+                    site.getStart(), site.getRefCount(), site.getAltCount(), site.getOtherAltCount(),
+                    Double.doubleToRawLongBits(site.getAlleleFrequency()));
+        }
+    }
+
+    static void coverage(final String label, final List<PileupSummary> sites) {
+        final StringBuilder text = new StringBuilder();
+        for (final PileupSummary site : sites) {
+            if (text.length() > 0) {
+                text.append(',');
+            }
+            text.append(site.getContig()).append(':').append(site.getStart());
+        }
+        System.out.printf("coverage\t%s\t%s%n", label, text.length() == 0 ? "(none)" : text.toString());
+    }
+
+    static void segments(final String label, final List<List<PileupSummary>> segments) {
+        for (int i = 0; i < segments.size(); i++) {
+            final List<PileupSummary> segment = segments.get(i);
+            System.out.printf("segments\t%s\t%d=%s,%d,%d,%d%n", label, i,
+                    segment.get(0).getContig(), segment.get(0).getStart(),
+                    segment.get(segment.size() - 1).getEnd(), segment.size());
+        }
+    }
+
+    static void maf(final String label, final List<MinorAlleleFractionRecord> records) {
+        for (int i = 0; i < records.size(); i++) {
+            final MinorAlleleFractionRecord record = records.get(i);
+            System.out.printf("maf\t%s\t%d=%s,%d,%d,%016x%n", label, i,
+                    record.getContig(), record.getStart(), record.getEnd(),
+                    Double.doubleToRawLongBits(record.getMinorAlleleFraction()));
+        }
+    }
+
+    static void contamination(final String label, final Pair<Double, Double> answer) {
+        System.out.printf("contamination\t%s\t%016x,%016x%n", label,
+                Double.doubleToRawLongBits(answer.getLeft()),
+                Double.doubleToRawLongBits(answer.getRight()));
+    }
+}


### PR DESCRIPTION
`CalculateContamination` is the last unblocked member of G2.3 (#67). The decomposition under it is
ported and pinned (#415, #416); this measures everything above it, from the coverage filter the tool
applies to the estimate and its standard error.

**Seven behaviours the dump is built to catch:**

- **The coverage filter uses a median *and* a mean** — low threshold a ratio of the median, high
  threshold a ratio of the mean, both computed *after* dropping sites at or below `MIN_COVERAGE`.
- **The model iterates three times** between minor allele fractions and contamination, each round
  feeding the previous contamination back in.
- **The LoH search walks the threshold down** in steps of 0.04 and stops at the *first* threshold
  keeping more than a quarter of the sites.
- **The strategy cascade is three strategies over one loop** — hom alt above 0.25, hom ref down to
  0.20, then the unscrupulous hom ref — returning the first estimate whose standard error is small
  enough relative to the estimate.
- **The standard error is a binary search**; the closed formula is only its fallback.
- **The unscrupulous strategy goes through a `Percentile`**, so its threshold is commons-math's
  interpolation rather than a sorted index.
- **The segmentation is per contig**, so a contig with too few het sites for the window is one
  segment rather than none.

The corpus is built from a formula with integer counts throughout — no rounding rule, no generator —
so a port rebuilds exactly the same input, and the `sites` rows carry it so a port that built a
different corpus fails on the corpus rather than on the model. Three tables: a tumour with a loss of
heterozygosity in the second half of chr1, a matched normal without one, and a short contig below
the segmenter's window.

**606 rows**, `golden-pending`. The golden comes from this PR's CI run on the x86-64 runner, not
from a laptop (decision 0008).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #10.
