### PR TITLE
Take the htsjdk-rs that writes the header the way htsjdk writes it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=9a66bab9c9859474393ced791ee742c3feba3fd7#9a66bab9c9859474393ced791ee742c3feba3fd7"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=f6f319c56f18271126e8c39ada67c10dc9bf81ac#f6f319c56f18271126e8c39ada67c10dc9bf81ac"
 dependencies = [
  "htsjdk-bgzf",
  "md-5",
@@ -278,7 +278,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=9a66bab9c9859474393ced791ee742c3feba3fd7#9a66bab9c9859474393ced791ee742c3feba3fd7"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=f6f319c56f18271126e8c39ada67c10dc9bf81ac#f6f319c56f18271126e8c39ada67c10dc9bf81ac"
 dependencies = [
  "flate2",
  "libz-sys",
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=9a66bab9c9859474393ced791ee742c3feba3fd7#9a66bab9c9859474393ced791ee742c3feba3fd7"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=f6f319c56f18271126e8c39ada67c10dc9bf81ac#f6f319c56f18271126e8c39ada67c10dc9bf81ac"
 dependencies = [
  "flate2",
  "htsjdk-bam",
@@ -296,7 +296,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=9a66bab9c9859474393ced791ee742c3feba3fd7#9a66bab9c9859474393ced791ee742c3feba3fd7"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=f6f319c56f18271126e8c39ada67c10dc9bf81ac#f6f319c56f18271126e8c39ada67c10dc9bf81ac"
 dependencies = [
  "htsjdk-tribble",
  "jmath",
@@ -315,7 +315,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=9a66bab9c9859474393ced791ee742c3feba3fd7#9a66bab9c9859474393ced791ee742c3feba3fd7"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=f6f319c56f18271126e8c39ada67c10dc9bf81ac#f6f319c56f18271126e8c39ada67c10dc9bf81ac"
 
 [[package]]
 name = "lexical-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # resolved it. A pin nothing resolves is a pin nothing checks, so the line arrives with its first
 # caller.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "9a66bab9c9859474393ced791ee742c3feba3fd7" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "f6f319c56f18271126e8c39ada67c10dc9bf81ac" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "f6f319c56f18271126e8c39ada67c10dc9bf81ac" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "f6f319c56f18271126e8c39ada67c10dc9bf81ac" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "f6f319c56f18271126e8c39ada67c10dc9bf81ac" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "f6f319c56f18271126e8c39ada67c10dc9bf81ac" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "f6f319c56f18271126e8c39ada67c10dc9bf81ac" }


### PR DESCRIPTION
htsjdk-rs `f6f319c` fixes `BamWriter` (IPNP-BIPN/htsjdk-rs#164, measured in #171, fixed in #172):

- the version on the `@HD` line is **replaced** with the current one rather than kept, because
  `SAMFileWriterImpl.writeHeader` encodes with `keepExistingVersionNumber = false`;
- the **sort order is stamped** onto the header before it is written, so a header with no `@HD SO`
  produces a file with `SO:unsorted`.

**Every suite here is still green, all 167.** That is the answer to the question a bump like this
raises: no tool in this port hands `BamWriter` a header whose version is not already current, or one
with no sort order, so nothing this repository produces changes.

Worth recording rather than assuming, since the fix does change bytes for callers that do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #13.
