### PR TITLE
Reset the shared generator between the normal-artifact cases

### DIFF
--- a/tools/readfilter-conformance/GetNormalArtifactDataDump.java
+++ b/tools/readfilter-conformance/GetNormalArtifactDataDump.java
@@ -16,8 +16,11 @@
  *   - A SITE WITH NO NORMAL ALTERNATE IS SKIPPED, and so is one whose normal alternate is more than
  *     a fifth of the normal pileup: the tool is looking for artefacts, not variants;
  *   - THE DOWNSAMPLE IS RANDOM BUT SEEDED. `Utils.getRandomGenerator()` is `new Random(47382911)`,
- *     shared across the whole run, so the sites that survive depend on how many `nextDouble` calls
- *     came before -- a port that drew at a different moment keeps a different set of sites;
+ *     ONE STATIC GENERATOR FOR THE PROCESS, drawn on once per candidate locus. A real run is one
+ *     tool per JVM and starts at the seed; this harness runs seven in one JVM, so it RESETS the
+ *     generator before each, which is what makes each case mean what the same command would mean on
+ *     its own. Without the reset the seventh case's answer depends on how many candidates the first
+ *     six had, which is a property of the harness rather than of the tool;
  *   - THE KEEP PROBABILITY HAS A FLOOR of 0.05 and comes from the tumour's binomial p-value, so a
  *     site the tumour supports strongly is always kept and one it does not is usually dropped;
  *   - A TUMOUR ALTERNATE ABOVE HALF THE TUMOUR PILEUP IS SKIPPED, and that test happens AFTER the
@@ -207,6 +210,12 @@ public class GetNormalArtifactDataDump {
         final List<String> argv = new ArrayList<>(Arrays.asList(
                 "-R", fasta.toString(), "-I", bam.toString(), "-O", out.toString()));
         argv.addAll(Arrays.asList(extra));
+        // `Utils.getRandomGenerator()` is ONE static generator for the whole process, and this tool
+        // draws from it once per candidate locus. A real run is one tool per JVM and therefore
+        // starts at the seed; seven runs in one JVM would not, and the sites the seventh keeps
+        // would depend on how many candidates the first six had. Resetting is what makes each case
+        // here mean what the same command would mean on its own.
+        org.broadinstitute.hellbender.utils.Utils.resetRandomGenerator();
         try {
             new GetNormalArtifactData().instanceMain(argv.toArray(new String[0]));
         } catch (final Exception | AssertionError e) {


### PR DESCRIPTION
A correction to #441's measurement, before its golden is committed. **The dump measured the harness
as much as the tool**, and a port that agreed with the tool would have disagreed with the golden.

`Utils.getRandomGenerator()` is **one static `java.util.Random(47382911)` for the whole process**,
and `GetNormalArtifactData` draws from it once per candidate locus. A real run is one tool per JVM
and therefore starts at the seed. This dump runs seven tools in one JVM, so the seventh case started
wherever the first six had left the generator: the `floor` case — whose entire point is that the keep
probability is at its floor and the *draw* decides — kept **one** locus of thirty because it began at
draw 47 rather than at draw 0.

**From the seed, three of the first thirty draws are at or below 0.05, and the port keeps three.**
Same tool, same generator; the difference was entirely the harness.

`Utils.resetRandomGenerator()` before each case now, so every case means what the same command means
on its own. `floor` keeps three; the other six are unchanged, their keep probabilities being close
enough to one that no draw ever rejected.

The golden for this suite has not been committed yet, so this is a correction to the measurement
rather than a refresh of a claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #13.
