### PR TITLE
The determinism gate, in this repository too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,57 @@ jobs:
           done
           echo "$revisions" | wc -l
 
+  determinism:
+    name: "Determinism: the same suites in a different environment"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          # Pinned; must match rust-toolchain.toml.
+          toolchain: "1.97.1"
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: The suites pass under a foreign locale, timezone, temporary directory and one thread
+        # V.7. Every claim in this repository is a byte claim, and a byte claim that holds only in
+        # one environment is not one. The `test` job already runs the suites in the runner's own
+        # environment; this runs them in a deliberately different one.
+        #
+        # LC_ALL is the axis that has actually bitten this programme: htsjdk-rs decision 0011
+        # established that the REFERENCE's metrics formatting is locale-dependent, and the oracle
+        # pins en_US because of it. Rust's `format!` is locale-independent by construction, so this
+        # gate is what turns "by construction" into "measured": under fr_FR a locale-sensitive
+        # formatter writes `0,333333` and every suite comparing a formatted number would fail.
+        #
+        # TZ moves any accidental date formatting; TMPDIR moves every fixture the suites write, so
+        # a path that leaked into an output would show; and one test thread removes the scheduling
+        # that hid a fixture race until it reached a loaded runner.
+        run: |
+          set -eux
+          mkdir -p /tmp/gatk-rs-elsewhere
+          sudo locale-gen fr_FR.UTF-8 || true
+          LC_ALL=fr_FR.UTF-8 LANG=fr_FR.UTF-8 TZ=Asia/Kolkata \
+            TMPDIR=/tmp/gatk-rs-elsewhere RUST_TEST_THREADS=1 \
+            cargo test --workspace --release
+
+      - name: Two clean builds of the same source are the same bytes
+        # A port whose own build is not reproducible cannot support a claim that its output is.
+        # One crate is enough to catch a build that embeds a path, a timestamp or a hostname, and
+        # `gatk-engine` is the one every tool depends on.
+        run: |
+          set -eux
+          cargo build --release -p gatk-engine
+          find target/release -maxdepth 1 -name 'libgatk_engine*.rlib' -exec sha256sum {} \; \
+            | sed 's#.*/##' > /tmp/build1.txt
+          cargo clean
+          cargo build --release -p gatk-engine
+          find target/release -maxdepth 1 -name 'libgatk_engine*.rlib' -exec sha256sum {} \; \
+            | sed 's#.*/##' > /tmp/build2.txt
+          diff /tmp/build1.txt /tmp/build2.txt
+          cat /tmp/build1.txt
+
 # The jobs below this line are generated from tools/conformance/manifest.json by
 # tools/conformance/generate_ci.py. Edit the manifest, not this file: the `guard` job
 # fails if the two disagree.

--- a/tools/conformance/ci.template.yml
+++ b/tools/conformance/ci.template.yml
@@ -86,6 +86,57 @@ jobs:
           done
           echo "$revisions" | wc -l
 
+  determinism:
+    name: "Determinism: the same suites in a different environment"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          # Pinned; must match rust-toolchain.toml.
+          toolchain: "1.97.1"
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: The suites pass under a foreign locale, timezone, temporary directory and one thread
+        # V.7. Every claim in this repository is a byte claim, and a byte claim that holds only in
+        # one environment is not one. The `test` job already runs the suites in the runner's own
+        # environment; this runs them in a deliberately different one.
+        #
+        # LC_ALL is the axis that has actually bitten this programme: htsjdk-rs decision 0011
+        # established that the REFERENCE's metrics formatting is locale-dependent, and the oracle
+        # pins en_US because of it. Rust's `format!` is locale-independent by construction, so this
+        # gate is what turns "by construction" into "measured": under fr_FR a locale-sensitive
+        # formatter writes `0,333333` and every suite comparing a formatted number would fail.
+        #
+        # TZ moves any accidental date formatting; TMPDIR moves every fixture the suites write, so
+        # a path that leaked into an output would show; and one test thread removes the scheduling
+        # that hid a fixture race until it reached a loaded runner.
+        run: |
+          set -eux
+          mkdir -p /tmp/gatk-rs-elsewhere
+          sudo locale-gen fr_FR.UTF-8 || true
+          LC_ALL=fr_FR.UTF-8 LANG=fr_FR.UTF-8 TZ=Asia/Kolkata \
+            TMPDIR=/tmp/gatk-rs-elsewhere RUST_TEST_THREADS=1 \
+            cargo test --workspace --release
+
+      - name: Two clean builds of the same source are the same bytes
+        # A port whose own build is not reproducible cannot support a claim that its output is.
+        # One crate is enough to catch a build that embeds a path, a timestamp or a hostname, and
+        # `gatk-engine` is the one every tool depends on.
+        run: |
+          set -eux
+          cargo build --release -p gatk-engine
+          find target/release -maxdepth 1 -name 'libgatk_engine*.rlib' -exec sha256sum {} \; \
+            | sed 's#.*/##' > /tmp/build1.txt
+          cargo clean
+          cargo build --release -p gatk-engine
+          find target/release -maxdepth 1 -name 'libgatk_engine*.rlib' -exec sha256sum {} \; \
+            | sed 's#.*/##' > /tmp/build2.txt
+          diff /tmp/build1.txt /tmp/build2.txt
+          cat /tmp/build1.txt
+
 # {{ORACLE_JOBS}}
 
   inventory:


### PR DESCRIPTION
#85 (V.7) asked for it in all three repositories and it was running in picard-rs alone. This is its
shape for a **library** port: there are no binaries here, so what runs twice is the suites.

### Two jobs, two claims

**The suites in a foreign environment** — French locale, Indian timezone, a non-default `TMPDIR`, and
**one test thread**. Every claim here is a byte claim, and one that holds only in the runner's own
environment is not one.

`LC_ALL` is the axis that has bitten this programme before: htsjdk-rs decision 0011 established that
the *reference's* metrics formatting is locale-dependent, which is why the oracle pins `en_US`.
Rust's `format!` is locale-independent by construction — this gate turns "by construction" into
"measured", because under `fr_FR` a locale-sensitive formatter writes `0,333333` and every suite
comparing a formatted number fails at once. There are **195** such suites now.

`TZ` moves any accidental date formatting. `TMPDIR` moves every fixture the suites write, so a path
that leaked into an output would show. One test thread removes the scheduling that hid a fixture
race here until it reached a loaded runner — which cost two pushes to find.

**Two clean builds of `gatk-engine`** with a `cargo clean` between, compared by hash. A port whose own
build is not reproducible cannot support a claim that its output is.

Both pass locally: **195 suites green under the foreign environment.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #13.
