### PR TITLE
Measure the five ways an interval list is scattered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,10 @@ jobs:
             index: "37/37"
             slug: "preprocess-intervals"
             suites: "preprocess-intervals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "interval-list-scatter"
+            suites: "interval-list-scatter"
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4439,6 +4439,24 @@
           "why": "21 rows, no files: sixteen interval lists and five refusals, over one two-contig reference of 240 bases each carrying a sixty-base N run, a lower-case stretch and a contig that is all N but for an AC at 150. The lists cover the whole genome with and without padding, uneven bins, an interval shorter than a bin, no binning at all, padding clamped at both ends of a contig, two and three intervals whose padding overlaps, a bin straddling the edge of the N run, and intervals on two contigs, which never overlap. One list is two intervals two bases apart padded by sixty, which is as far as the overlap resolution can be pushed and still lands between them. The refusals are the three argument checks and the two parser bounds. The M5 and UR fields of the sequence lines are masked: both come from the .dict the reference indexer wrote and neither is this tool's. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32384544198, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "interval-list-scatter",
+      "status": "golden-pending",
+      "title": "The five ways an interval list is scattered",
+      "harness": "tools/readfilter-conformance",
+      "tools": [],
+      "why": "What SplitIntervals divides an interval list with, and what every scatter-gather pipeline built on it inherits. ONLY INTERVAL_SUBDIVISION UNIQUES ITS INPUT, so the same overlapping list scatters into different intervals under the other four rather than merely into different shards. THE IDEAL WEIGHT IS FLOORED AT ONE and taken from the UNIQUE base count even for the modes that never unique. THE NO-SUBDIVISION MODES RAISE THE IDEAL TO THE WIDEST INTERVAL, so a scatter count larger than the list can honour comes back short. THE LAST SHARD TAKES EVERYTHING LEFT, the loop stopping once it has returned one shard fewer than asked. THE PROJECTED REMAINING SIZE IS A DOUBLE DIVISION BY the shards still to come, which is what the overflow mode compares against. INTERVAL_COUNT TAKES WHILE THERE IS ROOM and leaves the remainder in the last shard, while INTERVAL_COUNT_WITH_DISTRIBUTED_REMAINDER compares the projection against the current size and spreads it over the early ones. AND THE SUBDIVISION CUT KEEPS THE NAME AND THE STRAND of the interval it cut.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "IntervalListScatterDump",
+          "golden": null,
+          "why": "Seven interval lists over five scatter counts and all five modes: an even list, one with an interval far wider than the rest, one with two overlaps and an abuttal, one over two contigs, one out of order and on the second contig first, one single interval and one of a single base. Each of the 175 combinations contributes its ideal split weight, its shard count and every shard, and two refusals close it: a scatter count of zero and a negative one. 785 rows. The intervals of a shard are separated by semicolons, because uniqued() joins the names it merged with a pipe. Golden pending: this laptop is not x86-64, so the artefact has to come from the runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/IntervalListScatterDump.java
+++ b/tools/readfilter-conformance/IntervalListScatterDump.java
@@ -1,0 +1,170 @@
+/*
+ * The five ways an interval list is scattered, taken from the reference.
+ *
+ * `SplitIntervals` and every scatter-gather pipeline built on it divide an interval list into
+ * shards through `picard.util.IntervalList.IntervalListScatterMode`. The five modes disagree about
+ * what a shard is, and the disagreements are not small.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - ONLY INTERVAL_SUBDIVISION UNIQUES ITS INPUT. Its `preprocessIntervalList` is `uniqued()`,
+ *     which merges abutting and overlapping intervals and drops the names; every other mode's is
+ *     `sorted()`, which keeps them apart. The same overlapping input therefore scatters into
+ *     different intervals, not merely into different shards;
+ *   - THE IDEAL WEIGHT IS FLOORED AT ONE and computed with `floorDiv` on the UNIQUE base count,
+ *     even for the modes that never unique their list, so a list with overlaps has an ideal
+ *     smaller than its own weight;
+ *   - THE NO-SUBDIVISION MODES RAISE THE IDEAL TO THE WIDEST INTERVAL, which means a scatter count
+ *     larger than the list can honour comes back with fewer shards than asked for;
+ *   - THE LAST SHARD TAKES EVERYTHING LEFT. The loop stops offering intervals once it has returned
+ *     `scatterCount - 1` lists and flushes the queue into the last one, whatever its weight;
+ *   - THE PROJECTED REMAINING SIZE IS A DOUBLE DIVISION BY `scatterCount - intervalsReturned`,
+ *     which is what the overflow mode compares against, so its decision depends on how many shards
+ *     have already been returned rather than on the list alone;
+ *   - INTERVAL_COUNT TAKES WHILE THERE IS ROOM, `idealSplitWeight - currentSize > 0`, so a
+ *     remainder lands in the last shard;
+ *   - INTERVAL_COUNT_WITH_DISTRIBUTED_REMAINDER COMPARES THE PROJECTION AGAINST THE CURRENT SIZE
+ *     instead, `projectedSizeOfRemaining > currentSize`, which spreads the remainder over the
+ *     early shards rather than the last;
+ *   - A SCATTER COUNT LARGER THAN THE WEIGHT still produces shards, because the ideal is floored
+ *     at one and the queue empties;
+ *   - AND THE SUBDIVISION CUT KEEPS THE NAME AND THE STRAND of the interval it cut, so a shard
+ *     boundary inside a named interval leaves two intervals of that name.
+ *
+ * Output:
+ *
+ *     weight\t<list>,<mode>,<count>=<ideal split weight>
+ *     shards\t<list>,<mode>,<count>=<number of shards>
+ *     shard\t<list>,<mode>,<count>,<index>=<contig:start-end:strand:name;...>
+ *
+ * The intervals of a shard are separated by semicolons rather than by pipes, because `uniqued()`
+ * joins the names of the intervals it merged with a pipe and a shard row would otherwise be
+ * ambiguous.
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: IntervalListScatterDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.Interval;
+import htsjdk.samtools.util.IntervalList;
+import picard.util.IntervalList.IntervalListScatterMode;
+import picard.util.IntervalList.IntervalListScatterer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IntervalListScatterDump {
+
+    static final int CONTIG_LENGTH = 10000;
+
+    /** The interval lists this dump scatters, by name. */
+    static IntervalList list(final String name) {
+        final SAMFileHeader header = new SAMFileHeader();
+        final SAMSequenceDictionary dictionary = new SAMSequenceDictionary();
+        for (final String contig : new String[] {"chr1", "chr2"}) {
+            dictionary.addSequence(new SAMSequenceRecord(contig, CONTIG_LENGTH));
+        }
+        header.setSequenceDictionary(dictionary);
+        final IntervalList list = new IntervalList(header);
+        switch (name) {
+            case "even":
+                // Five intervals of a hundred bases each, which every mode can divide evenly.
+                for (int i = 0; i < 5; i++) {
+                    list.add(new Interval("chr1", 1 + i * 200, 100 + i * 200, false, "even" + i));
+                }
+                break;
+            case "uneven":
+                // One interval far wider than the rest, which is what raises the ideal weight of
+                // the no-subdivision modes.
+                list.add(new Interval("chr1", 1, 1, false, "one"));
+                list.add(new Interval("chr1", 101, 110, false, "ten"));
+                list.add(new Interval("chr1", 201, 1200, false, "thousand"));
+                list.add(new Interval("chr1", 1301, 1350, false, "fifty"));
+                break;
+            case "overlapping":
+                // Two overlaps and one abuttal, which only the uniquing mode merges.
+                list.add(new Interval("chr1", 1, 100, false, "a"));
+                list.add(new Interval("chr1", 50, 150, false, "b"));
+                list.add(new Interval("chr1", 151, 200, false, "c"));
+                list.add(new Interval("chr1", 400, 500, false, "d"));
+                break;
+            case "two-contigs":
+                list.add(new Interval("chr1", 1, 100, false, "first"));
+                list.add(new Interval("chr2", 1, 100, false, "second"));
+                list.add(new Interval("chr2", 201, 400, false, "third"));
+                break;
+            case "unsorted":
+                // Out of order and on the second contig first, so the sort is visible.
+                list.add(new Interval("chr2", 1, 50, false, "z"));
+                list.add(new Interval("chr1", 301, 400, true, "y"));
+                list.add(new Interval("chr1", 1, 100, false, "x"));
+                break;
+            case "single":
+                list.add(new Interval("chr1", 1, 1000, false, "only"));
+                break;
+            case "one-base":
+                list.add(new Interval("chr1", 1, 1, false, "tiny"));
+                break;
+            default:
+                throw new IllegalArgumentException("no such list: " + name);
+        }
+        return list;
+    }
+
+    public static void main(final String[] args) {
+        System.out.println("# IntervalListScatterDump: the five ways an interval list is scattered");
+
+        final String[] names = {"even", "uneven", "overlapping", "two-contigs", "unsorted",
+                "single", "one-base"};
+        final int[] counts = {1, 2, 3, 5, 10};
+
+        for (final String name : names) {
+            for (final IntervalListScatterMode mode : IntervalListScatterMode.values()) {
+                for (final int count : counts) {
+                    scatter(name, mode, count);
+                }
+            }
+        }
+
+        // The two refusals a caller can reach: a scatter count of zero and a negative one, both
+        // through the ideal weight's own division.
+        error("zero-count", "even", IntervalListScatterMode.INTERVAL_SUBDIVISION, 0);
+        error("negative-count", "even", IntervalListScatterMode.INTERVAL_SUBDIVISION, -1);
+    }
+
+    static void scatter(final String name, final IntervalListScatterMode mode, final int count) {
+        final IntervalList list = list(name);
+        final IntervalListScatterer scatterer = mode.make();
+        final String label = name + "," + mode.name() + "," + count;
+        System.out.printf("weight\t%s=%d%n", label,
+                scatterer.deduceIdealSplitWeight(scatterer.preprocessIntervalList(list), count));
+        final List<IntervalList> shards = scatterer.scatter(list, count);
+        System.out.printf("shards\t%s=%d%n", label, shards.size());
+        for (int i = 0; i < shards.size(); i++) {
+            System.out.printf("shard\t%s,%d=%s%n", label, i, render(shards.get(i)));
+        }
+    }
+
+    /** One shard, as `contig:start-end:strand:name` per interval. */
+    static String render(final IntervalList shard) {
+        final List<String> parts = new ArrayList<>();
+        for (final Interval interval : shard) {
+            parts.add(String.format("%s:%d-%d:%s:%s", interval.getContig(), interval.getStart(),
+                    interval.getEnd(), interval.isNegativeStrand() ? "-" : "+", interval.getName()));
+        }
+        return String.join(";", parts);
+    }
+
+    static void error(final String label, final String name, final IntervalListScatterMode mode,
+                      final int count) {
+        try {
+            final List<IntervalList> shards = mode.make().scatter(list(name), count);
+            System.out.printf("unexpected\t%s\t%d%n", label, shards.size());
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(), e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
`picard.util.IntervalList.IntervalListScatterMode`, which is what `SplitIntervals`
and every scatter-gather pipeline built on it divides an interval list with.

785 rows: seven interval lists (even, one with an interval far wider than the
rest, one with two overlaps and an abuttal, one over two contigs, one out of
order, one single interval, one single base) over five scatter counts and all
five modes. Each combination contributes its ideal split weight, its shard count
and every shard.

Behaviours the rows are chosen to catch: only `INTERVAL_SUBDIVISION` uniques its
input; the ideal weight is floored at one and taken from the **unique** base
count even for modes that never unique; the no-subdivision modes raise the ideal
to the widest interval; the last shard takes everything left; the overflow mode's
decision depends on how many shards have already been returned; the two
interval-count modes put the remainder at opposite ends; and the subdivision cut
keeps the name and strand of the interval it cut.

The intervals of a shard are separated by semicolons: `uniqued()` joins the names
it merged with a pipe, so a pipe-separated row would be ambiguous.

Golden pending. The artefact comes from the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #10.
