### PR TITLE
Measure CheckTerminatorBlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,10 @@ jobs:
             index: "39/39"
             slug: "gather-bqsr-reports-gather-tranches"
             suites: "gather-bqsr-reports gather-tranches"
+          - group: golden-pending
+            index: "1/1"
+            slug: "check-terminator-block"
+            suites: "check-terminator-block"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,14 +7,14 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 103 | 33.1% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 196 | 63.0% |
+| not started | 195 | 62.7% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (43 of 109 started)
+## picard-origin tools (44 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -24,6 +24,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `BamIndexStats` | reporting-walker | oracle-backed | bamindexstats | 1 | not measured |
 | `BedToIntervalList` | interval-utility | unchecked | bedtointervallist | 1 | not measured |
 | `CalculateReadGroupChecksum` | reporting-walker | oracle-backed | rgchecksum | 1 | not measured |
+| `CheckTerminatorBlock` | reporting-walker | golden-pending | check-terminator-block | 1 | not measured |
 | `CleanSam` | record-transform | oracle-backed | cleansam | 1 | not measured |
 | `CollectAlignmentSummaryMetrics` | reporting-walker | oracle-backed | metrics, rejections | 5 | t=2, 0/16 rows (0%) |
 | `CollectBaseDistributionByCycle` | reporting-walker | oracle-backed | metrics | 4 | not measured |
@@ -62,9 +63,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ValidateSamFile` | reporting-walker | oracle-backed | validatesam | 6 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>66 not started</summary>
+<details><summary>65 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `CheckTerminatorBlock`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MakeSitesOnlyVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `MergeVcfs`, `PositionBasedDownsampleSam`, `RenameSampleInVcf`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `SortVcf`, `SplitVcfs`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
+`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MakeSitesOnlyVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `MergeVcfs`, `PositionBasedDownsampleSam`, `RenameSampleInVcf`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `SortVcf`, `SplitVcfs`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4659,6 +4659,26 @@
           "why": "Eleven runs over five hand-written VQSLOD tranche files: two shards of four levels, the same two reversed, one shard alone, a shard carrying a level the other does not, a shard with no known variants, one requested sensitivity, seven of them, two given out of order, the two other modes and a file of the wrong version. Eleven rows: ten gathered files and one refusal. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32413651130, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "check-terminator-block",
+      "status": "golden-pending",
+      "title": "Whether a block-compressed file finished",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "CheckTerminatorBlock"
+      ],
+      "why": "A FILE SHORTER THAN THE EMPTY BLOCK IS DEFECTIVE before it is read. THE TERMINATOR IS COMPARED AS 28 LITERAL BYTES, so an empty gzip block from another deflater is not one. A FILE WITH NO TERMINATOR IS SEARCHED BACKWARDS for a block preamble and the FIRST match decides, so a healthy block earlier cannot rescue a truncated one after it. THE SIZE FIELD IS BSIZE, one less than the block's length. A FILE THAT IS NOT GZIP AT ALL IS DEFECTIVE rather than an exception. AND THE EXIT CODE IS 100 FOR DEFECTIVE and 0 for both other answers, so a file with a healthy last block but no terminator passes.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "CheckTerminatorBlockDump",
+          "golden": null,
+          "why": "Nine files, each carried in the golden as base64 so a port replays the same bytes: a complete bgzipped file, the same with its terminator cut off, the same one byte shorter again, the terminator alone, one byte short of the terminator, nothing at all, a file that is not gzip, a complete file with a payload byte flipped, and one whose terminator's last byte is wrong. Each contributes its termination answer and the tool's exit code. Golden pending: this laptop is not x86-64, so the artefact has to come from the runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/CheckTerminatorBlockDump.java
+++ b/tools/readfilter-conformance/CheckTerminatorBlockDump.java
@@ -1,0 +1,115 @@
+/*
+ * CheckTerminatorBlock, and the termination check under it, taken from the reference.
+ *
+ * The tool is four lines over `BlockCompressedInputStream.checkTermination`, whose three answers
+ * are what every BAM writer's "did this file finish" question comes down to.
+ *
+ * Seven behaviours this is built to catch.
+ *
+ *   - A FILE SHORTER THAN THE EMPTY BLOCK IS DEFECTIVE without being read at all, the length test
+ *     coming before any seek;
+ *   - THE TERMINATOR IS COMPARED AS 28 LITERAL BYTES, so a file whose last block is an empty gzip
+ *     block written by any other deflater is NOT a terminator;
+ *   - A FILE WITH NO TERMINATOR IS SEARCHED BACKWARDS from its end for a block preamble, and the
+ *     search window is the whole file when the file is smaller than the maximum block size;
+ *   - THE PREAMBLE MATCH IS THE FIRST ONE FOUND WALKING BACKWARDS, and the answer is decided on
+ *     that one alone: a healthy block earlier in the file cannot rescue a truncated one after it;
+ *   - THE SIZE FIELD IS `BSIZE`, one LESS than the block's length, so the test is
+ *     `remaining == totalBlockSizeMinusOne + 1`;
+ *   - A FILE THAT IS NOT GZIP AT ALL IS DEFECTIVE rather than an exception, the backwards search
+ *     simply finding no preamble;
+ *   - AND THE TOOL'S EXIT CODE IS 100 FOR DEFECTIVE and 0 for both other answers, so a file with a
+ *     healthy last block but no terminator passes.
+ *
+ * Output:
+ *
+ *     fixture\t<label>\t<the file, base64>
+ *     termination\t<label>=<HAS_TERMINATOR_BLOCK|HAS_HEALTHY_LAST_BLOCK|DEFECTIVE>
+ *     exit\t<label>=<the tool's return code>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: CheckTerminatorBlockDump
+ */
+
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.BlockCompressedStreamConstants;
+import picard.sam.CheckTerminatorBlock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+public class CheckTerminatorBlockDump {
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("check-terminator-block-dump");
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# CheckTerminatorBlockDump: whether a block-compressed file finished");
+
+        // A complete bgzipped file: two blocks of payload and the terminator.
+        final byte[] complete = bgzip("The quick brown fox jumps over the lazy dog.\n".repeat(40));
+        probe(dir, "complete", complete);
+        // The same file with its terminator cut off, whose last block is still healthy.
+        probe(dir, "no-terminator", Arrays.copyOf(complete,
+                complete.length - BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK.length));
+        // The same again with one more byte gone, so the last block is short.
+        probe(dir, "truncated-block", Arrays.copyOf(complete,
+                complete.length - BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK.length - 1));
+        // Only the terminator.
+        probe(dir, "terminator-only", BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK.clone());
+        // One byte short of the terminator's length, which is the length test.
+        probe(dir, "too-short", Arrays.copyOf(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK,
+                BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK.length - 1));
+        // Nothing at all.
+        probe(dir, "empty", new byte[0]);
+        // Not gzip, and long enough to be searched.
+        probe(dir, "not-gzip", "this is not a block compressed file at all, not one byte of it\n"
+                .getBytes());
+        // A complete file with a byte flipped inside its last block's payload, which the check
+        // does not decompress and therefore does not notice.
+        final byte[] flipped = complete.clone();
+        flipped[flipped.length - BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK.length - 5] ^= 0xFF;
+        probe(dir, "corrupt-payload", flipped);
+        // A terminator whose last byte is wrong, so the 28-byte comparison fails and the backwards
+        // search takes over.
+        final byte[] wrongTerminator = complete.clone();
+        wrongTerminator[wrongTerminator.length - 1] ^= 0x01;
+        probe(dir, "wrong-terminator", wrongTerminator);
+    }
+
+    /** htsjdk's own bgzip writer, so the bytes are the ones a BAM would carry. */
+    static byte[] bgzip(final String text) throws Exception {
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (BlockCompressedOutputStream out = new BlockCompressedOutputStream(bytes, (File) null)) {
+            out.write(text.getBytes());
+        }
+        return bytes.toByteArray();
+    }
+
+    static void probe(final Path dir, final String label, final byte[] contents) throws Exception {
+        final Path file = dir.resolve(label + ".bam");
+        Files.write(file, contents);
+        System.out.printf("fixture\t%s\t%s%n", label, RecordTransformDump.base64(file));
+        try {
+            final BlockCompressedInputStream.FileTermination termination =
+                    BlockCompressedInputStream.checkTermination(file.toFile());
+            System.out.printf("termination\t%s=%s%n", label, termination.name());
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+        try {
+            final Object code = new CheckTerminatorBlock()
+                    .instanceMain(new String[] {"I=" + file});
+            System.out.printf("exit\t%s=%s%n", label, code);
+        } catch (final Exception e) {
+            System.out.printf("error\t%s-tool\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+        }
+    }
+}


### PR DESCRIPTION
Nine block-compressed files, each carried in the golden as base64: a complete
bgzipped file, the same with its terminator cut off, the same one byte shorter
again, the terminator alone, one byte short of the terminator, nothing at all, a
file that is not gzip, a complete file with a payload byte flipped, and one whose
terminator's last byte is wrong.

Behaviours the rows are chosen to catch: a file shorter than the empty block is
defective before it is read; the terminator is compared as 28 literal bytes; a
file with no terminator is searched backwards for a block preamble and the first
match decides; the size field is `BSIZE`, one less than the block's length; a
file that is not gzip at all is defective rather than an exception; and the exit
code is 100 for defective and 0 for both other answers, so a file with a healthy
last block but no terminator passes.

Golden pending. The artefact comes from the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
