### PR TITLE
Measure RenameSampleInVcf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,10 @@ jobs:
             index: "39/39"
             slug: "gather-bqsr-reports-gather-tranches-check-terminator-block"
             suites: "gather-bqsr-reports gather-tranches check-terminator-block"
+          - group: golden-pending
+            index: "1/1"
+            slug: "rename-sample-in-vcf"
+            suites: "rename-sample-in-vcf"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,14 +7,14 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 104 | 33.4% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 195 | 62.7% |
+| not started | 194 | 62.4% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (44 of 109 started)
+## picard-origin tools (45 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -49,6 +49,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `NonNFastaSize` | reference-utility | unchecked | nonnfastasize | 1 | not measured |
 | `NormalizeFasta` | reference-utility | unchecked | normalizefasta | 1 | not measured |
 | `QualityScoreDistribution` | reporting-walker | unchecked | qualityscoredistribution | 1 | not measured |
+| `RenameSampleInVcf` | variant-transform | golden-pending | rename-sample-in-vcf | 1 | not measured |
 | `ReorderSam` | record-transform | oracle-backed | reordersam | 1 | not measured |
 | `ReplaceSamHeader` | record-transform | oracle-backed | replacesamheader | 1 | not measured |
 | `RevertOriginalBaseQualitiesAndAddMateCigar` | record-transform | oracle-backed | revertorigmatecigar | 1 | not measured |
@@ -63,9 +64,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ValidateSamFile` | reporting-walker | oracle-backed | validatesam | 6 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>65 not started</summary>
+<details><summary>64 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MakeSitesOnlyVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `MergeVcfs`, `PositionBasedDownsampleSam`, `RenameSampleInVcf`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `SortVcf`, `SplitVcfs`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
+`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MakeSitesOnlyVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `MergeVcfs`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `SortVcf`, `SplitVcfs`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4679,6 +4679,26 @@
           "why": "Nine files, each carried in the golden as base64 so a port replays the same bytes: a complete bgzipped file, the same with its terminator cut off, the same one byte shorter again, the terminator alone, one byte short of the terminator, nothing at all, a file that is not gzip, a complete file with a payload byte flipped, and one whose terminator's last byte is wrong. Each contributes its termination answer and the tool's exit code. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32415499567, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "rename-sample-in-vcf",
+      "status": "golden-pending",
+      "title": "A single-sample VCF with its column renamed",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "RenameSampleInVcf"
+      ],
+      "why": "Small, and every corner is in what the WRITER does rather than what the tool does. THE HEADER IS REBUILT FROM ITS METADATA IN INPUT ORDER and one sample name, so the order of the output's lines is the writer's. THE SAMPLE NAME IS NOT VALIDATED: a name with a space goes straight into the column header. A MULTI-SAMPLE INPUT IS REFUSED BUT A SITES-ONLY ONE IS NOT, so a VCF with no sample column gets one, every record carrying a missing genotype. OLD_SAMPLE_NAME IS CHECKED AGAINST THE FIRST SAMPLE ONLY and its refusal names the sample that was there. THE RECORDS ARE WRITTEN BACK THROUGH THE PARSER, so INFO order, float formatting and missing-value spellings are the writer's. THE QUAL COLUMN IS REFORMATTED, an integral quality printed as an integer and everything else to two places. AND THE OUTPUT CARRIES NO PROVENANCE LINE of its own.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "RenameSampleInVcfDump",
+          "golden": null,
+          "why": "Ten runs, each carrying its input as well as its output so a port reads the same bytes: a plain rename, the old name asserted rightly and wrongly, a name with a space, a name that is a number, a rename to the same name, a sites-only input, a two-sample input, a file declaring no INFO lines whose records use them, and a file with no records at all. Twenty rows: ten inputs, seven outputs and three refusals. Golden pending: this laptop is not x86-64, so the artefact has to come from the runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/RenameSampleInVcfDump.java
+++ b/tools/readfilter-conformance/RenameSampleInVcfDump.java
@@ -1,0 +1,130 @@
+/*
+ * RenameSampleInVcf, taken from the reference.
+ *
+ * A single-sample VCF written back out with its one sample column renamed. Small, and every one of
+ * its corners is in what the WRITER does rather than in what the tool does.
+ *
+ * Eight behaviours this is built to catch.
+ *
+ *   - THE HEADER IS REBUILT FROM ITS METADATA IN INPUT ORDER and one sample name, so a line the
+ *     input carried survives and its ORDER is the writer's, not the input's;
+ *   - THE SAMPLE NAME IS NOT VALIDATED. A name with a space, a tab-free oddity or an empty string
+ *     goes straight into the column header;
+ *   - A MULTI-SAMPLE INPUT IS REFUSED, but a SITES-ONLY input is NOT: a VCF with no sample column
+ *     at all passes the size test and then the rename gives it one, with every record carrying a
+ *     missing genotype;
+ *   - OLD_SAMPLE_NAME IS CHECKED AGAINST THE FIRST SAMPLE only, and its refusal names the sample
+ *     that was there;
+ *   - THE RECORDS ARE WRITTEN BACK THROUGH THE PARSER, so a record's INFO field order, its float
+ *     formatting and its missing-value spellings are the writer's rather than the input's;
+ *   - A GENOTYPE'S OWN FIELDS SURVIVE THE RENAME, the sample being renamed in the header and the
+ *     genotype carried through by position;
+ *   - THE FILE'S OTHER HEADER LINES ARE NOT TOUCHED, contigs and INFO declarations included, so an
+ *     input declaring nothing still writes records that use undeclared keys;
+ *   - AND THE QUAL COLUMN IS REFORMATTED: `50.00` comes back `50` and `10.5` comes back `10.50`,
+ *     because the writer prints an integral quality as an integer and everything else to two
+ *     places. The output carries no provenance line of its own either: nothing says it was
+ *     renamed.
+ *
+ * Output:
+ *
+ *     input\t<label>=<the whole input vcf, escaped>
+ *     renamed\t<label>=<the whole output vcf, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: RenameSampleInVcfDump
+ */
+
+import picard.vcf.RenameSampleInVcf;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RenameSampleInVcfDump {
+
+    static final String HEADER =
+            "##fileformat=VCFv4.2\n"
+            + "##FILTER=<ID=LowQual,Description=\"Low quality\">\n"
+            + "##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allelic depths\">\n"
+            + "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Depth\">\n"
+            + "##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Genotype quality\">\n"
+            + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+            + "##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele frequency\">\n"
+            + "##INFO=<ID=DB,Number=0,Type=Flag,Description=\"dbSNP membership\">\n"
+            + "##contig=<ID=chr1,length=240>\n";
+
+    static final String RECORDS =
+            "chr1\t10\trs1\tA\tC\t50.00\tPASS\tAF=0.5;DB\tGT:AD:DP:GQ\t0/1:10,5:15:99\n"
+            + "chr1\t20\t.\tT\tG,C\t.\tLowQual\tAF=0.25,0.125\tGT:AD:DP\t1/2:1,2,3:6\n"
+            + "chr1\t30\t.\tG\t.\t10.5\t.\t.\tGT\t./.\n";
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("rename-sample-dump");
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# RenameSampleInVcfDump: a single-sample VCF with its column renamed");
+
+        final String single = HEADER + column("NA12878") + RECORDS;
+        run("plain", dir, single, "NEW_SAMPLE_NAME=renamed");
+        // The old name asserted, and asserted wrongly.
+        run("old-name-right", dir, single, "NEW_SAMPLE_NAME=renamed", "OLD_SAMPLE_NAME=NA12878");
+        run("old-name-wrong", dir, single, "NEW_SAMPLE_NAME=renamed", "OLD_SAMPLE_NAME=OTHER");
+        // Names the tool does not validate.
+        run("name-with-space", dir, single, "NEW_SAMPLE_NAME=two words");
+        run("name-that-is-a-number", dir, single, "NEW_SAMPLE_NAME=12345");
+        run("same-name", dir, single, "NEW_SAMPLE_NAME=NA12878");
+        // A sites-only VCF, which has no sample to rename and gets one anyway.
+        run("sites-only", dir,
+                HEADER + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+                        + "chr1\t10\trs1\tA\tC\t50.00\tPASS\tAF=0.5;DB\n",
+                "NEW_SAMPLE_NAME=renamed");
+        // Two samples, which is the refusal.
+        run("two-samples", dir,
+                HEADER + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tone\ttwo\n"
+                        + "chr1\t10\trs1\tA\tC\t50.00\tPASS\tAF=0.5\tGT\t0/1\t1/1\n",
+                "NEW_SAMPLE_NAME=renamed");
+        // A file declaring no INFO lines at all, whose records still use them.
+        run("undeclared-info", dir,
+                "##fileformat=VCFv4.2\n"
+                        + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+                        + "##contig=<ID=chr1,length=240>\n"
+                        + column("NA12878")
+                        + "chr1\t10\t.\tA\tC\t50.00\t.\tXX=1\tGT\t0/1\n",
+                "NEW_SAMPLE_NAME=renamed");
+        // No records at all.
+        run("no-records", dir, HEADER + column("NA12878"), "NEW_SAMPLE_NAME=renamed");
+    }
+
+    static String column(final String sample) {
+        return "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t" + sample + "\n";
+    }
+
+    static void run(final String label, final Path dir, final String input, final String... extra)
+            throws Exception {
+        final Path in = dir.resolve(label + ".vcf");
+        Files.writeString(in, input, StandardCharsets.UTF_8);
+        final Path out = dir.resolve("renamed-" + label + ".vcf");
+        System.out.printf("input\t%s=%s%n", label, ReferenceQueryDump.escape(input));
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "I=" + in, "O=" + out, "CREATE_INDEX=false"));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            final Object code = new RenameSampleInVcf().instanceMain(argv.toArray(new String[0]));
+            if (!Integer.valueOf(0).equals(code)) {
+                System.out.printf("exit\t%s=%s%n", label, code);
+                return;
+            }
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+            return;
+        }
+        System.out.printf("renamed\t%s=%s%n", label,
+                ReferenceQueryDump.escape(Files.readString(out)));
+    }
+}


### PR DESCRIPTION
Ten runs, each carrying its input as well as its output so a port reads the same
bytes: a plain rename, the old name asserted rightly and wrongly, a name with a
space, a name that is a number, a rename to the same name, a sites-only input, a
two-sample input, a file declaring no INFO lines whose records use them, and a
file with no records at all.

Behaviours the rows are chosen to catch: the header is rebuilt from its metadata
and one sample name; the name is not validated; a multi-sample input is refused
but a sites-only one is not, so it gains a column and a missing genotype on every
record; `OLD_SAMPLE_NAME` is checked against the first sample only; the records go
back out through the writer, so the QUAL column is reformatted (`50.00` → `50`,
`10.5` → `10.50`); and a record using an undeclared INFO key is a refusal from
the writer rather than from the tool.

Golden pending. The artefact comes from the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
