### PR TITLE
Measure MakeSitesOnlyVcf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,10 @@ jobs:
             index: "39/39"
             slug: "gather-bqsr-reports-gather-tranches-check-terminator-block-rename-sample-in-vcf"
             suites: "gather-bqsr-reports gather-tranches check-terminator-block rename-sample-in-vcf"
+          - group: golden-pending
+            index: "1/1"
+            slug: "make-sites-only-vcf"
+            suites: "make-sites-only-vcf"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,14 +7,14 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 105 | 33.8% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 194 | 62.4% |
+| not started | 193 | 62.1% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (45 of 109 started)
+## picard-origin tools (46 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -43,6 +43,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `IntervalListToBed` | interval-utility | unchecked | intervallisttobed | 1 | not measured |
 | `IntervalListTools` | interval-utility | oracle-backed | intervallisttools, intervallisttoolspadbreak | 4 | not measured |
 | `LiftOverIntervalList` | interval-utility | unchecked | liftoverintervallist | 1 | not measured |
+| `MakeSitesOnlyVcf` | variant-transform | golden-pending | make-sites-only-vcf | 1 | not measured |
 | `MeanQualityByCycle` | reporting-walker | oracle-backed | metrics | 4 | not measured |
 | `MergeBamAlignment` | record-transform | unchecked | mergebamalignment, mergebamalignment-full | 2 | not measured |
 | `MergeSamFiles` | record-transform | oracle-backed | merge | 1 | not measured |
@@ -64,9 +65,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ValidateSamFile` | reporting-walker | oracle-backed | validatesam | 6 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>64 not started</summary>
+<details><summary>63 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MakeSitesOnlyVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `MergeVcfs`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `SortVcf`, `SplitVcfs`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
+`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `MergeVcfs`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `SortVcf`, `SplitVcfs`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4699,6 +4699,26 @@
           "why": "Ten runs, each carrying its input as well as its output so a port reads the same bytes: a plain rename, the old name asserted rightly and wrongly, a name with a space, a name that is a number, a rename to the same name, a sites-only input, a two-sample input, a file declaring no INFO lines whose records use them, and a file with no records at all. Twenty rows: ten inputs, seven outputs and three refusals. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32416633089, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "make-sites-only-vcf",
+      "status": "golden-pending",
+      "title": "A VCF with its genotypes dropped",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "MakeSitesOnlyVcf"
+      ],
+      "why": "SAMPLE IS A TreeSet, so the output's columns are alphabetical however they were typed and whatever order the input had. NO SAMPLE AT ALL IS THE DEFAULT and leaves eight columns, not an empty FORMAT. A NAME THE INPUT DOES NOT CARRY BECOMES A COLUMN OF ITS OWN, the header being built from the names asked for rather than the names the file has, so every record writes ./. under a sample that never existed. THE ANNOTATIONS ARE KEPT AS THEY WERE, so AC and AN can disagree with the genotypes that are left. THE ALLELES ARE RESET FROM THE ORIGINAL RECORD, so an alternate no remaining genotype calls still appears in ALT. THE FORMAT COLUMN IS RECOMPUTED from the genotypes that remain and can be shorter than the input's. AND CREATE_INDEX IS ON BY DEFAULT for this tool, so a header declaring no contigs is a refusal rather than an unindexed output.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "MakeSitesOnlyVcfDump",
+          "golden": null,
+          "why": "Ten runs over a three-sample file whose columns are deliberately out of alphabetical order, each carrying its input as well as its output: the default sites-only run, one sample, the same sample twice, two given unsorted, all three, a sample the file does not carry, that one beside a present one, a file that already has no samples, a header declaring no contigs, and the same with the index turned off. Twenty rows: ten inputs, nine outputs and one refusal. Golden pending: this laptop is not x86-64, so the artefact has to come from the runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/MakeSitesOnlyVcfDump.java
+++ b/tools/readfilter-conformance/MakeSitesOnlyVcfDump.java
@@ -1,0 +1,118 @@
+/*
+ * MakeSitesOnlyVcf, taken from the reference.
+ *
+ * A VCF with its genotype columns dropped, or kept for a named subset. The tool is a header rebuilt
+ * with the samples the user asked for and a per-record subset, and everything else is the writer.
+ *
+ * Eight behaviours this is built to catch.
+ *
+ *   - SAMPLE IS A TreeSet, so the output's sample columns are in ALPHABETICAL order however the
+ *     user typed them and whatever order the input had;
+ *   - NO SAMPLE AT ALL IS THE DEFAULT and leaves the file with eight columns: no FORMAT column and
+ *     no sample columns, not an empty FORMAT;
+ *   - A NAME THE INPUT DOES NOT CARRY BECOMES A COLUMN OF ITS OWN. The header is built from the
+ *     names the user asked for, not from the names the file has, so the output declares a sample
+ *     that never existed and every record writes `./.` under it;
+ *   - THE ANNOTATIONS ARE KEPT AS THEY WERE. The INFO fields of a subset record are the whole
+ *     file's, not recomputed, so AC and AN can disagree with the genotypes that are left;
+ *   - THE ALLELES ARE RESET FROM THE ORIGINAL RECORD, `builder.alleles(ctx.getAlleles())`, so an
+ *     alternate no remaining genotype calls still appears in the ALT column;
+ *   - THE GENOTYPES ARE NO LONGER LAZY once subset, so the FORMAT column is recomputed from the
+ *     genotypes that remain and can be SHORTER than the input's;
+ *   - A FILE WITH NO SAMPLES AT ALL passes through unchanged;
+ *   - AND CREATE_INDEX IS ON BY DEFAULT for this tool, so a file whose header declares no contigs
+ *     is a refusal rather than an unindexed output.
+ *
+ * Output:
+ *
+ *     input\t<label>=<the whole input vcf, escaped>
+ *     sites\t<label>=<the whole output vcf, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: MakeSitesOnlyVcfDump
+ */
+
+import picard.vcf.MakeSitesOnlyVcf;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class MakeSitesOnlyVcfDump {
+
+    static final String HEADER =
+            "##fileformat=VCFv4.2\n"
+            + "##FILTER=<ID=LowQual,Description=\"Low quality\">\n"
+            + "##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allelic depths\">\n"
+            + "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Depth\">\n"
+            + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+            + "##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count\">\n"
+            + "##INFO=<ID=AN,Number=1,Type=Integer,Description=\"Allele number\">\n"
+            + "##contig=<ID=chr1,length=240>\n";
+
+    static final String THREE_SAMPLES = HEADER
+            + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tzeta\talpha\tmiddle\n"
+            + "chr1\t10\trs1\tA\tC\t50\tPASS\tAC=2;AN=6\tGT:AD:DP\t0/1:10,5:15\t0/0:20,0:20\t1/1:0,9:9\n"
+            + "chr1\t20\t.\tT\tG,C\t.\tLowQual\tAC=1,1;AN=6\tGT:AD\t0/1:5,5,0\t0/2:4,0,4\t0/0:9,0,0\n";
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("make-sites-only-dump");
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# MakeSitesOnlyVcfDump: a VCF with its genotypes dropped");
+
+        // The default: no samples at all.
+        run("sites-only", dir, THREE_SAMPLES);
+        // One sample, and the same one asked for twice.
+        run("one-sample", dir, THREE_SAMPLES, "S=alpha");
+        run("one-sample-twice", dir, THREE_SAMPLES, "S=alpha", "S=alpha");
+        // Two samples given in the order the file does not have them, which the TreeSet sorts.
+        run("two-samples-unsorted", dir, THREE_SAMPLES, "S=zeta", "S=alpha");
+        // Every sample, which is the file with its columns reordered.
+        run("all-samples", dir, THREE_SAMPLES, "S=zeta", "S=alpha", "S=middle");
+        // A sample the file does not carry, alone and beside one it does.
+        run("absent-sample", dir, THREE_SAMPLES, "S=absent");
+        run("absent-and-present", dir, THREE_SAMPLES, "S=absent", "S=alpha");
+        // A file that already has no samples.
+        run("already-sites-only", dir,
+                HEADER + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+                        + "chr1\t10\trs1\tA\tC\t50\tPASS\tAC=2;AN=6\n");
+        // A header declaring no contigs, which the on-by-default index refuses.
+        run("no-contigs", dir,
+                HEADER.replace("##contig=<ID=chr1,length=240>\n", "")
+                        + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\talpha\n"
+                        + "chr1\t10\trs1\tA\tC\t50\tPASS\tAC=1;AN=2\tGT\t0/1\n");
+        // The same file with the index turned off, which writes.
+        run("no-contigs-no-index", dir,
+                HEADER.replace("##contig=<ID=chr1,length=240>\n", "")
+                        + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\talpha\n"
+                        + "chr1\t10\trs1\tA\tC\t50\tPASS\tAC=1;AN=2\tGT\t0/1\n",
+                "CREATE_INDEX=false");
+    }
+
+    static void run(final String label, final Path dir, final String input, final String... extra)
+            throws Exception {
+        final Path in = dir.resolve(label + ".vcf");
+        Files.writeString(in, input, StandardCharsets.UTF_8);
+        final Path out = dir.resolve("sites-" + label + ".vcf");
+        System.out.printf("input\t%s=%s%n", label, ReferenceQueryDump.escape(input));
+        final List<String> argv = new ArrayList<>(Arrays.asList("I=" + in, "O=" + out));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            final Object code = new MakeSitesOnlyVcf().instanceMain(argv.toArray(new String[0]));
+            if (!Integer.valueOf(0).equals(code)) {
+                System.out.printf("exit\t%s=%s%n", label, code);
+                return;
+            }
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+            return;
+        }
+        System.out.printf("sites\t%s=%s%n", label, ReferenceQueryDump.escape(Files.readString(out)));
+    }
+}


### PR DESCRIPTION
Ten runs over a three-sample file whose columns are deliberately out of
alphabetical order (`zeta`, `alpha`, `middle`), each carrying its input as well
as its output: the default sites-only run, one sample, the same sample twice, two
given unsorted, all three, a sample the file does not carry, that one beside a
present one, a file that already has no samples, a header declaring no contigs,
and the same with the index turned off.

Behaviours the rows are chosen to catch: `SAMPLE` is a `TreeSet`, so the output
columns are alphabetical however they were typed; a name the input never carried
becomes a column of `./.`, the header being built from the names asked for; the
INFO fields are kept as they were, so AC and AN can disagree with the genotypes
left; the alleles are reset from the original record, so an ALT no remaining
genotype calls still appears; and `CREATE_INDEX` is on by default for this tool,
so a header declaring no contigs is a refusal.

Golden pending. The artefact comes from the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
