### PR TITLE
Measure SplitVcfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,10 @@ jobs:
             index: "39/39"
             slug: "gather-bqsr-reports-gather-tranches-check-terminator-block-rename-sample-in-vcf-make-sites-only-vcf"
             suites: "gather-bqsr-reports gather-tranches check-terminator-block rename-sample-in-vcf make-sites-only-vcf"
+          - group: golden-pending
+            index: "1/1"
+            slug: "split-vcfs"
+            suites: "split-vcfs"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,14 +7,14 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 106 | 34.1% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 193 | 62.1% |
+| not started | 192 | 61.7% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (46 of 109 started)
+## picard-origin tools (47 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -62,12 +62,13 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `SortSam` | record-transform | oracle-backed | sortsam, sortsam-bam | 2 | not measured |
 | `SplitSamByLibrary` | record-transform | oracle-backed | split | 2 | not measured |
 | `SplitSamByNumberOfReads` | record-transform | oracle-backed | split | 2 | not measured |
+| `SplitVcfs` | variant-transform | golden-pending | split-vcfs | 1 | not measured |
 | `ValidateSamFile` | reporting-walker | oracle-backed | validatesam | 6 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>63 not started</summary>
+<details><summary>62 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `MergeVcfs`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `SortVcf`, `SplitVcfs`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
+`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `MergeVcfs`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `SortVcf`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4719,6 +4719,26 @@
           "why": "Ten runs over a three-sample file whose columns are deliberately out of alphabetical order, each carrying its input as well as its output: the default sites-only run, one sample, the same sample twice, two given unsorted, all three, a sample the file does not carry, that one beside a present one, a file that already has no samples, a header declaring no contigs, and the same with the index turned off. Twenty rows: ten inputs, nine outputs and one refusal. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32418790241, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "split-vcfs",
+      "status": "golden-pending",
+      "title": "The SNPs in one file and the indels in the other",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "SplitVcfs"
+      ],
+      "why": "THE INDEL TEST RUNS FIRST, so a record that is both lands in the indel file. A MIXED RECORD IS IN NEITHER FILE, and so is a monomorphic one, a symbolic one and an MNP: the tool counts them out in silence. A SPANNING-DELETION ALTERNATE BESIDE A SNP LEAVES THE RECORD A SNP, the star being one base long, so it goes to the SNP file. STRICT IS ON BY DEFAULT, so a record that is neither refuses naming the type it found unless the user turns it off, after the earlier records are already written. BOTH FILES GET THE INPUT'S OWN HEADER however few records they hold. AND CREATE_INDEX IS ON BY DEFAULT, so a header declaring no contigs is a refusal before either file is opened.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "SplitVcfsDump",
+          "golden": null,
+          "why": "Eight runs, each carrying its input as well as its outputs: one file holding a record of every type the tool can meet, the same under STRICT, a file of only SNPs, one of only indels, one with no records, a STRICT run that does not refuse, a header declaring no contigs, and the same with the index off. Twenty-two rows: eight inputs, six pairs of outputs and two refusals, one for STRICT and one for the index. Golden pending: this laptop is not x86-64, so the artefact has to come from the runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/SplitVcfsDump.java
+++ b/tools/readfilter-conformance/SplitVcfsDump.java
@@ -1,0 +1,135 @@
+/*
+ * SplitVcfs, taken from the reference.
+ *
+ * One VCF in, two out: the indels in one file and the SNPs in the other, and everything that is
+ * neither in neither.
+ *
+ * Eight behaviours this is built to catch.
+ *
+ *   - THE INDEL TEST RUNS FIRST, so a record that is both by htsjdk's reckoning lands in the indel
+ *     file and never reaches the SNP one;
+ *   - A MIXED RECORD IS IN NEITHER FILE. `isIndel()` and `isSNP()` are both false for a record
+ *     carrying a SNP and an indel alternate, and the tool silently counts it out;
+ *   - A MONOMORPHIC RECORD IS ALSO IN NEITHER, its type being NO_VARIATION;
+ *   - A SYMBOLIC ALTERNATE IS IN NEITHER, while a SPANNING-DELETION `*` ALTERNATE BESIDE A SNP
+ *     LEAVES THE RECORD A SNP and it goes to the SNP file: `*` is one base long, so the type test
+ *     never sees a length difference;
+ *   - AN MNP IS IN NEITHER, being neither a SNP nor an indel;
+ *   - STRICT IS ON BY DEFAULT, so a record that is neither is a refusal naming the type it found
+ *     unless the user turns it off; the refusal comes after the earlier records are written;
+ *   - BOTH FILES GET THE INPUT'S OWN HEADER, samples and all, however few records they end up
+ *     holding;
+ *   - AND CREATE_INDEX IS ON BY DEFAULT, so an input whose header declares no contigs is a refusal
+ *     before either file is opened.
+ *
+ * Output:
+ *
+ *     input\t<label>=<the whole input vcf, escaped>
+ *     snps\t<label>=<the whole SNP output, escaped>
+ *     indels\t<label>=<the whole indel output, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: SplitVcfsDump
+ */
+
+import picard.vcf.SplitVcfs;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SplitVcfsDump {
+
+    static final String HEADER =
+            "##fileformat=VCFv4.2\n"
+            + "##FILTER=<ID=LowQual,Description=\"Low quality\">\n"
+            + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+            + "##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count\">\n"
+            + "##ALT=<ID=DEL,Description=\"Deletion\">\n"
+            + "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End\">\n"
+            + "##contig=<ID=chr1,length=240>\n"
+            + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA12878\n";
+
+    /** One record of each type the tool can meet. */
+    static final String EVERY_TYPE = HEADER
+            // A plain SNP.
+            + "chr1\t10\t.\tA\tC\t50\tPASS\tAC=1\tGT\t0/1\n"
+            // A biallelic SNP with two alternates, still a SNP.
+            + "chr1\t20\t.\tA\tC,G\t50\tPASS\tAC=1,1\tGT\t1/2\n"
+            // An insertion and a deletion.
+            + "chr1\t30\t.\tA\tACGT\t50\tPASS\tAC=1\tGT\t0/1\n"
+            + "chr1\t40\t.\tACGT\tA\t50\tPASS\tAC=1\tGT\t0/1\n"
+            // A SNP and an indel in one record, which is MIXED.
+            + "chr1\t50\t.\tA\tC,ACGT\t50\tPASS\tAC=1,1\tGT\t1/2\n"
+            // An MNP.
+            + "chr1\t60\t.\tAC\tGT\t50\tPASS\tAC=1\tGT\t0/1\n"
+            // Monomorphic: no alternate at all.
+            + "chr1\t70\t.\tA\t.\t50\tPASS\t.\tGT\t0/0\n"
+            // A symbolic alternate.
+            + "chr1\t80\t.\tA\t<DEL>\t50\tPASS\tEND=90\tGT\t0/1\n"
+            // A spanning deletion alternate beside a SNP.
+            + "chr1\t100\t.\tA\tC,*\t50\tPASS\tAC=1,1\tGT\t1/2\n";
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("split-vcfs-dump");
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# SplitVcfsDump: the SNPs in one file and the indels in the other");
+
+        // STRICT defaults to TRUE, so the file of every type refuses unless it is turned off.
+        run("every-type", dir, EVERY_TYPE, "STRICT=false");
+        run("strict", dir, EVERY_TYPE);
+        // Only SNPs, so the indel file is a header and nothing else.
+        run("snps-only", dir, HEADER
+                + "chr1\t10\t.\tA\tC\t50\tPASS\tAC=1\tGT\t0/1\n"
+                + "chr1\t20\t.\tG\tT\t50\tPASS\tAC=1\tGT\t0/1\n");
+        // Only indels.
+        run("indels-only", dir, HEADER
+                + "chr1\t30\t.\tA\tACGT\t50\tPASS\tAC=1\tGT\t0/1\n");
+        // No records at all: two headers.
+        run("no-records", dir, HEADER);
+        // Strict over a file that is all SNPs, which does not refuse.
+        run("strict-all-snps", dir, HEADER
+                + "chr1\t10\t.\tA\tC\t50\tPASS\tAC=1\tGT\t0/1\n");
+        // A header with no contigs, which the on-by-default index refuses.
+        run("no-contigs", dir,
+                HEADER.replace("##contig=<ID=chr1,length=240>\n", "")
+                        + "chr1\t10\t.\tA\tC\t50\tPASS\tAC=1\tGT\t0/1\n");
+        // The same with the index off.
+        run("no-contigs-no-index", dir,
+                HEADER.replace("##contig=<ID=chr1,length=240>\n", "")
+                        + "chr1\t10\t.\tA\tC\t50\tPASS\tAC=1\tGT\t0/1\n",
+                "CREATE_INDEX=false");
+    }
+
+    static void run(final String label, final Path dir, final String input, final String... extra)
+            throws Exception {
+        final Path in = dir.resolve(label + ".vcf");
+        Files.writeString(in, input, StandardCharsets.UTF_8);
+        final Path snps = dir.resolve("snps-" + label + ".vcf");
+        final Path indels = dir.resolve("indels-" + label + ".vcf");
+        System.out.printf("input\t%s=%s%n", label, ReferenceQueryDump.escape(input));
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "I=" + in, "SNP_OUTPUT=" + snps, "INDEL_OUTPUT=" + indels));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            final Object code = new SplitVcfs().instanceMain(argv.toArray(new String[0]));
+            if (!Integer.valueOf(0).equals(code)) {
+                System.out.printf("exit\t%s=%s%n", label, code);
+                return;
+            }
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+            return;
+        }
+        System.out.printf("snps\t%s=%s%n", label,
+                ReferenceQueryDump.escape(Files.readString(snps)));
+        System.out.printf("indels\t%s=%s%n", label,
+                ReferenceQueryDump.escape(Files.readString(indels)));
+    }
+}


### PR DESCRIPTION
Eight runs, each carrying its input as well as its two outputs: one file holding
a record of every type the tool can meet, the same under the default STRICT, a
file of only SNPs, one of only indels, one with no records, a STRICT run that
does not refuse, a header declaring no contigs, and the same with the index off.

Behaviours the rows are chosen to catch: the indel test runs first; a MIXED
record, a monomorphic one, an MNP and a symbolic alternate are each in neither
file; a spanning-deletion alternate beside a SNP leaves the record a SNP, the
star being one base long; STRICT is on by default, so a file carrying any of the
above refuses after the earlier records are written; both files get the input's
own header however few records they hold; and `CREATE_INDEX` is on by default.

Golden pending. The artefact comes from the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
