### PR TITLE
Measure MergeVcfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,10 @@ jobs:
             index: "40/40"
             slug: "split-vcfs-sort-vcf"
             suites: "split-vcfs sort-vcf"
+          - group: golden-pending
+            index: "1/1"
+            slug: "merge-vcfs"
+            suites: "merge-vcfs"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,14 +7,14 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 108 | 34.7% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 191 | 61.4% |
+| not started | 190 | 61.1% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (48 of 109 started)
+## picard-origin tools (49 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -47,6 +47,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `MeanQualityByCycle` | reporting-walker | oracle-backed | metrics | 4 | not measured |
 | `MergeBamAlignment` | record-transform | unchecked | mergebamalignment, mergebamalignment-full | 2 | not measured |
 | `MergeSamFiles` | record-transform | oracle-backed | merge | 1 | not measured |
+| `MergeVcfs` | variant-transform | golden-pending | merge-vcfs | 1 | not measured |
 | `NonNFastaSize` | reference-utility | unchecked | nonnfastasize | 1 | not measured |
 | `NormalizeFasta` | reference-utility | unchecked | normalizefasta | 1 | not measured |
 | `QualityScoreDistribution` | reporting-walker | unchecked | qualityscoredistribution | 1 | not measured |
@@ -67,9 +68,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ValidateSamFile` | reporting-walker | oracle-backed | validatesam | 6 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>61 not started</summary>
+<details><summary>60 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `MergeVcfs`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
+`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4759,6 +4759,26 @@
           "why": "Eleven runs, each carrying every input it was given as well as its output: one unsorted file over a dictionary declaring chr10 before chr2, two files whose records interleave and collide at one locus, the same two reversed, a merged header, a conflicting one, two samples, two files whose sample order differs, two files whose dictionaries differ, a file with no dictionary, a record on an undeclared contig, and a file with no records. The one refusal that names a path has it masked. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32420753151, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "merge-vcfs",
+      "status": "golden-pending",
+      "title": "Several sorted VCFs merged into one",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "MergeVcfs"
+      ],
+      "why": "The sibling of sort-vcf, and the differences are the point. THE MERGE IS A HEAP OVER SORTED INPUTS, so a file whose own records are out of order is a refusal from the merging iterator rather than being repaired. A TIE BETWEEN TWO INPUTS IS NOT DECIDED BY THE ORDER THEY WERE GIVEN, which is the opposite of SortVcf. THE CONTIG CHECK IS isCompatible, which is about INDICES, so both a subset that shifts an index and a reordering are refused. THE SAMPLE CHECK IS ON THE SORTED NAMES. EVERY COMMENT IS A LINE KEYED MergeVcfs.comment and the smart merge keys unstructured lines by their key, so TWO COMMENTS COLLAPSE INTO ONE. THE HEADERS ARE A LinkedHashSet, so two identical input headers collapse before the merge sees them. A FILE WITH NO CONTIG LINES IS A REFUSAL unless a dictionary is supplied. AND THE RECORDS GO BACK OUT THROUGH THE WRITER.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "MergeVcfsDump",
+          "golden": null,
+          "why": "Thirteen runs, each carrying every input as well as its output: two files that interleave and tie at one locus, the same two reversed, one file alone, three files, two identical files, a file whose own records are out of order, a second file declaring a subset of the contigs, one declaring them in another order, two files whose sample columns are ordered differently, one with different samples, a run with two comments, a file with no contig lines, and an empty file merged with a full one. The refusals that name a path have it masked. Golden pending: this laptop is not x86-64, so the artefact has to come from the runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/MergeVcfsDump.java
+++ b/tools/readfilter-conformance/MergeVcfsDump.java
@@ -1,0 +1,153 @@
+/*
+ * MergeVcfs, taken from the reference.
+ *
+ * Several already-sorted VCFs merged into one by a merging iterator, under a header smart-merged
+ * from all of them. The sibling of SortVcf, and the differences between the two are the point.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - THE MERGE IS A HEAP OVER SORTED INPUTS, not a sort of everything: a file whose own records
+ *     are out of order is a REFUSAL from the merging iterator, naming the comparator class and no
+ *     file at all;
+ *   - A TIE BETWEEN TWO INPUTS IS NOT DECIDED BY THE ORDER THEY WERE GIVEN. Both orders of the
+ *     same pair write the same two records in the same order, which is the opposite of SortVcf,
+ *     where the input order decides;
+ *   - THE CONTIG CHECK IS `isCompatible`, WHICH IS ABOUT INDICES: a second file must declare each
+ *     shared contig at the SAME index, so both a subset that shifts an index and a reordering are
+ *     refused, and the refusal names the file;
+ *   - THE SAMPLE CHECK IS ON THE SORTED NAMES, so two files whose sample columns are ordered
+ *     differently are accepted and the output's columns are the sorted names;
+ *   - EVERY COMMENT IS WRITTEN AS A LINE KEYED `MergeVcfs.comment`, and the smart merge keys
+ *     unstructured lines by their key, so TWO COMMENTS COLLAPSE INTO ONE: asking for two notes
+ *     writes the first and silently drops the second;
+ *   - THE HEADER IS A LinkedHashSet OF HEADERS, so two identical input headers collapse to one
+ *     before the merge ever sees them;
+ *   - A FILE WITH NO CONTIG LINES IS A REFUSAL unless a dictionary is supplied;
+ *   - THE INDEX CHECK RUNS AFTER EVERY FILE IS READ, so its refusal names no file at all;
+ *   - AND THE RECORDS GO BACK OUT THROUGH THE WRITER, so their QUAL spellings are the writer's.
+ *
+ * Output:
+ *
+ *     input\t<label>/<n>=<the whole input vcf, escaped>
+ *     merged\t<label>=<the whole output vcf, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: MergeVcfsDump
+ */
+
+import picard.vcf.MergeVcfs;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class MergeVcfsDump {
+
+    static String header(final String contigs, final String samples) {
+        return "##fileformat=VCFv4.2\n"
+                + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+                + "##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count\">\n"
+                + contigs
+                + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t" + samples + "\n";
+    }
+
+    /** chr10 before chr2, so the order is visibly the dictionary's. */
+    static final String CONTIGS =
+            "##contig=<ID=chr10,length=240>\n##contig=<ID=chr2,length=240>\n";
+
+    static String record(final String contig, final int position, final String id,
+                         final String qual) {
+        return contig + "\t" + position + "\t" + id + "\tA\tC\t" + qual + "\tPASS\tAC=1\tGT\t0/1\n";
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("merge-vcfs-dump");
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# MergeVcfsDump: several sorted VCFs merged into one");
+
+        final String first = header(CONTIGS, "NA1")
+                + record("chr10", 5, "first-a", "50.00")
+                + record("chr2", 10, "first-b", "10.5")
+                + record("chr2", 30, "first-c", "50");
+        final String second = header(CONTIGS, "NA1")
+                + record("chr10", 20, "second-a", "50")
+                + record("chr2", 10, "second-b", "50")
+                + record("chr2", 20, "second-c", "50");
+
+        run("two-files", dir, new String[] {first, second});
+        // The same two the other way round, which is what says whether the tie at chr2:10 is
+        // decided by the input order. It is not.
+        run("reversed", dir, new String[] {second, first});
+        // One file alone.
+        run("one-file", dir, new String[] {first});
+        // Three files, the third holding one record between the others.
+        run("three-files", dir, new String[] {first, second,
+                header(CONTIGS, "NA1") + record("chr2", 15, "third-a", "50")});
+        // Two identical files, which the LinkedHashSet of headers collapses.
+        run("identical-files", dir, new String[] {first, first});
+        // A file whose own records are out of order, which the merging iterator refuses.
+        run("unsorted-input", dir, new String[] {
+                header(CONTIGS, "NA1")
+                        + record("chr2", 30, "out-a", "50")
+                        + record("chr2", 10, "out-b", "50"),
+                second});
+        // A second file declaring only one of the first's contigs, which shifts that contig's
+        // index and is therefore not compatible.
+        run("subset-contigs", dir, new String[] {first,
+                header("##contig=<ID=chr2,length=240>\n", "NA1") + record("chr2", 25, "sub", "50")});
+        // A second file declaring the same contigs in the other order, which it does not.
+        run("reordered-contigs", dir, new String[] {first,
+                header("##contig=<ID=chr2,length=240>\n##contig=<ID=chr10,length=240>\n", "NA1")
+                        + record("chr2", 25, "reordered", "50")});
+        // Two samples listed in different orders.
+        run("sample-order-differs", dir, new String[] {
+                header(CONTIGS, "zeta\talpha")
+                        + "chr2\t10\t.\tA\tC\t50\tPASS\tAC=1\tGT\t0/1\t1/1\n",
+                header(CONTIGS, "alpha\tzeta")
+                        + "chr2\t20\t.\tA\tC\t50\tPASS\tAC=1\tGT\t0/1\t1/1\n"});
+        // A file with different samples, which is a refusal.
+        run("different-samples", dir, new String[] {first,
+                header(CONTIGS, "NA2") + record("chr2", 25, "other", "50")});
+        // Two comments, of which only the first survives the merge.
+        run("comments", dir, new String[] {first, second}, "CO=first note", "CO=second note");
+        // No contig lines at all.
+        run("no-contigs", dir, new String[] {
+                header("", "NA1") + record("chr2", 10, "nodict", "50")});
+        // A file with no records, merged with one that has them.
+        run("empty-file", dir, new String[] {header(CONTIGS, "NA1"), second});
+    }
+
+    static void run(final String label, final Path dir, final String[] inputs,
+                    final String... extra) throws Exception {
+        final List<String> argv = new ArrayList<>();
+        for (int i = 0; i < inputs.length; i++) {
+            final Path in = dir.resolve(label + "-" + i + ".vcf");
+            Files.writeString(in, inputs[i], StandardCharsets.UTF_8);
+            System.out.printf("input\t%s/%d=%s%n", label, i, ReferenceQueryDump.escape(inputs[i]));
+            argv.add("I=" + in);
+        }
+        final Path out = dir.resolve("merged-" + label + ".vcf");
+        argv.addAll(Arrays.asList("O=" + out, "CREATE_INDEX=false"));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            final Object code = new MergeVcfs().instanceMain(argv.toArray(new String[0]));
+            if (!Integer.valueOf(0).equals(code)) {
+                System.out.printf("exit\t%s=%s%n", label, code);
+                return;
+            }
+        } catch (final Exception | AssertionError e) {
+            // Two refusals name the input's path, which is where the run happened.
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())
+                            .replaceAll("/work/merge-vcfs-dump/[^ ]+", "<masked>")));
+            return;
+        }
+        System.out.printf("merged\t%s=%s%n", label,
+                ReferenceQueryDump.escape(Files.readString(out)));
+    }
+}


### PR DESCRIPTION
Thirteen runs, each carrying every input as well as its output: two files that
interleave and tie at one locus, the same two reversed, one file alone, three
files, two identical files, a file whose own records are out of order, a second
file declaring a subset of the contigs, one declaring them in another order, two
files whose sample columns are ordered differently, one with different samples, a
run with two comments, a file with no contig lines, and an empty file merged with
a full one.

Three findings separate this tool from `SortVcf`, whose golden landed earlier:

- an input whose own records are out of order is a **refusal** from the merging
  iterator, naming the comparator class and no file;
- a tie between two inputs is **not** decided by the order they were given — both
  orders write the same two records the same way, where `SortVcf`'s tie follows
  the input order;
- and two `CO=` comments **collapse into one**, the smart merge keying
  unstructured lines by their key, so the second note is silently dropped.

The refusals that name a path have it masked.

Golden pending. The artefact comes from the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
