### PR TITLE
Measure FixVcfHeader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,10 @@ jobs:
             index: "40/40"
             slug: "split-vcfs-sort-vcf-merge-vcfs"
             suites: "split-vcfs sort-vcf merge-vcfs"
+          - group: golden-pending
+            index: "1/1"
+            slug: "fix-vcf-header"
+            suites: "fix-vcf-header"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,14 +7,14 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 109 | 35.0% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 190 | 61.1% |
+| not started | 189 | 60.8% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (49 of 109 started)
+## picard-origin tools (50 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -40,6 +40,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `FastqToSam` | record-transform | oracle-backed | fastqtosam | 1 | not measured |
 | `FilterSamReads` | record-transform | oracle-backed | filtersamreads | 1 | not measured |
 | `FixMateInformation` | record-transform | oracle-backed | fixmate | 1 | not measured |
+| `FixVcfHeader` | variant-transform | golden-pending | fix-vcf-header | 1 | not measured |
 | `IntervalListToBed` | interval-utility | unchecked | intervallisttobed | 1 | not measured |
 | `IntervalListTools` | interval-utility | oracle-backed | intervallisttools, intervallisttoolspadbreak | 4 | not measured |
 | `LiftOverIntervalList` | interval-utility | unchecked | liftoverintervallist | 1 | not measured |
@@ -68,9 +69,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ValidateSamFile` | reporting-walker | oracle-backed | validatesam | 6 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>60 not started</summary>
+<details><summary>59 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `FixVcfHeader`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
+`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4779,6 +4779,26 @@
           "why": "Thirteen runs, each carrying every input as well as its output: two files that interleave and tie at one locus, the same two reversed, one file alone, three files, two identical files, a file whose own records are out of order, a second file declaring a subset of the contigs, one declaring them in another order, two files whose sample columns are ordered differently, one with different samples, a run with two comments, a file with no contig lines, and an empty file merged with a full one. The refusals that name a path have it masked. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32421712465, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "fix-vcf-header",
+      "status": "golden-pending",
+      "title": "A VCF header rebuilt from the records under it",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "FixVcfHeader"
+      ],
+      "why": "AN INVENTED LINE IS ALWAYS Number=. AND Type=String whatever the value looks like, with a fixed description naming the tool. THE STANDARD FORMAT LINES ARE ADDED WHATEVER THE FILE USES, so the output declares more than the input ever needed. A FILTER ON A RECORD IS A DECLARATION TO INVENT and PASS is not. CHECK_FIRST_N_RECORDS STOPS THE SEARCH EARLY, so a key in a later record is not declared and the write then fails on it. THE HEADER FILE REPLACES THE HEADER WHOLESALE, nothing of the input's surviving but its samples. ENFORCE_SAME_SAMPLES IS ON BY DEFAULT and compares the lists pairwise, naming the first index that differs. WITH IT OFF THE INPUT'S SAMPLES ARE KEPT. A HEADER FILE AND A RECORD LIMIT TOGETHER ARE A COMMAND-LINE REFUSAL. AND THE WRITER HAS ALLOW_MISSING_FIELDS_IN_HEADER UNSET, so anything the fixing missed is a refusal rather than a silently written file.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "FixVcfHeaderDump",
+          "golden": null,
+          "why": "Ten runs, each carrying its input and, where there is one, its replacement header: a file with undeclared INFO, FORMAT and FILTER keys, the same examined one record deep, a file missing nothing, a file with no records, a replacement header, one naming a different sample, the same unenforced, a sites-only header, an incomplete replacement, and a header file given beside a record limit. Golden pending: this laptop is not x86-64, so the artefact has to come from the runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/FixVcfHeaderDump.java
+++ b/tools/readfilter-conformance/FixVcfHeaderDump.java
@@ -1,0 +1,133 @@
+/*
+ * FixVcfHeader, taken from the reference.
+ *
+ * A VCF whose header does not declare everything its records use, written back out with the
+ * missing declarations invented, or with a header taken wholesale from another file.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - AN INVENTED LINE IS ALWAYS `Number=.` AND `Type=String`, whatever the value looks like, and
+ *     its description is a fixed sentence naming the tool;
+ *   - THE STANDARD FORMAT LINES ARE ADDED WHATEVER THE FILE USES. `addStandardFormatLines` puts
+ *     GT, AD, DP, GQ, PL and the rest into the output header even for a file that carries none of
+ *     them, so the output declares more than the input ever needed;
+ *   - A FILTER ON A RECORD IS A DECLARATION TO INVENT, and `PASS` is not: the filters of a passing
+ *     record are empty, so nothing is added for it;
+ *   - CHECK_FIRST_N_RECORDS STOPS THE SEARCH EARLY, so a key that appears only in a later record
+ *     is not declared and the write then fails on it;
+ *   - THE HEADER FILE REPLACES THE HEADER WHOLESALE. Nothing of the input's header survives except
+ *     its samples, and the tool warns about lines it is adding without ever comparing the two;
+ *   - ENFORCE_SAME_SAMPLES IS ON BY DEFAULT and compares the SORTED sample lists PAIRWISE, naming
+ *     the index of the first that differs;
+ *   - WITH IT OFF, THE INPUT'S SAMPLES ARE KEPT and the header file's are discarded, so a header
+ *     file with no samples at all still writes a file with the input's columns;
+ *   - A HEADER FILE AND CHECK_FIRST_N_RECORDS TOGETHER ARE A COMMAND-LINE REFUSAL;
+ *   - AND THE WRITER IS BUILT WITH ALLOW_MISSING_FIELDS_IN_HEADER UNSET, so anything the fixing
+ *     missed is a refusal at the record that uses it rather than a silently written file.
+ *
+ * Output:
+ *
+ *     input\t<label>=<the whole input vcf, escaped>
+ *     header\t<label>=<the replacement header file, escaped>
+ *     fixed\t<label>=<the whole output vcf, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: FixVcfHeaderDump
+ */
+
+import picard.vcf.FixVcfHeader;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FixVcfHeaderDump {
+
+    static final String COLUMNS =
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA1\n";
+
+    /** A header declaring nothing but the contig and GT. */
+    static final String BARE =
+            "##fileformat=VCFv4.2\n"
+            + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+            + "##contig=<ID=chr1,length=240>\n";
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("fix-vcf-header-dump");
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# FixVcfHeaderDump: a VCF header rebuilt from the records under it");
+
+        // Undeclared INFO keys, an undeclared FORMAT key and an undeclared filter.
+        final String undeclared = BARE + COLUMNS
+                + "chr1\t10\t.\tA\tC\t50\tPASS\tXX=1;YY=a,b\tGT:ZZ\t0/1:7\n"
+                + "chr1\t20\t.\tA\tG\t50\tmy_filter\tXX=2\tGT\t0/1\n";
+        run("undeclared", dir, undeclared, null);
+        // Only the first record examined, so the second's filter is never declared.
+        run("first-one-record", dir, undeclared, null, "N=1");
+        // A file whose header already declares everything.
+        run("nothing-missing", dir,
+                BARE.replace("##contig", "##INFO=<ID=XX,Number=1,Type=Integer,Description=\"x\">\n##contig")
+                        + COLUMNS + "chr1\t10\t.\tA\tC\t50\tPASS\tXX=1\tGT\t0/1\n", null);
+        // A file with no records at all, which still gains the standard FORMAT lines.
+        run("no-records", dir, BARE + COLUMNS, null);
+
+        // A replacement header that declares everything, with the same sample.
+        final String replacement = "##fileformat=VCFv4.2\n"
+                + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+                + "##FORMAT=<ID=ZZ,Number=1,Type=Integer,Description=\"z\">\n"
+                + "##FILTER=<ID=my_filter,Description=\"mine\">\n"
+                + "##INFO=<ID=XX,Number=1,Type=Integer,Description=\"x\">\n"
+                + "##INFO=<ID=YY,Number=.,Type=String,Description=\"y\">\n"
+                + "##contig=<ID=chr1,length=240>\n"
+                + COLUMNS;
+        run("replacement-header", dir, undeclared, replacement);
+        // The same header carrying a different sample name.
+        run("different-sample", dir, undeclared,
+                replacement.replace("\tNA1\n", "\tOTHER\n"));
+        // The same, with the sample check turned off, which keeps the input's samples.
+        run("different-sample-unenforced", dir, undeclared,
+                replacement.replace("\tNA1\n", "\tOTHER\n"), "ENFORCE_SAME_SAMPLES=false");
+        // A header file with no samples at all, unenforced.
+        run("sites-only-header", dir, undeclared,
+                replacement.replace("\tFORMAT\tNA1\n", "\n"), "ENFORCE_SAME_SAMPLES=false");
+        // A replacement header that does not declare one of the keys, which the writer refuses.
+        run("incomplete-header", dir, undeclared,
+                replacement.replace("##INFO=<ID=YY,Number=.,Type=String,Description=\"y\">\n", ""));
+        // Both a header file and a record limit, which is the command-line refusal.
+        run("header-and-limit", dir, undeclared, replacement, "N=1");
+    }
+
+    static void run(final String label, final Path dir, final String input, final String header,
+                    final String... extra) throws Exception {
+        final Path in = dir.resolve(label + ".vcf");
+        Files.writeString(in, input, StandardCharsets.UTF_8);
+        System.out.printf("input\t%s=%s%n", label, ReferenceQueryDump.escape(input));
+        final List<String> argv = new ArrayList<>(Arrays.asList("I=" + in));
+        if (header != null) {
+            final Path headerPath = dir.resolve(label + "-header.vcf");
+            Files.writeString(headerPath, header, StandardCharsets.UTF_8);
+            System.out.printf("header\t%s=%s%n", label, ReferenceQueryDump.escape(header));
+            argv.add("H=" + headerPath);
+        }
+        final Path out = dir.resolve("fixed-" + label + ".vcf");
+        argv.addAll(Arrays.asList("O=" + out, "CREATE_INDEX=false"));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            final Object code = new FixVcfHeader().instanceMain(argv.toArray(new String[0]));
+            if (!Integer.valueOf(0).equals(code)) {
+                System.out.printf("exit\t%s=%s%n", label, code);
+                return;
+            }
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+            return;
+        }
+        System.out.printf("fixed\t%s=%s%n", label, ReferenceQueryDump.escape(Files.readString(out)));
+    }
+}


### PR DESCRIPTION
Ten runs, each carrying its input and, where there is one, its replacement
header: a file with undeclared INFO, FORMAT and FILTER keys, the same examined
one record deep, a file missing nothing, a file with no records, a replacement
header, one naming a different sample, the same unenforced, a sites-only header,
an incomplete replacement, and a header file given beside a record limit.

Behaviours the rows are chosen to catch: an invented line is always `Number=.`
and `Type=String` with a fixed description naming the tool; the standard FORMAT
lines are added whatever the file uses, so a file carrying only GT comes out
declaring AD, DP, FT, GQ and PL too; `CHECK_FIRST_N_RECORDS` stops the search
early, so a filter that appears only in the second record is never declared and
the write then fails on it; `ENFORCE_SAME_SAMPLES` compares the lists pairwise
and names the first index that differs; with it off the input's samples are kept
and the header file's discarded; and the writer has `ALLOW_MISSING_FIELDS_IN_HEADER`
unset, so an incomplete replacement header is a refusal at the record that uses
the missing key.

Golden pending. The artefact comes from the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
