### PR TITLE
Measure FilterVcf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,10 @@ jobs:
             index: "40/40"
             slug: "split-vcfs-sort-vcf-merge-vcfs-fix-vcf-header"
             suites: "split-vcfs sort-vcf merge-vcfs fix-vcf-header"
+          - group: golden-pending
+            index: "1/1"
+            slug: "filter-vcf"
+            suites: "filter-vcf"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,14 +7,14 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 110 | 35.4% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 189 | 60.8% |
+| not started | 188 | 60.5% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (50 of 109 started)
+## picard-origin tools (51 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -39,6 +39,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ExtractSequences` | reference-utility | unchecked | extractsequences | 1 | not measured |
 | `FastqToSam` | record-transform | oracle-backed | fastqtosam | 1 | not measured |
 | `FilterSamReads` | record-transform | oracle-backed | filtersamreads | 1 | not measured |
+| `FilterVcf` | variant-transform | golden-pending | filter-vcf | 1 | not measured |
 | `FixMateInformation` | record-transform | oracle-backed | fixmate | 1 | not measured |
 | `FixVcfHeader` | variant-transform | oracle-backed | fix-vcf-header | 1 | not measured |
 | `IntervalListToBed` | interval-utility | unchecked | intervallisttobed | 1 | not measured |
@@ -69,9 +70,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ValidateSamFile` | reporting-walker | oracle-backed | validatesam | 6 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>59 not started</summary>
+<details><summary>58 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FilterVcf`, `FindMendelianViolations`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
+`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FindMendelianViolations`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4799,6 +4799,26 @@
           "why": "Ten runs, each carrying its input and, where there is one, its replacement header: a file with undeclared INFO, FORMAT and FILTER keys, the same examined one record deep, a file missing nothing, a file with no records, a replacement header, one naming a different sample, the same unenforced, a sites-only header, an incomplete replacement, and a header file given beside a record limit. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32424321216, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "filter-vcf",
+      "status": "golden-pending",
+      "title": "A VCF with its sites and genotypes filtered",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "FilterVcf"
+      ],
+      "why": "EVERY GENOTYPE IS GIVEN AN FT AND A PASSING ONE NEVER REACHES THE FILE, so the FORMAT column gains FT only where something was filtered. THE SITE FILTERS ARE A SET the writer sorts. LowQD IS NOT APPLIED WHEN QD IS ABSENT, the default being -1 and the test qd >= 0 && qd < minimum. StrandBias IS APPLIED TO A RECORD WITH NO FS ONLY IF THE THRESHOLD IS NEGATIVE. THE ALLELE BALANCE FILTER GROUPS BY THE GENOTYPE'S ALLELE LIST, so two samples with the same het call share one tally, and it ignores a het with no AD. THE GENOTYPE FILTERS READ getGQ() AND getDP(), which are -1 when absent, so a genotype carrying neither is filtered by both. AllGtsFiltered IS A SITE FILTER SET BY THE GENOTYPES: a record every one of whose genotypes was filtered is itself filtered. AND THE HEADER THE WRITER GETS IS THE READER'S OWN OBJECT, mutated in place.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "FilterVcfDump",
+          "golden": null,
+          "why": "Eleven runs over one three-sample file of nine records, one per behaviour: everything passing, a het whose balance is off in two samples, high FS with low QD, a record with neither, genotypes missing GQ and DP, a het with no AD, a record with no het at all, and one that already carries a filter. The runs move each threshold in turn, then all of them at once, and close with a file of no records and a header with no contigs. Golden pending: this laptop is not x86-64, so the artefact has to come from the runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/FilterVcfDump.java
+++ b/tools/readfilter-conformance/FilterVcfDump.java
@@ -1,0 +1,140 @@
+/*
+ * FilterVcf, taken from the reference.
+ *
+ * Three site filters and two genotype filters applied to every record, written back out with the
+ * FILTER column and every genotype's FT set.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - EVERY GENOTYPE IS GIVEN AN FT AND A PASSING ONE NEVER REACHES THE FILE. The iterator sets
+ *     `FT=PASS` on every genotype it did not filter, and the writer drops it, so the FORMAT column
+ *     gains `FT` only on the records where something was filtered;
+ *   - THE SITE FILTERS ARE COLLECTED INTO A SET and the writer sorts it, so two filters come out
+ *     alphabetically rather than in the order the filters ran;
+ *   - `LowQD` IS NOT APPLIED WHEN QD IS ABSENT. The default is -1 and the test is `qd >= 0 && qd <
+ *     minimum`, so a record with no QD passes however low the threshold;
+ *   - `StrandBias` IS APPLIED WHEN FS IS ABSENT ONLY IF THE THRESHOLD IS NEGATIVE, the default
+ *     being 0 and the test `fs > max`;
+ *   - THE ALLELE BALANCE FILTER GROUPS BY THE GENOTYPE'S ALLELE LIST, so two samples with the same
+ *     het call share one tally and a third with a different call has its own;
+ *   - IT IGNORES A HET GENOTYPE WITH NO AD, and answers nothing at all when the record has no het
+ *     genotype;
+ *   - THE GENOTYPE FILTERS READ getGQ() AND getDP(), which are -1 when absent, so a genotype
+ *     carrying neither is filtered by both at any non-negative threshold;
+ *   - `AllGtsFiltered` IS A SITE FILTER SET BY THE GENOTYPES: a record every one of whose
+ *     genotypes was filtered is itself filtered, and that filter replaces the PASS the site checks
+ *     would otherwise have written;
+ *   - AND THE HEADER THE WRITER GETS IS THE READER'S OWN OBJECT, mutated in place, so the four
+ *     lines the tool adds are there even though `writeHeader` was handed the input's header.
+ *
+ * Output:
+ *
+ *     input\t<label>=<the whole input vcf, escaped>
+ *     filtered\t<label>=<the whole output vcf, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: FilterVcfDump
+ */
+
+import picard.vcf.filter.FilterVcf;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FilterVcfDump {
+
+    static final String HEADER =
+            "##fileformat=VCFv4.2\n"
+            + "##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allelic depths\">\n"
+            + "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Depth\">\n"
+            + "##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Genotype quality\">\n"
+            + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+            + "##INFO=<ID=FS,Number=1,Type=Float,Description=\"Fisher strand\">\n"
+            + "##INFO=<ID=QD,Number=1,Type=Float,Description=\"Quality by depth\">\n"
+            + "##contig=<ID=chr1,length=240>\n"
+            + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tone\ttwo\tthree\n";
+
+    /** One record per behaviour, all three samples present. */
+    static final String RECORDS =
+            // Everything passes.
+            "chr1\t10\t.\tA\tC\t50\t.\tFS=1.0;QD=20.0\tGT:AD:DP:GQ\t0/1:10,10:20:99\t"
+            + "0/0:20,0:20:99\t1/1:0,20:20:99\n"
+            // A het whose allele balance is far off, shared by two samples.
+            + "chr1\t20\t.\tA\tC\t50\t.\tFS=1.0;QD=20.0\tGT:AD:DP:GQ\t0/1:19,1:20:99\t"
+            + "0/1:18,2:20:99\t0/0:20,0:20:99\n"
+            // High FS and low QD together, which is two site filters at once.
+            + "chr1\t30\t.\tA\tC\t50\t.\tFS=99.0;QD=0.5\tGT:AD:DP:GQ\t0/1:10,10:20:99\t"
+            + "0/0:20,0:20:99\t0/0:20,0:20:99\n"
+            // No QD and no FS at all.
+            + "chr1\t40\t.\tA\tC\t50\t.\t.\tGT:AD:DP:GQ\t0/1:10,10:20:99\t0/0:20,0:20:99\t"
+            + "0/0:20,0:20:99\n"
+            // One genotype with neither GQ nor DP, one with a low GQ, one with a low DP.
+            + "chr1\t50\t.\tA\tC\t50\t.\tFS=1.0;QD=20.0\tGT:AD\t0/1:10,10\t"
+            + "0/0:20,0\t1/1:0,20\n"
+            + "chr1\t60\t.\tA\tC\t50\t.\tFS=1.0;QD=20.0\tGT:AD:DP:GQ\t0/1:10,10:20:5\t"
+            + "0/0:20,0:2:99\t1/1:0,20:20:99\n"
+            // A het with no AD, which the allele balance filter skips.
+            + "chr1\t70\t.\tA\tC\t50\t.\tFS=1.0;QD=20.0\tGT:DP:GQ\t0/1:20:99\t0/0:20:99\t"
+            + "0/0:20:99\n"
+            // No het genotype at all.
+            + "chr1\t80\t.\tA\tC\t50\t.\tFS=1.0;QD=20.0\tGT:AD:DP:GQ\t0/0:20,0:20:99\t"
+            + "1/1:0,20:20:99\t0/0:20,0:20:99\n"
+            // A record that already carries a filter, which is replaced rather than added to.
+            + "chr1\t90\t.\tA\tC\t50\tmine\tFS=1.0;QD=20.0\tGT:AD:DP:GQ\t0/1:10,10:20:99\t"
+            + "0/0:20,0:20:99\t0/0:20,0:20:99\n";
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("filter-vcf-dump");
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# FilterVcfDump: a VCF with its sites and genotypes filtered");
+
+        final String input = HEADER + RECORDS;
+        run("defaults", dir, input);
+        // Each threshold moved in turn.
+        run("min-ab", dir, input, "MIN_AB=0.4");
+        run("max-fs", dir, input, "MAX_FS=0.5");
+        run("min-qd", dir, input, "MIN_QD=25");
+        run("min-gq", dir, input, "MIN_GQ=50");
+        run("min-dp", dir, input, "MIN_DP=10");
+        // A negative FS threshold, which filters the record that has no FS at all.
+        run("negative-fs", dir, input, "MAX_FS=-1");
+        // Every threshold at once.
+        run("everything", dir, input, "MIN_AB=0.45", "MAX_FS=0.5", "MIN_QD=25", "MIN_GQ=50",
+                "MIN_DP=10");
+        // A file with no records.
+        run("no-records", dir, HEADER);
+        // A header with no contigs, which a .vcf output refuses.
+        run("no-contigs", dir,
+                HEADER.replace("##contig=<ID=chr1,length=240>\n", "") + RECORDS);
+    }
+
+    static void run(final String label, final Path dir, final String input, final String... extra)
+            throws Exception {
+        final Path in = dir.resolve(label + ".vcf");
+        Files.writeString(in, input, StandardCharsets.UTF_8);
+        System.out.printf("input\t%s=%s%n", label, ReferenceQueryDump.escape(input));
+        final Path out = dir.resolve("filtered-" + label + ".vcf");
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "I=" + in, "O=" + out, "CREATE_INDEX=false"));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            final Object code = new FilterVcf().instanceMain(argv.toArray(new String[0]));
+            if (!Integer.valueOf(0).equals(code)) {
+                System.out.printf("exit\t%s=%s%n", label, code);
+                return;
+            }
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+            return;
+        }
+        System.out.printf("filtered\t%s=%s%n", label,
+                ReferenceQueryDump.escape(Files.readString(out)));
+    }
+}


### PR DESCRIPTION
Eleven runs over one three-sample file of nine records, one per behaviour:
everything passing, a het whose balance is off in two samples, high FS with low
QD, a record with neither, genotypes missing GQ and DP, a het with no AD, a
record with no het at all, and one that already carries a filter. The runs move
each threshold in turn, then all of them at once, and close with a file of no
records and a header with no contigs.

Behaviours the rows are chosen to catch: a passing genotype is given `FT=PASS`
and the writer drops it, so FT appears only where something was filtered; a
record whose genotypes were all filtered is itself `AllGtsFiltered`; `LowQD` is
not applied when QD is absent, the default being -1 and the test `qd >= 0 && qd <
minimum`; `StrandBias` reaches a record with no FS only when the threshold is
negative; the allele-balance filter groups by the genotype's allele list, so two
samples with the same het call share one tally, and it ignores a het with no AD;
and the genotype filters read `getGQ()` and `getDP()`, which are -1 when absent.

Golden pending. The artefact comes from the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
