### PR TITLE
Measure UpdateVcfSequenceDictionary, Picard's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,10 @@ jobs:
             index: "40/40"
             slug: "split-vcfs-sort-vcf-merge-vcfs-fix-vcf-header-filter-vcf"
             suites: "split-vcfs sort-vcf merge-vcfs fix-vcf-header filter-vcf"
+          - group: golden-pending
+            index: "1/1"
+            slug: "picard-update-vcf-dictionary"
+            suites: "picard-update-vcf-dictionary"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,14 +7,14 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 111 | 35.7% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 188 | 60.5% |
+| not started | 187 | 60.1% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (51 of 109 started)
+## picard-origin tools (52 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -67,12 +67,13 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `SplitSamByLibrary` | record-transform | oracle-backed | split | 2 | not measured |
 | `SplitSamByNumberOfReads` | record-transform | oracle-backed | split | 2 | not measured |
 | `SplitVcfs` | variant-transform | oracle-backed | split-vcfs | 1 | not measured |
+| `UpdateVcfSequenceDictionary` | variant-transform | golden-pending | picard-update-vcf-dictionary | 1 | not measured |
 | `ValidateSamFile` | reporting-walker | oracle-backed | validatesam | 6 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>58 not started</summary>
+<details><summary>57 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FindMendelianViolations`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `UpdateVcfSequenceDictionary`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
+`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FindMendelianViolations`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `VcfFormatConverter`, `VcfToAdpc`, `VcfToIntervalList`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4819,6 +4819,26 @@
           "why": "Eleven runs over one three-sample file of nine records, one per behaviour: everything passing, a het whose balance is off in two samples, high FS with low QD, a record with neither, genotypes missing GQ and DP, a het with no AD, a record with no het at all, and one that already carries a filter. The runs move each threshold in turn, then all of them at once, and close with a file of no records and a header with no contigs. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32425686817, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "picard-update-vcf-dictionary",
+      "status": "golden-pending",
+      "title": "A VCF's contig lines replaced, Picard's way",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "UpdateVcfSequenceDictionary"
+      ],
+      "why": "GATK has a tool of almost the same name, already ported, and the two disagree about nearly everything: this one has no --replace, no per-record validation and no refusals of its own. THE DICTIONARY REPLACES THE CONTIG LINES AND NOTHING ELSE. A CONTIG THE INPUT HAD AND THE DICTIONARY LACKS IS SIMPLY GONE and its RECORDS ARE STILL WRITTEN, so the output declares fewer contigs than its records use. THE INPUT'S OWN CONTIG ATTRIBUTES ARE LOST and only some of the dictionary's replace them: a sequence carrying M5, UR and AS writes a contig line with assembly= and nothing else. THE ORDER IS THE DICTIONARY'S. AN INPUT WITH NO CONTIG LINES GAINS THE WHOLE DICTIONARY. A DICTIONARY WITH NO SEQUENCES IS NOT REFUSED HERE. THE SAMPLES ARE UNTOUCHED, the header being mutated in place. The dump's class is named PicardUpdateVcfDictionaryDump because the GATK tool's dump already holds the other name, and on a case-insensitive filesystem the two are one file.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "PicardUpdateVcfDictionaryDump",
+          "golden": null,
+          "why": "Eight runs, each carrying its input and its dictionary: both contigs named, the same two reversed, a dictionary missing one of them, one naming a contig the file never mentions, one carrying the M5, UR and AS fields a real .dict has, an input with no contig lines, a dictionary with no sequences at all, and a file with no records. Golden pending: this laptop is not x86-64, so the artefact has to come from the runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/PicardUpdateVcfDictionaryDump.java
+++ b/tools/readfilter-conformance/PicardUpdateVcfDictionaryDump.java
@@ -1,0 +1,137 @@
+/*
+ * UpdateVcfSequenceDictionary (Picard's), taken from the reference.
+ *
+ * The class is named PicardUpdateVcfDictionaryDump rather than after its tool: GATK has a tool
+ * called UpdateVCFSequenceDictionary whose dump is already here, and on a case-insensitive
+ * filesystem the two file names are one file.
+ *
+ * A VCF whose contig lines are replaced by a dictionary read from elsewhere. GATK has a tool of
+ * almost the same name, already ported, and the two disagree about nearly everything: this one has
+ * no `--replace`, no per-record validation and no refusals of its own.
+ *
+ * Eight behaviours this is built to catch.
+ *
+ *   - THE DICTIONARY REPLACES THE CONTIG LINES AND NOTHING ELSE. Every other header line survives,
+ *     in the writer's order;
+ *   - A CONTIG THE INPUT HAD AND THE DICTIONARY LACKS IS SIMPLY GONE from the header, and its
+ *     RECORDS ARE STILL WRITTEN: there is no per-record check, so the output declares fewer contigs
+ *     than its records use;
+ *   - THE INPUT'S OWN CONTIG ATTRIBUTES ARE LOST, and only some of the dictionary's replace them:
+ *     a `.dict` sequence carrying `M5`, `UR` and `AS` writes a contig line with `assembly=` and
+ *     nothing else, so the checksum and the URI do not survive the round trip either way;
+ *   - THE ORDER IS THE DICTIONARY'S, so a dictionary listing the contigs the other way round
+ *     reorders the header while leaving the records where they were;
+ *   - AN INPUT WITH NO CONTIG LINES GAINS THE WHOLE DICTIONARY;
+ *   - A DICTIONARY WITH NO SEQUENCES AT ALL IS NOT REFUSED HERE, but leaves a header the indexing
+ *     writer then refuses;
+ *   - THE SAMPLES ARE UNTOUCHED, the header being mutated in place rather than rebuilt;
+ *   - AND THE DICTIONARY CAN COME FROM A `.dict`, A `.fasta` OR ANOTHER VCF, all three through the
+ *     same extractor.
+ *
+ * Output:
+ *
+ *     input\t<label>=<the whole input vcf, escaped>
+ *     dictionary\t<label>=<the dictionary source, escaped>
+ *     updated\t<label>=<the whole output vcf, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: PicardUpdateVcfDictionaryDump
+ */
+
+import picard.vcf.UpdateVcfSequenceDictionary;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PicardUpdateVcfDictionaryDump {
+
+    static String header(final String contigs) {
+        return "##fileformat=VCFv4.2\n"
+                + "##FILTER=<ID=LowQual,Description=\"Low quality\">\n"
+                + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+                + "##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count\">\n"
+                + contigs
+                + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA1\n";
+    }
+
+    static final String RECORDS =
+            "chr1\t10\t.\tA\tC\t50\tPASS\tAC=1\tGT\t0/1\n"
+            + "chr2\t20\t.\tA\tG\t50\tPASS\tAC=1\tGT\t0/1\n";
+
+    /** A `.dict` file, which is a SAM header and nothing else. */
+    static String dict(final String... sequences) {
+        final StringBuilder text = new StringBuilder("@HD\tVN:1.6\tSO:unsorted\n");
+        for (final String sequence : sequences) {
+            text.append(sequence).append('\n');
+        }
+        return text.toString();
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("update-vcf-dictionary-dump");
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# UpdateVcfSequenceDictionaryDump: a VCF's contig lines replaced");
+
+        final String withContigs = header(
+                "##contig=<ID=chr1,length=240,assembly=mine>\n##contig=<ID=chr2,length=240>\n")
+                + RECORDS;
+
+        // A dictionary naming both contigs, with a length the input did not have.
+        run("both-contigs", dir, withContigs,
+                dict("@SQ\tSN:chr1\tLN:1000", "@SQ\tSN:chr2\tLN:2000"));
+        // The same two the other way round, which reorders the header only.
+        run("reversed", dir, withContigs,
+                dict("@SQ\tSN:chr2\tLN:2000", "@SQ\tSN:chr1\tLN:1000"));
+        // A dictionary naming only one of them, whose records are still written.
+        run("missing-contig", dir, withContigs, dict("@SQ\tSN:chr1\tLN:1000"));
+        // A dictionary naming a contig the file never mentions.
+        run("extra-contig", dir, withContigs,
+                dict("@SQ\tSN:chr1\tLN:1000", "@SQ\tSN:chr2\tLN:2000", "@SQ\tSN:chr3\tLN:3000"));
+        // A dictionary carrying the fields a .dict usually has.
+        run("with-attributes", dir, withContigs,
+                dict("@SQ\tSN:chr1\tLN:1000\tM5:abc\tUR:file:/nowhere\tAS:other",
+                        "@SQ\tSN:chr2\tLN:2000"));
+        // An input with no contig lines at all.
+        run("no-contigs-in", dir, header("") + RECORDS,
+                dict("@SQ\tSN:chr1\tLN:1000", "@SQ\tSN:chr2\tLN:2000"));
+        // A dictionary with no sequences, which this tool does not refuse.
+        run("empty-dictionary", dir, withContigs, dict());
+        // A file with no records.
+        run("no-records", dir, header("##contig=<ID=chr1,length=240>\n"),
+                dict("@SQ\tSN:chr1\tLN:1000"));
+    }
+
+    static void run(final String label, final Path dir, final String input, final String dictionary,
+                    final String... extra) throws Exception {
+        final Path in = dir.resolve(label + ".vcf");
+        Files.writeString(in, input, StandardCharsets.UTF_8);
+        final Path dictPath = dir.resolve(label + ".dict");
+        Files.writeString(dictPath, dictionary, StandardCharsets.UTF_8);
+        System.out.printf("input\t%s=%s%n", label, ReferenceQueryDump.escape(input));
+        System.out.printf("dictionary\t%s=%s%n", label, ReferenceQueryDump.escape(dictionary));
+        final Path out = dir.resolve("updated-" + label + ".vcf");
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "I=" + in, "SD=" + dictPath, "O=" + out, "CREATE_INDEX=false"));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            final Object code =
+                    new UpdateVcfSequenceDictionary().instanceMain(argv.toArray(new String[0]));
+            if (!Integer.valueOf(0).equals(code)) {
+                System.out.printf("exit\t%s=%s%n", label, code);
+                return;
+            }
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+            return;
+        }
+        System.out.printf("updated\t%s=%s%n", label,
+                ReferenceQueryDump.escape(Files.readString(out)));
+    }
+}


### PR DESCRIPTION
GATK's `UpdateVCFSequenceDictionary` is already ported; this is Picard's tool of
almost the same name, and the pair disagree about nearly everything. Picard's has
no `--replace`, no per-record validation, and no refusals of its own.

Eight runs, each carrying its input and its dictionary: both contigs named, the
same two reversed, a dictionary missing one of them, one naming a contig the file
never mentions, one carrying the M5/UR/AS fields a real `.dict` has, an input
with no contig lines, a dictionary with no sequences at all, and a file with no
records.

What the rows show: a contig the input had and the dictionary lacks is gone from
the header while its records are still written; an empty dictionary is accepted
and leaves a file with no contig lines at all; and only `AS` survives into the
contig line, so a checksum and a URI are dropped either way.

The dump's class is named `PicardUpdateVcfDictionaryDump` — the GATK dump already
holds the other name, and on a case-insensitive filesystem those are one file.

Golden pending. The artefact comes from the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
