### PR TITLE
Measure GatherVcfs, Picard's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,10 @@ jobs:
             index: "41/41"
             slug: "picard-update-vcf-dictionary-vcf-to-interval-list"
             suites: "picard-update-vcf-dictionary vcf-to-interval-list"
+          - group: golden-pending
+            index: "1/1"
+            slug: "picard-gather-vcfs"
+            suites: "picard-gather-vcfs"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,14 +7,14 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 113 | 36.3% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 186 | 59.8% |
+| not started | 185 | 59.5% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (53 of 109 started)
+## picard-origin tools (54 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -42,6 +42,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `FilterVcf` | variant-transform | oracle-backed | filter-vcf | 1 | not measured |
 | `FixMateInformation` | record-transform | oracle-backed | fixmate | 1 | not measured |
 | `FixVcfHeader` | variant-transform | oracle-backed | fix-vcf-header | 1 | not measured |
+| `GatherVcfs` | variant-transform | golden-pending | picard-gather-vcfs | 1 | not measured |
 | `IntervalListToBed` | interval-utility | unchecked | intervallisttobed | 1 | not measured |
 | `IntervalListTools` | interval-utility | oracle-backed | intervallisttools, intervallisttoolspadbreak | 4 | not measured |
 | `LiftOverIntervalList` | interval-utility | unchecked | liftoverintervallist | 1 | not measured |
@@ -72,9 +73,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VcfToIntervalList` | variant-transform | oracle-backed | vcf-to-interval-list | 1 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>56 not started</summary>
+<details><summary>55 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FindMendelianViolations`, `GatherBamFiles`, `GatherVcfs`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `VcfFormatConverter`, `VcfToAdpc`
+`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FindMendelianViolations`, `GatherBamFiles`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `VcfFormatConverter`, `VcfToAdpc`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4859,6 +4859,26 @@
           "why": "Six runs over one file of eighteen records covering each behaviour: named and unnamed records, a deletion overlapping the record inside it, an abutting pair and a pair one base apart, an UNNAMED filtered record before an unnamed one so that including it renumbers everything after, a filtered record bridging two others, a PASS filter, a symbolic ALT with END, two records sharing a name, an unnamed one merged with a named one, and a contig change. The runs are the defaults, INCLUDE_FILTERED, an unsorted file, a file with no records, a header with no contigs, and USE_FIRST last because VARIANT_ID_METHOD is static. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32458935026, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "picard-gather-vcfs",
+      "status": "golden-pending",
+      "title": "Shards of a scattered run concatenated, Picard's way",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "GatherVcfs"
+      ],
+      "why": "GATK's GatherVcfsCloud is already measured under gather-vcfs; this is the other tool of nearly the same name and it refuses differently. A REFUSAL IS AN EXIT CODE, NOT AN EXCEPTION: doWork catches RuntimeException, logs, DELETES THE OUTPUT and returns 1. AND AN AssertionError IS NOT A RuntimeException, so the dictionary mismatch walks out while the sample mismatch beside it becomes exit 1. CREATE_INDEX DEFAULTS TO TRUE, set in the constructor, and an input with no contig lines is a PicardException RAISED BEFORE THE TRY; with CREATE_INDEX=false the same input reaches a null dictionary and becomes exit 1. THERE ARE TWO ORDER CHECKS AND THEY COMPARE DIFFERENT THINGS, the first the files' first records and the second the next file's first record against the last record written. AN EMPTY SHARD IS SKIPPED BY BOTH. REORDER_INPUT_BY_FIRST_VARIANT PUTS EVERY EMPTY FILE LAST. ONLY THE FIRST COMMENT SURVIVES: they are GatherVcfs.comment lines, a different key from the neighbouring MergeVcfs, and VCFHeader keys an unstructured line by its key alone, so the second CO= is dropped without a word. THE MODE IS CHOSEN BY FILE EXTENSION and needs every input and the output block compressed. AND THE BLOCK COPYING PATH REWRITES ONLY THE BLOCK THAT ENDS EACH LATER FILE'S HEADER, copying every other block byte for byte and appending one terminator of its own.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "PicardGatherVcfsDump",
+          "golden": null,
+          "why": "Thirteen runs over shards of one scattered two-sample run: three ordered shards, one alone, two with comments, an empty shard in the middle, the shards out of order, the same reordered by the tool with the empty one among them, a pair whose records overlap though their first records do not, a shard with one sample, a shard with another dictionary, a pair with no contig lines with and without the index, and the same shards block compressed gathered into a plain vcf and into a block compressed one. The block compressed output is recorded as its decompressed text, its bgzf block sizes and its SHA-256."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/PicardGatherVcfsDump.java
+++ b/tools/readfilter-conformance/PicardGatherVcfsDump.java
@@ -1,0 +1,266 @@
+/*
+ * Picard's GatherVcfs, taken from the reference.
+ *
+ * Concatenating shards of one scattered run. GATK's GatherVcfsCloud is already ported and measured
+ * under `gather-vcfs`; this is the OTHER tool of nearly the same name, and the two disagree about
+ * how they refuse, about which order checks they run and about what a comment line is called. The
+ * dump's class is named PicardGatherVcfsDump because GatherVcfsDump already holds the GATK tool,
+ * and on a case-insensitive filesystem two files of one name are one file.
+ *
+ * Eleven behaviours this is built to catch.
+ *
+ *   - A REFUSAL IS AN EXIT CODE, NOT AN EXCEPTION. `doWork` wraps everything after the dictionary
+ *     check in `try { ... } catch (RuntimeException e)`, logs, DELETES THE OUTPUT and returns 1, so
+ *     a caller sees a status and a log line where GATK's tool throws;
+ *   - AND AN AssertionError IS NOT A RuntimeException: the dictionary mismatch, which
+ *     `assertSameDictionary` raises as an AssertionError, walks straight out of doWork while the
+ *     sample mismatch beside it becomes exit 1;
+ *   - CREATE_INDEX DEFAULTS TO TRUE, set in the constructor and not by the parser, and an input
+ *     with no ##contig lines is then a PicardException RAISED BEFORE THE TRY, so that one is an
+ *     exception too;
+ *   - WITH CREATE_INDEX=false AND NO CONTIG LINES the dictionary is null and the ordering check
+ *     dereferences it, so the same input fails as a NullPointerException turned into exit 1;
+ *   - THERE ARE TWO ORDER CHECKS AND THEY COMPARE DIFFERENT THINGS. The first compares the FIRST
+ *     record of each file with the first record of the previous file; the second, inside the
+ *     gathering, compares the next file's first record with the LAST RECORD WRITTEN. A pair of
+ *     shards that overlap passes the first and fails the second, with a different message;
+ *   - AN EMPTY SHARD IS SKIPPED BY BOTH, `lastContext` never moving, so a shard with no records
+ *     between two ordered ones changes nothing;
+ *   - REORDER_INPUT_BY_FIRST_VARIANT SORTS BY THE FIRST RECORD and puts every EMPTY FILE LAST,
+ *     the comparator answering 1 whenever the left file is empty;
+ *   - ONLY THE FIRST COMMENT SURVIVES. They are added to the first file's header as
+ *     `GatherVcfs.comment` lines, a different key from the MergeVcfs.comment the neighbouring tool
+ *     writes, and VCFHeader keys an unstructured line BY ITS KEY ALONE: the second CO= is dropped
+ *     without a word, so two comments in and one comment out;
+ *   - THE HEADER WRITTEN IS THE FIRST FILE'S, whatever the others declare;
+ *   - THE MODE IS CHOSEN BY FILE EXTENSION AND NEEDS EVERY INPUT AND THE OUTPUT BLOCK COMPRESSED,
+ *     so .vcf.gz inputs gathered into a .vcf take the conventional path;
+ *   - AND THE BLOCK COPYING PATH REWRITES ONLY THE BLOCK THAT ENDS EACH LATER FILE'S HEADER,
+ *     copying every other block byte for byte and appending one terminator block of its own.
+ *
+ * Output:
+ *
+ *     input\t<label>=<the whole input vcf, escaped>
+ *     gathered\t<label>=<the whole output vcf, escaped>
+ *     blocks\t<label>=<the output's bgzf block sizes, comma separated>
+ *     sha256\t<label>=<the output file's digest>
+ *     exit\t<label>=<the exit code>\t<the ERROR log lines, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: PicardGatherVcfsDump
+ */
+
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.Log;
+import picard.vcf.GatherVcfs;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PicardGatherVcfsDump {
+
+    static final String HEADER =
+            "##fileformat=VCFv4.2\n"
+            + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+            + "##contig=<ID=chr1,length=1000>\n"
+            + "##contig=<ID=chr2,length=1000>\n"
+            + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tone\ttwo\n";
+
+    /** The same header with the two contig lines gone. */
+    static final String HEADER_NO_CONTIGS =
+            HEADER.replace("##contig=<ID=chr1,length=1000>\n", "")
+                    .replace("##contig=<ID=chr2,length=1000>\n", "");
+
+    /** The same header with one contig a different length, which is a different dictionary. */
+    static final String HEADER_OTHER_DICTIONARY =
+            HEADER.replace("##contig=<ID=chr2,length=1000>", "##contig=<ID=chr2,length=999>");
+
+    /** The same header with one sample instead of two. */
+    static final String HEADER_ONE_SAMPLE =
+            HEADER.replace("\tone\ttwo\n", "\tone\n");
+
+    static String record(final String contig, final int position, final String genotypes) {
+        return contig + "\t" + position + "\t.\tA\tC\t.\t.\t.\tGT\t" + genotypes + "\n";
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("picard-gather-vcfs-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# PicardGatherVcfsDump: shards of a scattered run concatenated");
+
+        // Three shards in genomic order, sharing a dictionary and a sample list.
+        final String first = HEADER + record("chr1", 100, "0/1\t0/0") + record("chr1", 200, "0/1\t0/0");
+        final String second = HEADER + record("chr1", 300, "0/0\t1/1") + record("chr2", 50, "0/1\t0/1");
+        final String third = HEADER + record("chr2", 100, "1/1\t0/0");
+        // One with no records at all.
+        final String empty = HEADER;
+        // One whose first record is after the first shard's first record but before its last, which
+        // passes the first order check and fails the second.
+        final String overlapping = HEADER + record("chr1", 150, "0/1\t0/0");
+
+        final Path a = write(dir, "a", first);
+        final Path b = write(dir, "b", second);
+        final Path c = write(dir, "c", third);
+        final Path none = write(dir, "none", empty);
+        final Path over = write(dir, "over", overlapping);
+        final Path oneSample = write(dir, "one-sample",
+                HEADER_ONE_SAMPLE + record("chr2", 300, "0/1"));
+        final Path otherDictionary = write(dir, "other-dictionary",
+                HEADER_OTHER_DICTIONARY + record("chr2", 400, "0/1\t0/0"));
+        final Path bareA = write(dir, "bare-a", HEADER_NO_CONTIGS + record("chr1", 100, "0/1\t0/0"));
+        final Path bareB = write(dir, "bare-b", HEADER_NO_CONTIGS + record("chr1", 300, "0/0\t1/1"));
+
+        // The same three shards block compressed, for the two mode choices.
+        final Path gzA = writeCompressed(dir, "a", first);
+        final Path gzB = writeCompressed(dir, "b", second);
+        final Path gzC = writeCompressed(dir, "c", third);
+
+        run(dir, "ordered", ".vcf", List.of(a, b, c));
+        run(dir, "single", ".vcf", List.of(a));
+        // Two comments, which become GatherVcfs.comment lines in the first file's header.
+        run(dir, "comments", ".vcf", List.of(a, b), "CO=one comment", "CO=another");
+        // An empty shard between two ordered ones, which neither check notices.
+        run(dir, "empty-shard", ".vcf", List.of(a, none, b));
+        // The shards out of order, refused by the first check.
+        run(dir, "unordered", ".vcf", List.of(c, a, b));
+        // The same three reordered by the tool, with the empty one which sorts last.
+        run(dir, "reordered", ".vcf", List.of(c, none, a, b), "RI=true");
+        // Shards whose first records are in order and whose records overlap, refused by the second
+        // check with a different message.
+        run(dir, "overlapping", ".vcf", List.of(a, over), "CREATE_INDEX=false");
+        // A shard with one sample where the others have two.
+        run(dir, "different-samples", ".vcf", List.of(a, oneSample));
+        // A shard whose dictionary differs, which is an AssertionError and not an exit code.
+        run(dir, "different-dictionary", ".vcf", List.of(a, otherDictionary));
+        // No contig lines, which CREATE_INDEX refuses before anything is opened.
+        run(dir, "no-contigs", ".vcf", List.of(bareA, bareB));
+        // The same inputs without the index, which reach the null dictionary instead.
+        run(dir, "no-contigs-no-index", ".vcf", List.of(bareA, bareB), "CREATE_INDEX=false");
+        // Block compressed inputs gathered into a plain vcf, which is the conventional path.
+        run(dir, "gz-in-plain-out", ".vcf", List.of(gzA, gzB, gzC));
+        // And block compressed on both sides, which is the block copying path.
+        run(dir, "gz-in-gz-out", ".vcf.gz", List.of(gzA, gzB, gzC));
+    }
+
+    /** A plain vcf, printed as one of the golden's inputs. */
+    static Path write(final Path dir, final String label, final String text) throws Exception {
+        final Path file = dir.resolve(label + ".vcf");
+        Files.writeString(file, text, StandardCharsets.UTF_8);
+        System.out.printf("input\t%s=%s%n", label, ReferenceQueryDump.escape(text));
+        return file;
+    }
+
+    /** The same text as a bgzf file, whose bytes are the reference's own writer's. */
+    static Path writeCompressed(final Path dir, final String label, final String text)
+            throws Exception {
+        final Path file = dir.resolve(label + ".vcf.gz");
+        try (BlockCompressedOutputStream out = new BlockCompressedOutputStream(file.toFile())) {
+            out.write(text.getBytes(StandardCharsets.UTF_8));
+        }
+        return file;
+    }
+
+    static void run(final Path dir, final String label, final String extension,
+                    final List<Path> inputs, final String... extra) throws Exception {
+        final Path out = dir.resolve("gathered-" + label + extension);
+        final List<String> argv = new ArrayList<>();
+        for (final Path input : inputs) {
+            argv.add("I=" + input);
+        }
+        argv.add("O=" + out);
+        argv.addAll(Arrays.asList(extra));
+
+        // htsjdk's Log holds System.err in a static field taken at class load, so redirecting
+        // System.err does nothing: the stream has to be replaced through Log itself.
+        final PrintStream realErr = Log.getGlobalPrintStream();
+        final ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        Object code;
+        try {
+            Log.setGlobalPrintStream(new PrintStream(captured, true, StandardCharsets.UTF_8));
+            code = new GatherVcfs().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Log.setGlobalPrintStream(realErr);
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+            return;
+        } finally {
+            Log.setGlobalPrintStream(realErr);
+        }
+
+        if (!Integer.valueOf(0).equals(code)) {
+            System.out.printf("exit\t%s=%s\t%s%n", label, code,
+                    ReferenceQueryDump.escape(errorLines(captured.toString(StandardCharsets.UTF_8), dir)));
+            System.out.printf("output-exists\t%s=%s%n", label, Files.exists(out));
+            return;
+        }
+
+        if (extension.endsWith(".gz")) {
+            final byte[] bytes = Files.readAllBytes(out);
+            System.out.printf("gathered\t%s=%s%n", label,
+                    ReferenceQueryDump.escape(decompress(out)));
+            System.out.printf("blocks\t%s=%s%n", label, blockSizes(bytes));
+            System.out.printf("sha256\t%s=%s%n", label, digest(bytes));
+            return;
+        }
+        System.out.printf("gathered\t%s=%s%n", label,
+                ReferenceQueryDump.escape(Files.readString(out)));
+    }
+
+    /** The ERROR lines of the captured log, with the timestamps and the directory masked. */
+    static String errorLines(final String log, final Path dir) {
+        final StringBuilder text = new StringBuilder();
+        for (final String line : log.split("\n")) {
+            if (!line.startsWith("ERROR")) {
+                continue;
+            }
+            text.append(masked(line.replaceAll("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}", "MASKED"), dir))
+                    .append("\n");
+        }
+        return text.toString();
+    }
+
+    /** The dump's own directory, whose absolute path reaches several messages. */
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+
+    /** Everything the output decompresses to, which is what the conventional path would write. */
+    static String decompress(final Path file) throws Exception {
+        try (BlockCompressedInputStream in = new BlockCompressedInputStream(file.toFile())) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /** The BSIZE of every bgzf block, which says which blocks were copied and which rewritten. */
+    static String blockSizes(final byte[] bytes) {
+        final StringBuilder sizes = new StringBuilder();
+        int position = 0;
+        while (position + 18 <= bytes.length) {
+            final int size = ((bytes[position + 16] & 0xff) | ((bytes[position + 17] & 0xff) << 8)) + 1;
+            if (sizes.length() > 0) {
+                sizes.append(",");
+            }
+            sizes.append(size);
+            position += size;
+        }
+        return sizes.toString();
+    }
+
+    static String digest(final byte[] bytes) throws Exception {
+        final StringBuilder text = new StringBuilder();
+        for (final byte b : MessageDigest.getInstance("SHA-256").digest(bytes)) {
+            text.append(String.format("%02x", b));
+        }
+        return text.toString();
+    }
+}


### PR DESCRIPTION
GATK's `GatherVcfsCloud` is already ported and measured under `gather-vcfs`. This is the other tool of nearly the same name, and the two disagree about how they refuse, which order checks they run and what a comment line is called. The dump's class is `PicardGatherVcfsDump` because `GatherVcfsDump` already holds the GATK tool, and a case-insensitive filesystem makes two files of one name into one file.

Eleven behaviours the dump is built to catch:

- a refusal is an exit code, not an exception: `doWork` catches `RuntimeException`, logs, deletes the output and returns 1;
- and an `AssertionError` is not a `RuntimeException`, so the dictionary mismatch walks out of `doWork` while the sample mismatch beside it becomes exit 1;
- `CREATE_INDEX` defaults to true, set in the constructor rather than by the parser, and an input with no `##contig` lines is a `PicardException` raised before the try;
- with `CREATE_INDEX=false` the same input reaches a null dictionary instead and becomes exit 1;
- there are two order checks and they compare different things: the files' first records, then the next file's first record against the last record written. A pair of shards that overlap passes the first and fails the second;
- an empty shard is skipped by both;
- `REORDER_INPUT_BY_FIRST_VARIANT` sorts by the first record and puts every empty file last;
- only the first comment survives: `VCFHeader` keys an unstructured line by its key alone, so a second `CO=` is dropped without a word;
- the header written is the first file's;
- the mode is chosen by file extension and needs every input *and* the output block compressed, so `.vcf.gz` inputs gathered into a `.vcf` take the conventional path;
- and the block copying path rewrites only the block that ends each later file's header, copying every other block byte for byte and appending one terminator of its own. The golden records that output's decompressed text, its bgzf block sizes and its SHA-256.

The log lines are captured through `Log.setGlobalPrintStream`, htsjdk's `Log` holding `System.err` in a static field taken at class load, with the timestamps and the working directory masked.

The manifest entry is `golden-pending`. The golden comes from the pinned container on a real x86-64 runner, in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
