### PR TITLE
Measure BuildBamIndex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,10 @@ jobs:
             index: "41/41"
             slug: "picard-update-vcf-dictionary-vcf-to-interval-list-picard-gather-vcfs-vcf-format-converter"
             suites: "picard-update-vcf-dictionary vcf-to-interval-list picard-gather-vcfs vcf-format-converter"
+          - group: golden-pending
+            index: "1/1"
+            slug: "build-bam-index"
+            suites: "build-bam-index"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,14 +7,14 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 115 | 37.0% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 184 | 59.2% |
+| not started | 183 | 58.8% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (55 of 109 started)
+## picard-origin tools (56 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -23,6 +23,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `AddOrReplaceReadGroups` | record-transform | oracle-backed | addreplacerg | 1 | not measured |
 | `BamIndexStats` | reporting-walker | oracle-backed | bamindexstats | 1 | not measured |
 | `BedToIntervalList` | interval-utility | unchecked | bedtointervallist | 1 | not measured |
+| `BuildBamIndex` | record-transform | golden-pending | build-bam-index | 1 | not measured |
 | `CalculateReadGroupChecksum` | reporting-walker | oracle-backed | rgchecksum | 1 | not measured |
 | `CheckTerminatorBlock` | reporting-walker | oracle-backed | check-terminator-block | 1 | not measured |
 | `CleanSam` | record-transform | oracle-backed | cleansam | 1 | not measured |
@@ -74,9 +75,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VcfToIntervalList` | variant-transform | oracle-backed | vcf-to-interval-list | 1 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>54 not started</summary>
+<details><summary>53 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `BuildBamIndex`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FindMendelianViolations`, `GatherBamFiles`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `VcfToAdpc`
+`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FindMendelianViolations`, `GatherBamFiles`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SetNmAndUqTags`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `VcfToAdpc`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -4899,6 +4899,26 @@
           "why": "Nine runs over one two-sample file of four records, whose header lines are deliberately out of the writer's order and whose records carry a phased genotype, a no-call, two alternates and a symbolic allele: an indexed vcf to a vcf, the same file with no index with the requirement on and off, a file with no contig lines with the index on and off, a file with no records, block compressed output recorded as the text it decompresses to, binary output recorded as a digest and a length, and the round trip back from it. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32462370522, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "build-bam-index",
+      "status": "golden-pending",
+      "title": "The .bai of a coordinate-sorted BAM",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "BuildBamIndex"
+      ],
+      "why": "The index itself is htsjdk's BAMIndexer, already ported and proven byte-identical; this suite is for everything around it. THE DEFAULT OUTPUT IS RELATIVE TO THE WORKING DIRECTORY AND NOT TO THE INPUT, the path being built from inputPath.getFileName(), so a BAM in a subdirectory writes its index where the process was started. AND THE EXTENSION IS REPLACED ONLY FOR A NAME ENDING .bam: anything else gets .bai appended. A SAM INPUT IS REFUSED BY THE READER'S TYPE and not by the extension. A BAM SORTED BY QUERYNAME IS REFUSED, and so is one whose header says unsorted, by the same message. The check reads the header's SO field and nothing else, but a file whose header lies cannot be built here, SAMFileWriterImpl.assertPresorted refusing to write records out of order under a coordinate header, so that claim stays unmeasured rather than guessed. READS WITH NO ALIGNMENT START ARE COUNTED rather than dropped. AND AN EMPTY BAM STILL PRODUCES AN INDEX.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "BuildBamIndexDump",
+          "golden": null,
+          "why": "Seven runs over five fixtures: a coordinate-sorted BAM over two contigs with two unmapped reads at the end, the same reads under a queryname header and under an unsorted one, a BAM with no records, and a sam file. The runs index each of them with an explicit output, then twice with none at all: once for a name ending .bam and once for a name that does not. Every input and every index travels as base64."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/BuildBamIndexDump.java
+++ b/tools/readfilter-conformance/BuildBamIndexDump.java
@@ -1,0 +1,209 @@
+/*
+ * BuildBamIndex, taken from the reference.
+ *
+ * The .bai of a coordinate-sorted BAM. The index itself is htsjdk's BAMIndexer, already ported and
+ * proven byte-identical; what this dump is for is everything AROUND it, which is where the tool's
+ * own behaviour lives.
+ *
+ * Six behaviours this is built to catch.
+ *
+ *   - THE DEFAULT OUTPUT IS RELATIVE TO THE WORKING DIRECTORY, NOT TO THE INPUT. The path is built
+ *     from `inputPath.getFileName()`, so a BAM in a subdirectory with no OUTPUT given writes its
+ *     index into the directory the process was started in;
+ *   - AND THE EXTENSION IS REPLACED ONLY FOR A NAME ENDING .bam: anything else gets `.bai`
+ *     APPENDED, so `reads.bam.copy` becomes `reads.bam.copy.bai`;
+ *   - A SAM INPUT IS REFUSED BY THE READER'S TYPE, not by the extension, with a SAMException whose
+ *     message is the tool's own;
+ *   - A BAM SORTED BY QUERYNAME IS REFUSED, and so is one whose header says `unsorted`, by the
+ *     same message: the check is on the header's SO field alone and reads nothing;
+ *   - (the check reads the header's SO field and nothing else, but a file whose header lies cannot
+ *     be built here: `SAMFileWriterImpl.assertPresorted` refuses to write records out of order
+ *     under a coordinate header, so that claim stays unmeasured rather than guessed);
+ *   - READS WITH NO ALIGNMENT START ARE COUNTED, not dropped: the unmapped reads at the end of a
+ *     coordinate-sorted file become the index's no-coordinate count;
+ *   - AND AN EMPTY BAM STILL PRODUCES AN INDEX, one bin-less reference per sequence in the header.
+ *
+ * Output:
+ *
+ *     fixture\t<label>\t<the input BAM, base64>
+ *     index\t<label>\t<the .bai written, base64>
+ *     wrote\t<label>\t<the path the index landed on, relative to the working directory>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: BuildBamIndexDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import picard.sam.BuildBamIndex;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class BuildBamIndexDump {
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("build-bam-index-dump");
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# BuildBamIndexDump: the .bai of a coordinate-sorted BAM");
+
+        // A coordinate-sorted BAM with reads on two contigs and two unmapped reads at the end.
+        final Path sorted = dir.resolve("sorted.bam");
+        buildBam(sorted, SAMFileHeader.SortOrder.coordinate, true);
+        fixture("sorted", sorted);
+
+        // The same reads with the header claiming queryname, and with it claiming unsorted.
+        final Path queryname = dir.resolve("queryname.bam");
+        buildBam(queryname, SAMFileHeader.SortOrder.queryname, false);
+        fixture("queryname", queryname);
+        final Path unsorted = dir.resolve("unsorted.bam");
+        buildBam(unsorted, SAMFileHeader.SortOrder.unsorted, false);
+        fixture("unsorted", unsorted);
+
+        // A BAM with no records at all.
+        final Path empty = dir.resolve("empty.bam");
+        buildEmptyBam(empty);
+        fixture("empty", empty);
+
+        // A sam file, which the reader's type refuses.
+        final Path sam = dir.resolve("plain.sam");
+        buildSam(sam);
+        fixture("plain-sam", sam);
+
+        // The same sorted BAM under a name that does not end in .bam.
+        final Path oddName = dir.resolve("sorted.bam.copy");
+        Files.copy(sorted, oddName);
+
+        run("sorted", sorted, dir.resolve("sorted-out.bai"));
+        run("empty", empty, dir.resolve("empty-out.bai"));
+        run("queryname", queryname, dir.resolve("queryname-out.bai"));
+        run("unsorted", unsorted, dir.resolve("unsorted-out.bai"));
+        run("plain-sam", sam, dir.resolve("sam-out.bai"));
+        // No OUTPUT at all, which lands beside the process and not beside the input.
+        run("default-output", sorted, null);
+        // And a name that does not end in .bam, whose default output gains .bai rather than
+        // replacing anything.
+        run("default-output-odd-name", oddName, null);
+    }
+
+    static void fixture(final String label, final Path bam) throws Exception {
+        System.out.printf("fixture\t%s\t%s%n", label, RecordTransformDump.base64(bam));
+    }
+
+    /** One run, with the index it wrote and where it landed. */
+    static void run(final String label, final Path input, final Path output) throws Exception {
+        final List<String> argv = new ArrayList<>(List.of("I=" + input));
+        if (output != null) {
+            argv.add("O=" + output);
+        }
+        try {
+            final Object code = new BuildBamIndex().instanceMain(argv.toArray(new String[0]));
+            if (!Integer.valueOf(0).equals(code)) {
+                System.out.printf("exit\t%s\t%s%n", label, code);
+                return;
+            }
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+            return;
+        }
+        final Path landed = output != null ? output : defaultOutput(input);
+        System.out.printf("wrote\t%s\t%s%n", label, landed);
+        System.out.printf("index\t%s\t%s%n", label, RecordTransformDump.base64(landed));
+    }
+
+    /** Where the tool puts an index when OUTPUT is not given, which is the working directory. */
+    static Path defaultOutput(final Path input) {
+        final String name = input.getFileName().toString();
+        if (name.endsWith(".bam")) {
+            return Path.of(name.substring(0, name.lastIndexOf('.')) + ".bai");
+        }
+        return Path.of(name + ".bai");
+    }
+
+    /** A BAM whose header claims the given order, optionally with unmapped reads at the end. */
+    static void buildBam(final Path file, final SAMFileHeader.SortOrder order,
+                         final boolean withUnmapped) {
+        final SAMFileHeader header = header(order);
+        final int[] starts = {100, 300, 500};
+        try (SAMFileWriter writer =
+                     new SAMFileWriterFactory().makeBAMWriter(header, true, file.toFile())) {
+            for (int i = 0; i < starts.length; i++) {
+                writer.addAlignment(read(header, "r" + i, "chr1", starts[i]));
+            }
+            writer.addAlignment(read(header, "s0", "chr2", 200));
+            if (withUnmapped) {
+                for (int i = 0; i < 2; i++) {
+                    final SAMRecord unmapped = new SAMRecord(header);
+                    unmapped.setReadName("u" + i);
+                    unmapped.setReadUnmappedFlag(true);
+                    unmapped.setReferenceIndex(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
+                    unmapped.setAlignmentStart(SAMRecord.NO_ALIGNMENT_START);
+                    unmapped.setReadBases(bases());
+                    unmapped.setBaseQualities(qualities());
+                    writer.addAlignment(unmapped);
+                }
+            }
+        }
+    }
+
+    static void buildEmptyBam(final Path file) {
+        try (SAMFileWriter writer = new SAMFileWriterFactory()
+                .makeBAMWriter(header(SAMFileHeader.SortOrder.coordinate), true, file.toFile())) {
+            // Nothing to add: the header alone is the file.
+            assert writer != null;
+        }
+    }
+
+    static void buildSam(final Path file) {
+        final SAMFileHeader header = header(SAMFileHeader.SortOrder.coordinate);
+        try (SAMFileWriter writer =
+                     new SAMFileWriterFactory().makeSAMWriter(header, true, file.toFile())) {
+            writer.addAlignment(read(header, "r0", "chr1", 100));
+        }
+    }
+
+    static SAMFileHeader header(final SAMFileHeader.SortOrder order) {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", 1000),
+                new SAMSequenceRecord("chr2", 1000))));
+        header.setSortOrder(order);
+        return header;
+    }
+
+    static SAMRecord read(final SAMFileHeader header, final String name, final String contig,
+                          final int start) {
+        final SAMRecord record = new SAMRecord(header);
+        record.setReadName(name);
+        record.setReferenceName(contig);
+        record.setAlignmentStart(start);
+        record.setCigarString("10M");
+        record.setReadBases(bases());
+        record.setBaseQualities(qualities());
+        record.setMappingQuality(60);
+        return record;
+    }
+
+    static byte[] bases() {
+        final byte[] bases = new byte[10];
+        Arrays.fill(bases, (byte) 'A');
+        return bases;
+    }
+
+    static byte[] qualities() {
+        final byte[] qualities = new byte[10];
+        Arrays.fill(qualities, (byte) 30);
+        return qualities;
+    }
+}


### PR DESCRIPTION
The `.bai` of a coordinate-sorted BAM. The index itself is htsjdk's `BAMIndexer`, already ported and proven byte-identical by htsjdk-rs's own goldens; this dump is for everything around it, which is where the tool's own behaviour lives.

Six behaviours the dump is built to catch:

- the default output is relative to the **working directory** and not to the input: the path is built from `inputPath.getFileName()`, so a BAM in a subdirectory writes its index where the process was started (`build-bam-index-dump/sorted.bam` indexes to `./sorted.bai`);
- and the extension is replaced only for a name ending `.bam`: anything else gets `.bai` appended, so `sorted.bam.copy` becomes `sorted.bam.copy.bai`;
- a sam input is refused by the reader's *type* and not by the extension;
- a BAM sorted by queryname is refused, and so is one whose header says `unsorted`, by the same message;
- reads with no alignment start are counted rather than dropped;
- and an empty BAM still produces an index, one bin-less reference per sequence.

The check reads the header's `SO` field and nothing else, but a file whose header lies cannot be built here: `SAMFileWriterImpl.assertPresorted` refuses to write records out of order under a coordinate header. That claim stays unmeasured rather than guessed.

The manifest entry is `golden-pending`. The golden comes from the pinned container on a real x86-64 runner, in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
