### PR TITLE
Measure AddCommentsToBam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,10 @@ jobs:
             index: "42/42"
             slug: "print-bgzf-block-information-index-feature-file-set-nm-md-uq-tags-gather-bam-files"
             suites: "print-bgzf-block-information index-feature-file set-nm-md-uq-tags gather-bam-files"
+          - group: golden-pending
+            index: "1/1"
+            slug: "add-comments-to-bam"
+            suites: "add-comments-to-bam"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,18 +7,19 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 120 | 38.6% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 179 | 57.6% |
+| not started | 178 | 57.2% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
 
-## picard-origin tools (58 of 109 started)
+## picard-origin tools (59 of 109 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
 | `AccumulateQualityYieldMetrics` | reporting-walker | unchecked | accumulatequalityyield | 1 | not measured |
+| `AddCommentsToBam` | record-transform | golden-pending | add-comments-to-bam | 1 | not measured |
 | `AddOATag` | record-transform | oracle-backed | addoatag, addoatag-bam | 2 | t=2, 0/9 rows (0%) |
 | `AddOrReplaceReadGroups` | record-transform | oracle-backed | addreplacerg | 1 | not measured |
 | `BamIndexStats` | reporting-walker | oracle-backed | bamindexstats | 1 | not measured |
@@ -77,9 +78,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VcfToIntervalList` | variant-transform | oracle-backed | vcf-to-interval-list | 1 | not measured |
 | `ViewSam` | reporting-walker | oracle-backed | viewsam | 1 | not measured |
 
-<details><summary>51 not started</summary>
+<details><summary>50 not started</summary>
 
-`AccumulateVariantCallingMetrics`, `AddCommentsToBam`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FindMendelianViolations`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `VcfToAdpc`
+`AccumulateVariantCallingMetrics`, `BaitDesigner`, `BamToBfq`, `BpmToNormalizationManifestCsv`, `CalculateFingerprintMetrics`, `CheckFingerprint`, `CheckIlluminaDirectory`, `ClusterCrosscheckMetrics`, `CollectArraysVariantCallingMetrics`, `CollectDuplicateMetrics`, `CollectHiSeqXPfFailMetrics`, `CollectHsMetrics`, `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `CollectIndependentReplicateMetrics`, `CollectJumpingLibraryMetrics`, `CollectMultipleMetrics`, `CollectOxoGMetrics`, `CollectRawWgsMetrics`, `CollectRrbsMetrics`, `CollectSamErrorMetrics`, `CollectSequencingArtifactMetrics`, `CollectTargetedPcrMetrics`, `CollectUmiPrevalenceMetrics`, `CollectVariantCallingMetrics`, `CollectWgsMetrics`, `CollectWgsMetricsWithNonZeroCoverage`, `CombineGenotypingArrayVcfs`, `CompareMetrics`, `ConvertSequencingArtifactToOxoG`, `CreateBafRegressMetricsFile`, `CreateVerifyIDIntensityContaminationMetricsFile`, `CrosscheckFingerprints`, `EstimateLibraryComplexity`, `ExtractIlluminaBarcodes`, `FifoBuffer`, `FindMendelianViolations`, `GenotypeConcordance`, `GtcToVcf`, `IlluminaBasecallsToFastq`, `IlluminaBasecallsToSam`, `LiftoverVcf`, `MarkDuplicates`, `MarkDuplicatesWithMateCigar`, `MarkIlluminaAdapters`, `MergePedIntoVcf`, `PositionBasedDownsampleSam`, `SimpleMarkDuplicatesWithMateCigar`, `UmiAwareMarkDuplicatesWithMateCigar`, `VcfToAdpc`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5000,6 +5000,26 @@
           "why": "Ten runs over six fixtures: two shards in coordinate order sharing a header, an empty shard, a shard declaring another read group, a shard whose records come before the first's, and the second shard written as a sam. The runs gather two shards, one alone, three with the empty one between, a pair whose read groups disagree, a pair out of order, a pair with a sam among them, then the same pair with an index and with a digest, then a list file, and close with a path that does not exist. The deflater factory is pinned and recorded, and every BAM travels as base64 and again as text. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32497693342, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "add-comments-to-bam",
+      "status": "golden-pending",
+      "title": "A BAM header gaining @CO lines",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "AddCommentsToBam"
+      ],
+      "why": "THE COMMENTS ARE APPENDED IN ORDER AND AFTER ANY THE FILE ALREADY HAD. @CO IS ADDED BY htsjdk AND NOT BY THE TOOL, AND IT IS NOT DOUBLED: addComment prefixes only a comment that does not already start with @CO, which the measurement corrected. A COMMENT HOLDING A TAB SURVIVES WHOLE, so a comment can forge extra header fields, while a comment holding a NEWLINE never reaches the tool's own check, the parser refusing it first as an IllegalArgumentException, so the PicardException the tool carries for that case is unreachable from the command line. THE SAM REFUSAL IS ON THE PATH'S SUFFIX, not on the file's contents, so a BAM named .sam is refused by the tool while a sam named .bam gets past that check and is refused later by the block copy for having no valid GZIP block at its end. THE RECORDS ARE COPIED AS COMPRESSED BLOCKS, so only the header block is rewritten. THE HEADER IS REWRITTEN WHOLE, so its dictionary, read groups and program records come back in htsjdk's own order. NO COMMENT AT ALL IS STILL A REWRITE. AND CREATE_MD5_FILE AND CREATE_INDEX WRITE BESIDE THE OUTPUT without changing its bytes.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "AddCommentsToBamDump",
+          "golden": null,
+          "why": "Ten runs over one three-record BAM whose header already carries a comment, a read group and a program record: one comment, two, none at all, one already carrying the @CO prefix, one holding a tab, one holding a newline, the digest and the index, then the same bytes under a .sam name and a real sam under a .bam name. The deflater factory is pinned and recorded, and every BAM travels as base64 and again as text."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/AddCommentsToBamDump.java
+++ b/tools/readfilter-conformance/AddCommentsToBamDump.java
@@ -1,0 +1,214 @@
+/*
+ * AddCommentsToBam's output, taken from the reference.
+ *
+ * A BAM whose header gains @CO lines and whose records are copied block for block. The whole tool
+ * is fifteen lines, and every one of them is a decision this dump measures.
+ *
+ * Eight behaviours this is built to catch.
+ *
+ *   - THE COMMENTS ARE APPENDED IN ORDER AND AFTER ANY THE FILE ALREADY HAD, `addComment` pushing
+ *     onto the header's own list;
+ *   - `@CO` IS ADDED BY htsjdk AND NOT BY THE TOOL, AND IT IS NOT DOUBLED: `addComment` prefixes
+ *     only a comment that does not already start with `@CO\t`, so `@CO\talready prefixed` comes
+ *     out exactly once. Measured: the guess was that it doubled;
+ *   - A COMMENT HOLDING A TAB SURVIVES WHOLE, so a comment can forge extra header fields;
+ *   - A COMMENT HOLDING A NEWLINE NEVER REACHES THE TOOL'S OWN CHECK: the parser refuses it first,
+ *     as an IllegalArgumentException naming the character, so the PicardException the tool carries
+ *     for that case is unreachable from the command line;
+ *   - THE SAM REFUSAL IS ON THE PATH'S SUFFIX, not on the file's contents, so a BAM named `.sam` is
+ *     refused by the tool, while a sam named `.bam` gets past that check and is refused LATER, by
+ *     the block copy, for having no valid GZIP block at its end;
+ *   - THE RECORDS ARE COPIED AS COMPRESSED BLOCKS, so the output's record bytes are the input's
+ *     bytes and only the header block is rewritten;
+ *   - THE HEADER IS REWRITTEN WHOLE, so its sequence dictionary, read groups and program records
+ *     come back in htsjdk's own order rather than the input's;
+ *   - NO COMMENT AT ALL IS STILL A REWRITE, which is not a copy: the header block is re-encoded;
+ *   - AND CREATE_MD5_FILE AND CREATE_INDEX WRITE BESIDE THE OUTPUT without changing its bytes.
+ *
+ * Output:
+ *
+ *     deflater\t<class>
+ *     fixture\t<label>\t<the input BAM, base64>
+ *     output\t<label>\t<the rewritten BAM, base64>
+ *     sam\t<label>=<the rewritten BAM as text, escaped>
+ *     md5\t<label>\t<the .md5's contents>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: AddCommentsToBamDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMProgramRecord;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.ValidationStringency;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+import picard.sam.AddCommentsToBam;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class AddCommentsToBamDump {
+
+    public static void main(final String[] args) throws Exception {
+        // Static, and it decides every output byte.
+        BlockCompressedOutputStream.setDefaultDeflaterFactory(new DeflaterFactory());
+
+        final Path dir = Path.of("add-comments-to-bam-dump");
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# AddCommentsToBamDump: a BAM header gaining @CO lines");
+        System.out.printf("deflater\t%s%n",
+                BlockCompressedOutputStream.getDefaultDeflaterFactory().getClass().getName());
+
+        // A BAM whose header already carries a comment, a read group and a program record.
+        final Path bam = dir.resolve("reads.bam");
+        buildBam(bam);
+        System.out.printf("fixture\treads\t%s%n", RecordTransformDump.base64(bam));
+        // The same bytes under a `.sam` name, which the tool refuses on the suffix alone.
+        final Path named = dir.resolve("misnamed.sam");
+        Files.copy(bam, named);
+        // And a real sam file under a `.bam` name, which gets past the suffix check.
+        final Path samAsBam = dir.resolve("really-sam.bam");
+        buildSam(samAsBam);
+        System.out.printf("fixture\treally-sam\t%s%n", RecordTransformDump.base64(samAsBam));
+
+        run(dir, "one-comment", bam, List.of("a comment"));
+        run(dir, "two-comments", bam, List.of("first", "second"));
+        // No comment at all, which is still a rewrite of the header block.
+        run(dir, "no-comment", bam, List.of());
+        // A comment that already carries the prefix, which is NOT added again.
+        run(dir, "already-prefixed", bam, List.of("@CO\talready prefixed"));
+        // A comment holding a tab, which reaches the file whole.
+        run(dir, "with-tab", bam, List.of("key\tvalue"));
+        // A comment holding a newline, which the parser refuses before the tool sees it.
+        run(dir, "with-newline", bam, List.of("first line\nsecond line"));
+        // The digest and the index, neither of which changes the output's bytes.
+        run(dir, "md5", bam, List.of("a comment"), "CREATE_MD5_FILE=true");
+        run(dir, "indexed", bam, List.of("a comment"), "CREATE_INDEX=true");
+        // The suffix refusal, and the file that is a sam but is not named one.
+        run(dir, "named-sam", named, List.of("a comment"));
+        run(dir, "sam-named-bam", samAsBam, List.of("a comment"));
+    }
+
+    static void run(final Path dir, final String label, final Path input,
+                    final List<String> comments, final String... extra) throws Exception {
+        final Path out = dir.resolve("commented-" + label + ".bam");
+        final List<String> argv = new ArrayList<>(Arrays.asList("I=" + input, "O=" + out));
+        for (final String comment : comments) {
+            argv.add("C=" + comment);
+        }
+        argv.add("USE_JDK_DEFLATER=true");
+        argv.add("USE_JDK_INFLATER=true");
+        argv.addAll(Arrays.asList(extra));
+        try {
+            final Object code = new AddCommentsToBam().instanceMain(argv.toArray(new String[0]));
+            if (!Integer.valueOf(0).equals(code)) {
+                System.out.printf("exit\t%s\t%s%n", label, code);
+                return;
+            }
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+            return;
+        }
+        System.out.printf("output\t%s\t%s%n", label, RecordTransformDump.base64(out));
+        System.out.printf("sam\t%s=%s%n", label, ReferenceQueryDump.escape(asText(out)));
+        final Path digest = dir.resolve("commented-" + label + ".bam.md5");
+        if (Files.exists(digest)) {
+            System.out.printf("md5\t%s\t%s%n", label, Files.readString(digest));
+        }
+    }
+
+    static String asText(final Path bam) {
+        final StringBuilder text = new StringBuilder();
+        try (SamReader reader = SamReaderFactory.makeDefault()
+                .validationStringency(ValidationStringency.SILENT)
+                .open(new File(bam.toString()))) {
+            text.append(reader.getFileHeader().getSAMString());
+            for (final SAMRecord record : reader) {
+                text.append(record.getSAMString());
+            }
+        } catch (final Exception e) {
+            text.append("error: ").append(e);
+        }
+        return text.toString();
+    }
+
+    static SAMFileHeader header() {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", 1000),
+                new SAMSequenceRecord("chr2", 1000))));
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        final SAMReadGroupRecord group = new SAMReadGroupRecord("rg1");
+        group.setSample("s1");
+        group.setLibrary("lib1");
+        header.addReadGroup(group);
+        final SAMProgramRecord program = new SAMProgramRecord("upstream");
+        program.setProgramVersion("1.0");
+        header.addProgramRecord(program);
+        // A comment the file already had, which the tool's own comments follow.
+        header.addComment("an existing comment");
+        return header;
+    }
+
+    static void buildBam(final Path file) {
+        final SAMFileHeader header = header();
+        try (SAMFileWriter writer =
+                     new SAMFileWriterFactory().makeBAMWriter(header, true, file.toFile())) {
+            for (final SAMRecord record : records(header)) {
+                writer.addAlignment(record);
+            }
+        }
+    }
+
+    static void buildSam(final Path file) {
+        final SAMFileHeader header = header();
+        try (SAMFileWriter writer =
+                     new SAMFileWriterFactory().makeSAMWriter(header, true, file.toFile())) {
+            for (final SAMRecord record : records(header)) {
+                writer.addAlignment(record);
+            }
+        }
+    }
+
+    static List<SAMRecord> records(final SAMFileHeader header) {
+        final List<SAMRecord> records = new ArrayList<>();
+        for (final int start : new int[] {100, 200, 300}) {
+            final SAMRecord record = new SAMRecord(header);
+            record.setReadName("r" + start);
+            record.setReferenceName("chr1");
+            record.setAlignmentStart(start);
+            record.setCigarString("10M");
+            final byte[] bases = new byte[10];
+            Arrays.fill(bases, (byte) 'A');
+            record.setReadBases(bases);
+            final byte[] qualities = new byte[10];
+            Arrays.fill(qualities, (byte) 30);
+            record.setBaseQualities(qualities);
+            record.setMappingQuality(60);
+            record.setAttribute("RG", "rg1");
+            records.add(record);
+        }
+        return records;
+    }
+
+    /** The dump's own directory, whose absolute path reaches the refusals. */
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toAbsolutePath().toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
A BAM whose header gains `@CO` lines and whose records are copied block for block. The whole tool is fifteen lines, and every one of them is a decision this dump measures.

Eight behaviours the dump is built to catch:

- the comments are appended in order and after any the file already had;
- `@CO` is added by htsjdk and not by the tool, and it is **not** doubled: `addComment` prefixes only a comment that does not already start with `@CO\t`. The dump was written expecting a doubled prefix and the measurement corrected it;
- a comment holding a tab survives whole, so a comment can forge extra header fields;
- a comment holding a newline never reaches the tool's own check: the parser refuses it first, as `java.lang.IllegalArgumentException: Supplied String contains illegal character '\n'.`, which makes the `PicardException` the tool carries for that case unreachable from the command line;
- the sam refusal is on the path's suffix and not on the file's contents, so a BAM named `.sam` is refused by the tool while a sam named `.bam` gets past that check and is refused later by the block copy, for having no valid GZIP block at its end;
- the records are copied as compressed blocks, so only the header block is rewritten;
- the header is rewritten whole, so its dictionary, read groups and program records come back in htsjdk's order;
- no comment at all is still a rewrite, and `CREATE_MD5_FILE` and `CREATE_INDEX` write beside the output without changing its bytes.

The deflater factory is pinned and recorded, and every BAM travels as base64 and again as text.

The manifest entry is `golden-pending`. The golden comes from the pinned container on a real x86-64 runner, in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #8.
