### PR TITLE
Record GATK 4.7.0.0, and why the target stays at 4.6.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Ported from GATK `4.6.2.0`, commit `76edc75c26504da94bbaee66584e107e76ee15de`, w
 All three ports in this program use those exact pins, so they are mutually coherent by
 construction.
 
+GATK 4.7.0.0 (htsjdk 5.0.0, Picard 3.5.0) was released on 2026-08-18, and the target deliberately
+stays at 4.6.2.0: 216 suites are oracle-backed against it, and the three ports move together or
+not at all. The delta, and the order the move has to happen in, are recorded in ROADMAP.md.
+
 ## Origin
 
 This grows out of [broadinstitute/gatk#9384](https://github.com/broadinstitute/gatk/pull/9384)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1220,6 +1220,36 @@ the CPU path that already exists, and no bit-identity claim may weaken to buy a 
       state)
 - [ ] per-tool validation reports (inputs, records, byte-equal file count, argument coverage, t
       level, fuzzer branch coverage, quarantined fields)
+- [ ] the reference version moves to GATK 4.7.0.0, htsjdk 5.0.0 and Picard 3.5.0, once G2 and P
+      are closed (see below)
+
+---
+
+## The reference has moved on, and this one deliberately has not
+
+GATK [4.7.0.0](https://github.com/broadinstitute/gatk/releases/tag/4.7.0.0) was released on
+2026-08-18. It pins **htsjdk 5.0.0**, **Picard 3.5.0**, GKL 0.9.1 and commons-beanutils 1.11.0.
+
+**The target stays at 4.6.2.0 until G2 and P are closed.** 216 suites are oracle-backed against
+4.6.2.0, and moving the target does not adjust them, it re-opens them: every golden has to be
+re-measured on a new oracle and either survives the bump or is replaced with the difference
+explained. The three ports are also coherent only because they name one set of pins, and htsjdk
+4.2.0 to 5.0.0 is a major bump, so htsjdk-rs would have to land first. Finishing against a frozen
+target and moving once is cheaper than chasing a moving one.
+
+What will be waiting, in short. The full delta, per pull request, is in the tracking issue.
+
+| Where | What changes |
+|---|---|
+| GATK 4.7.0.0 | one new tool, `ConvertCountsToDepthFile`, so the inventory's 311 becomes 312; behaviour changes in `SVConcordance`, `SVStratify`, `SVAnnotate`, `PrintSVEvidence`, `CollectSVEvidence`, `HaplotypeCaller`, `GenotypeGVCFs` and `Funcotator`, all still open; `--output-cram-version`, defaulting to 3.1 |
+| htsjdk 5.0.0 | `jlibdeflate` becomes the default DEFLATE engine, so every BGZF byte depends on a pinning that must be re-verified; CRAM 3.1 write support with a trial-compression codec choice; `SAMRecord.toString()` returns the full SAM line; three fixed bugs that this port reproduced faithfully and would now have to stop reproducing |
+| Picard 3.5.0 | `MarkDuplicates` physical location moves from `short` to `int`, changing optical-duplicate counts; `FilterVcf` plumbs `CREATE_INDEX`; fixes in `RevertSam`, `CollectRnaSeqMetrics`, `MergeBamAlignment` and `CrosscheckFingerprints` |
+
+The deflater line is the one to watch. The dumps already pin the factory and print
+`deflater\t<class>` into every golden, which is the guard put there after a Picard call silently
+replaced the factory and the goldens after it were GKL bytes. It is what makes this bump
+survivable at all, and on the move it must be re-verified against the new default rather than
+assumed to still hold.
 
 ---
 


### PR DESCRIPTION
GATK [4.7.0.0](https://github.com/broadinstitute/gatk/releases/tag/4.7.0.0) landed on 2026-08-18, pinning htsjdk 5.0.0, Picard 3.5.0, GKL 0.9.1 and commons-beanutils 1.11.0. Nothing in this program moves, and that is a decision rather than staleness, so it is written down: a section in `ROADMAP.md`, a Milestone V box, and four lines in the README beside the pin table.

**Why the target stays.** 216 suites are oracle-backed against 4.6.2.0, and moving the target does not adjust them, it re-opens them. The three ports are coherent only because they name one set of pins, and htsjdk 4.2.0 to 5.0.0 is a major bump, so htsjdk-rs would have to land first. Finishing against a frozen target and moving once is cheaper than chasing a moving one.

**What is waiting**, per pull request, in #810: one new tool, `ConvertCountsToDepthFile`, taking the inventory from 311 to 312 (#811); behaviour changes in `SVConcordance`, `SVStratify`, `SVAnnotate`, `PrintSVEvidence`, `CollectSVEvidence`, `HaplotypeCaller`, `GenotypeGVCFs` and `Funcotator`, all still open, so nothing measured is invalidated; `jlibdeflate` becoming htsjdk's default DEFLATE engine; CRAM 3.1 becoming the default write version, with a trial-compression codec choice to reproduce; and `MarkDuplicates` moving its physical location from `short` to `int`, which changes optical-duplicate counts.

The deflater line is the one to watch. Every BGZF byte this program reproduces depends on which deflater ran, and the dumps already pin the factory and print the class into every golden, a guard that exists because a Picard call once replaced the factory silently and the goldens after it were GKL bytes. On the move it must be re-verified against the new default, not assumed to still hold.

Documentation only. `preflight` green.

Part of #810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)