### PR TITLE
Build the 4.7.0.0 oracle beside the 4.6.2.0 one

### DIFF
--- a/tools/conformance/run_suite.py
+++ b/tools/conformance/run_suite.py
@@ -9,6 +9,12 @@ in CI is a real difference in the environment rather than a difference in how it
     python3 tools/conformance/run_suite.py --probe rnaseq-overlap-order
     python3 tools/conformance/run_suite.py --list
 
+`--oracle-image` runs a suite against another image than the manifest's. It exists for one job:
+surveying a candidate reference version before anything is migrated to it, by running the goldens
+we already have against the newer oracle and reading off which ones move. A suite that fails under
+an overridden image is not a regression, it is a measurement, so the override is printed on every
+run and refuses to be silent.
+
 The oracle image must exist; build it with
 
     docker build --platform linux/amd64 -t picard-rs-oracle:3.4.0 tools/oracle
@@ -221,9 +227,22 @@ def main(argv):
     )
     ap.add_argument("--probe")
     ap.add_argument("--list", action="store_true")
+    ap.add_argument(
+        "--oracle-image",
+        help="run against this image instead of the manifest's. For surveying a candidate "
+        "reference version: a failure here is a measurement, not a regression.",
+    )
     args = ap.parse_args(argv)
 
     manifest = comparator.load_manifest(args.manifest)
+    if args.oracle_image:
+        print(
+            f"!! oracle overridden: {manifest['oracle']['image']} -> {args.oracle_image}.\n"
+            f"!! Differences below are measurements of that image, not regressions, and nothing\n"
+            f"!! produced under an overridden oracle may be committed as a golden.",
+            flush=True,
+        )
+        manifest["oracle"] = dict(manifest["oracle"], image=args.oracle_image)
 
     if args.list:
         for suite in manifest["suites"]:

--- a/tools/oracle/Dockerfile
+++ b/tools/oracle/Dockerfile
@@ -9,10 +9,24 @@
 # tag 4.6.2.0 pins them, and it carries the `gatk` wrapper script, which is the entry point the
 # bit-identity claim is defined against: `gatk <Tool>` fixes the argument parser to Barclay
 # (`--INPUT`) rather than Picard's legacy syntax.
+#
+# The version is an argument so a second oracle can be built beside the first rather than in place
+# of it. The move to 4.7.0.0 is not a matter of editing this file: it is a matter of building both
+# images and re-running every suite against the new one, so the two have to coexist.
+#
+#     docker build --platform linux/amd64 -t gatk-rs-oracle:4.6.2.0 tools/oracle
+#     docker build --platform linux/amd64 -t gatk-rs-oracle:4.7.0.0 \
+#       --build-arg GATK_VERSION=4.7.0.0 \
+#       --build-arg GATK_SHA256=d093d2693b1626361a413ca59d6d4a0bf968717f280a8fd9ce060b25eb2ed1db \
+#       tools/oracle
+#
+# The checksum is an argument too, defaulting to 4.6.2.0's, so naming a new version without also
+# naming its checksum fails at `sha256sum -c` rather than producing an unverified image.
 
 FROM eclipse-temurin@sha256:068a8f9ae4b74d9a20de3ecca771ba1a6437f1d7a8a8ad6deaf9dbdd2274397a
 
 ARG GATK_VERSION=4.6.2.0
+ARG GATK_SHA256=32d2f90bf13fcb3a8ac765bb2cb8ec1fc9a6cc447055d0156bd1db2092d4e3e8
 
 # python3 is not optional: the `gatk` wrapper is a Python script, so without it the entry point the
 # claim is defined against cannot run at all.
@@ -35,16 +49,20 @@ WORKDIR /opt/oracle
 RUN set -eux; \
     curl -fsSL -o /tmp/gatk.zip \
       https://github.com/broadinstitute/gatk/releases/download/${GATK_VERSION}/gatk-${GATK_VERSION}.zip; \
-    echo "32d2f90bf13fcb3a8ac765bb2cb8ec1fc9a6cc447055d0156bd1db2092d4e3e8  /tmp/gatk.zip" \
+    echo "${GATK_SHA256}  /tmp/gatk.zip" \
       | sha256sum -c -; \
     unzip -q /tmp/gatk.zip -d /opt; \
     rm /tmp/gatk.zip; \
     ln -s /opt/gatk-${GATK_VERSION} /opt/gatk
 
 ENV GATK_HOME=/opt/gatk
-ENV GATK_JAR=/opt/gatk/gatk-package-4.6.2.0-local.jar
-ENV ORACLE_CP=/opt/gatk/gatk-package-4.6.2.0-local.jar:/opt/oracle/classes
+ENV GATK_JAR=/opt/gatk/gatk-package-${GATK_VERSION}-local.jar
+ENV ORACLE_CP=/opt/gatk/gatk-package-${GATK_VERSION}-local.jar:/opt/oracle/classes
 ENV PATH=/opt/gatk:$PATH
+
+# What the probe asserts GATK reports about itself. Passed in rather than compiled in, so one
+# probe serves both images and neither can be built against the wrong jar.
+ENV ORACLE_GATK_VERSION=${GATK_VERSION}
 
 # JaCoCo for the coverage-guided fuzzer, pinned by sha256 like everything else: the fuzzer's
 # stopping condition is a coverage threshold on the reference, so a silently different JaCoCo would
@@ -75,8 +93,15 @@ COPY OracleProbe.java .
 RUN mkdir -p classes && javac -cp "$ORACLE_CP" -d classes OracleProbe.java
 
 # Fail the build itself if the environment does not satisfy the contract.
-RUN java -cp "$ORACLE_CP:classes" OracleProbe
+#
+# The deflater property is passed here exactly as the manifest passes it to every suite, because
+# the probe's job is to assert the configuration the goldens are produced under, not some other
+# one. It is also the only way to find out whether the property still works: under htsjdk 5.0.0
+# this run is what proves `-Dsamjdk.use_libdeflate=false` actually reaches
+# `Defaults.USE_LIBDEFLATE`, and under 4.2.0 it proves the property is harmlessly unknown. The
+# first attempt at building a 4.7.0.0 image failed right here, which is the check working.
+RUN java -Dsamjdk.use_libdeflate=false -cp "$ORACLE_CP:classes" OracleProbe
 
 WORKDIR /work
 ENTRYPOINT ["/bin/sh", "-c"]
-CMD ["java -cp \"$ORACLE_CP:/opt/oracle/classes\" OracleProbe"]
+CMD ["java -Dsamjdk.use_libdeflate=false -cp \"$ORACLE_CP:/opt/oracle/classes\" OracleProbe"]

--- a/tools/oracle/OracleProbe.java
+++ b/tools/oracle/OracleProbe.java
@@ -40,7 +40,15 @@ public class OracleProbe {
 
     private static final String EXPECTED_ARCH = "amd64";
     private static final String EXPECTED_JAVA_MAJOR = "17";
-    private static final String EXPECTED_GATK_VERSION = "4.6.2.0";
+    /**
+     * The version this image is meant to be. Taken from the environment the Dockerfile sets rather
+     * than compiled in, so one probe serves the 4.6.2.0 oracle and the 4.7.0.0 one that has to be
+     * built beside it for the move, and neither can be built against the wrong jar without saying
+     * so.
+     */
+    private static final String EXPECTED_GATK_VERSION =
+            System.getenv("ORACLE_GATK_VERSION") == null
+                    ? "4.6.2.0" : System.getenv("ORACLE_GATK_VERSION");
 
     /**
      * htsjdk-rs decision 0011: FormatUtil reaches NumberFormat.getNumberInstance(), which takes the
@@ -182,6 +190,8 @@ public class OracleProbe {
         json.append("  \"java_version\": \"").append(javaVersion).append("\",\n");
         json.append("  \"java_vendor\": \"").append(javaVendor).append("\",\n");
         json.append("  \"gatk_version\": \"").append(gatkVersion).append("\",\n");
+        json.append("  \"gatk_version_expected\": \"").append(EXPECTED_GATK_VERSION)
+            .append("\",\n");
         json.append("  \"picard_classes_present\": ").append(!"unknown".equals(picardVersion))
             .append(",\n");
         json.append("  \"jar_implementation_version\": \"").append(picardVersion).append("\",\n");


### PR DESCRIPTION
Second brick of the move to the current Broad releases (#810). Moving the reference is not a matter of editing a version string: every golden has to be re-measured against the new image and either survive or be replaced with the difference explained, so the two oracles have to exist at the same time.

**The Dockerfile takes the version and its checksum as arguments**, both defaulting to 4.6.2.0's, so naming a new version without naming its checksum fails at `sha256sum -c` rather than producing an unverified image. The jar path and classpath follow the version, and the version the probe asserts arrives through `ORACLE_GATK_VERSION` rather than being compiled in, so one probe serves both images and neither can be built against the wrong jar in silence.

```
docker build --platform linux/amd64 -t gatk-rs-oracle:4.7.0.0 \
  --build-arg GATK_VERSION=4.7.0.0 \
  --build-arg GATK_SHA256=d093d2693b1626361a413ca59d6d4a0bf968717f280a8fd9ce060b25eb2ed1db \
  tools/oracle
```

**The first attempt at that build failed**, which is the check from #813 earning its keep an hour after it was written:

```
- htsjdk.samtools.Defaults.USE_LIBDEFLATE is true.
```

So the probe now runs under the same `-Dsamjdk.use_libdeflate=false` the manifest passes to every suite. That makes the image build the thing that proves the property still reaches htsjdk: under 5.0.0 it turns `USE_LIBDEFLATE` off, under 4.2.0 it is harmlessly unknown. Both images build with `"contract_satisfied": true`, reporting `"use_libdeflate": "false"` and `"absent"` respectively.

**`run_suite.py` gains `--oracle-image`**, for the survey: run the goldens we already have against the newer oracle and read off which move. The override is printed on every run, with the reminder that a difference under it is a measurement rather than a regression, and that nothing produced that way may be committed as a golden.

Both images built locally, `preflight` green.

Part of #810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)