### PR TITLE
Survey the 216 goldens against 4.7.0.0, and remove the first artefact

### DIFF
--- a/tools/conformance/survey.py
+++ b/tools/conformance/survey.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Run the goldens we already have against another oracle, and classify what moved.
+
+Written for the move to a newer reference (GATK 4.7.0.0, htsjdk 5.0.0, Picard 3.5.0). Moving the
+target does not adjust 216 oracle-backed suites, it re-opens them, and the only honest way to size
+that is to measure it: run every suite against the candidate image and sort the differences into
+the ones that are the reference saying its own version and the ones that are the reference
+behaving differently.
+
+    python3 tools/conformance/survey.py --oracle-image gatk-rs-oracle:4.7.0.0 \
+        --version-was 4.6.2.0 --version-now 4.7.0.0
+
+Each suite lands in one of three buckets:
+
+  * **identical**, the golden matches under the new oracle with no help at all;
+  * **version stamp only**, it matches once the new version string is rewritten to the old one,
+    which is the `@PG` line's `VN:` and nothing else;
+  * **behaviour**, something else moved, and the first differing row is printed.
+
+The second bucket is a *heuristic and is named as one*: a genuine difference that happened to
+contain the literal new version string would be swallowed by it. It is here to make the third
+bucket small enough to read, not to decide anything. Nothing produced by this script may be
+committed as a golden: a golden comes from the pinned container on a real x86-64 runner, and this
+runs wherever it is invoked.
+"""
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import compare as comparator  # noqa: E402
+import run_suite  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def rewrite(path, was, now):
+    """A copy of the regenerated dump with the new version string put back to the old one."""
+    out = Path(str(path) + ".versioned")
+    out.write_text(path.read_text().replace(now, was))
+    return out
+
+
+def survey_suite(manifest, suite, workdir, was, now):
+    """Run one suite under the overridden oracle and say which bucket it falls in."""
+    props = suite.get("java_props", manifest.get("default_java_props", []))
+    fixtures = None
+    if suite.get("needs_fixtures"):
+        fixtures = Path(workdir) / f"fixtures-{suite['id']}"
+        if run_suite.build_fixtures(manifest, fixtures) != 0:
+            return "error", ["could not build the fixtures"]
+    verdict, notes = "identical", []
+    for case in suite["cases"]:
+        dump = case["dump"]
+        real = Path(workdir) / f"{suite['id']}.{dump}.txt"
+        if run_suite.docker_run(manifest, suite["harness"], dump, props, real, fixtures) != 0:
+            return "error", [f"{dump}: the dump did not run under this oracle"]
+        ok, _, messages = comparator.compare_case(real, case["golden"], suite["compare"])
+        if ok:
+            continue
+        ok, _, messages = comparator.compare_case(
+            rewrite(real, was, now), case["golden"], suite["compare"]
+        )
+        if ok:
+            verdict = "version" if verdict != "behaviour" else verdict
+            notes.append(f"{dump}: the version stamp, and nothing else")
+            continue
+        verdict = "behaviour"
+        notes.append(f"{dump}: " + "; ".join(messages[:3]))
+    return verdict, notes
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest")
+    ap.add_argument("--oracle-image", required=True)
+    ap.add_argument("--version-was", required=True)
+    ap.add_argument("--version-now", required=True)
+    ap.add_argument("--suites", help="space separated ids; default is every oracle-backed suite")
+    args = ap.parse_args(argv)
+
+    manifest = comparator.load_manifest(args.manifest)
+    print(
+        f"!! surveying against {args.oracle_image}, not {manifest['oracle']['image']}.\n"
+        f"!! Nothing produced here may be committed as a golden.",
+        flush=True,
+    )
+    manifest["oracle"] = dict(manifest["oracle"], image=args.oracle_image)
+
+    ids = (
+        args.suites.split()
+        if args.suites
+        else [s["id"] for s in manifest["suites"] if s["status"] == "oracle-backed"]
+    )
+    buckets = {"identical": [], "version": [], "behaviour": [], "error": []}
+    with tempfile.TemporaryDirectory() as workdir:
+        for suite_id in ids:
+            suite = comparator.suite_by_id(manifest, suite_id)
+            verdict, notes = survey_suite(manifest, suite, workdir, args.version_was, args.version_now)
+            buckets[verdict].append(suite_id)
+            print(f"{verdict:10} {suite_id}", flush=True)
+            for note in notes:
+                print(f"           {note}", flush=True)
+
+    print()
+    for name, title in [
+        ("identical", "identical under the new oracle"),
+        ("version", "the version stamp only"),
+        ("behaviour", "something else moved"),
+        ("error", "did not run"),
+    ]:
+        print(f"{len(buckets[name]):4}  {title}")
+        if name in ("behaviour", "error") and buckets[name]:
+            for suite_id in buckets[name]:
+                print(f"        {suite_id}")
+    return 1 if buckets["behaviour"] or buckets["error"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/readfilter-conformance/AddCommentsToBamDump.java
+++ b/tools/readfilter-conformance/AddCommentsToBamDump.java
@@ -140,7 +140,7 @@ public class AddCommentsToBamDump {
                 .open(new File(bam.toString()))) {
             text.append(reader.getFileHeader().getSAMString());
             for (final SAMRecord record : reader) {
-                text.append(record.getSAMString());
+                text.append(PrintReadsDump.samLine(record));
             }
         } catch (final Exception e) {
             text.append("error: ").append(e);

--- a/tools/readfilter-conformance/GatherBamFilesDump.java
+++ b/tools/readfilter-conformance/GatherBamFilesDump.java
@@ -167,7 +167,7 @@ public class GatherBamFilesDump {
                 .open(new File(bam.toString()))) {
             text.append(reader.getFileHeader().getSAMString());
             for (final SAMRecord record : reader) {
-                text.append(record.getSAMString());
+                text.append(PrintReadsDump.samLine(record));
             }
         } catch (final Exception e) {
             text.append("error: ").append(e);

--- a/tools/readfilter-conformance/PrintReadsDump.java
+++ b/tools/readfilter-conformance/PrintReadsDump.java
@@ -52,6 +52,7 @@
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMProgramRecord;
+import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
@@ -148,5 +149,24 @@ public class PrintReadsDump {
 
     static String base64(final Path path) throws Exception {
         return Base64.getEncoder().encodeToString(Files.readAllBytes(path));
+    }
+
+    /**
+     * One record as a SAM line, terminated by exactly one newline whatever htsjdk does.
+     *
+     * `SAMRecord.getSAMString()` returned a line ENDING IN A NEWLINE up to htsjdk 4.2.0 and returns
+     * one WITHOUT it from 5.0.0, where `getSAMString` was rerouted to a new
+     * `SAMTextWriter.writeAlignmentNoNewline`. The 5.0.0 release notes announce the change to
+     * `SAMRecord.toString()` and say nothing about this one, so a dump that concatenates records
+     * silently produces one long line instead of many, and a dump that escapes a single record
+     * silently loses its trailing `\n`.
+     *
+     * That is a property of the measuring instrument, not of the tool being measured, so it is
+     * removed rather than recorded: every dump asks for its line here and gets the same text under
+     * either htsjdk.
+     */
+    static String samLine(final SAMRecord record) {
+        final String line = record.getSAMString();
+        return line.endsWith("\n") ? line : line + "\n";
     }
 }

--- a/tools/readfilter-conformance/SetNmMdAndUqTagsDump.java
+++ b/tools/readfilter-conformance/SetNmMdAndUqTagsDump.java
@@ -207,7 +207,7 @@ public class SetNmMdAndUqTagsDump {
                 .validationStringency(htsjdk.samtools.ValidationStringency.SILENT)
                 .open(new File(bam.toString()))) {
             for (final SAMRecord record : reader) {
-                text.append(record.getSAMString());
+                text.append(PrintReadsDump.samLine(record));
             }
         } catch (final Exception e) {
             text.append("error: ").append(e);


### PR DESCRIPTION
Third brick of the move to the current Broad releases (#810), and the first measurement of what it actually costs.

## The survey

`tools/conformance/survey.py` runs the goldens we already have against another oracle and sorts what moves into three buckets: identical, the version stamp only, something else. The middle bucket is a heuristic and is named as one, since a real difference containing the literal new version string would be swallowed by it; it exists to make the third bucket small enough to read. Nothing it produces may be committed as a golden.

**193 of the 216 suites are byte-identical under GATK 4.7.0.0.** The 23 that are not have three causes, and none is the tool being measured behaving differently:

| cause | what it is |
|---|---|
| `@PG` line `VN:` | the reference naming its own version |
| `##GATKCommandLine` gains `--output-cram-version 3.1` | the reference echoing an argument list that grew |
| `SAMRecord.getSAMString()` loses its trailing newline | the instrument, not the reference |

## The third one, which is ours to fix

Up to htsjdk 4.2.0 `getSAMString()` returned a line **ending in a newline**. From 5.0.0 it is rerouted to a new `SAMTextWriter.writeAlignmentNoNewline` and returns one without. The 5.0.0 release notes announce the change to `SAMRecord.toString()` and say nothing about this one, so a dump that concatenates records silently produces one long line instead of many:

```
...RG:Z:rg1\nr200\t0\tchr1...      4.6.2.0
...RG:Z:rg1r200\t0\tchr1...        4.7.0.0
```

Three dumps concatenate records that way. They now go through `PrintReadsDump.samLine`, which terminates the line with exactly one newline whatever htsjdk does. The other twenty-three call sites are either a `SAMFileHeader`, which is unaffected, or already `.trim()`ed.

**Under 4.6.2.0 nothing moves**: the three suites re-run and match. **Under 4.7.0.0 all three go from failing to identical**, which is the evidence that those tools did not change:

```
   3  identical under the new oracle
   0  the version stamp only
   0  something else moved
```

Preflight green.

Part of #810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)