### PR TITLE
Measure NuMTFilterTool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,6 +350,10 @@ jobs:
             index: "44/44"
             slug: "condense-depth-evidence-site-depth-to-baf-multi-feature-walker"
             suites: "condense-depth-evidence site-depth-to-baf multi-feature-walker"
+          - group: golden-pending
+            index: "1/1"
+            slug: "numt-filter"
+            suites: "numt-filter"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 129 | 41.5% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 170 | 54.7% |
+| not started | 169 | 54.3% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (81 of 190 started)
+## gatk-origin tools (82 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -144,6 +144,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `MergeAnnotatedRegionsByAnnotation` | unclassified | oracle-backed | merge-annotated-regions-by-annotation | 1 | not measured |
 | `MergeMutectStats` | unclassified | oracle-backed | mutect-gathers | 1 | not measured |
 | `MethylationTypeCaller` | record-transform | oracle-backed | methylation-type-caller | 1 | not measured |
+| `NuMTFilterTool` | unclassified | golden-pending | numt-filter | 1 | not measured |
 | `Pileup` | locus-walker | oracle-backed | pileup-tool | 1 | not measured |
 | `PostProcessReadsForRSEM` | record-transform | oracle-backed | post-process-reads-for-rsem | 1 | not measured |
 | `PreprocessIntervals` | interval-utility | oracle-backed | preprocess-intervals | 1 | not measured |
@@ -171,9 +172,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>109 not started</summary>
+<details><summary>108 not started</summary>
 
-`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectF1R2Counts`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `DownsampleByDuplicateSet`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MTLowHeteroplasmyFilterTool`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `MergeMutect2CallsWithMC3`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `NuMTFilterTool`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadCounts`, `PrintReadsSpark`, `PrintSVEvidence`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `SplitCRAM`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectF1R2Counts`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `DownsampleByDuplicateSet`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MTLowHeteroplasmyFilterTool`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `MergeMutect2CallsWithMC3`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadCounts`, `PrintReadsSpark`, `PrintSVEvidence`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `SplitCRAM`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5181,6 +5181,26 @@
           "why": "Ten runs over one-, two- and three-file sets of DepthEvidence: alternating loci, two records that are the same interval, three that are, the same start with different ends, three contigs in dictionary order, a contig the dictionary does not name at all, one it names beside one it does not, an unsorted file offered indexed and again unindexed, no dictionary, and two dictionaries that disagree, once by a missing contig and once by their order. The tool prints every feature it is handed, so the merge order is the output. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32573124567, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "numt-filter",
+      "status": "golden-pending",
+      "title": "Mitochondrial calls filtered by a Poisson depth cutoff",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "NuMTFilterTool"
+      ],
+      "why": "THE TOOL DOES NOTHING AT ITS DEFAULTS: the median autosomal coverage defaults to zero and the cutoff is only computed when both it and the copy count are above zero, so the cutoff stays 0 and no alternate is ever below it. THE CUTOFF IS A POISSON QUANTILE, PoissonDistribution(coverage * copies / 2).inverseCumulativeProbability(0.99). THE FILTER IS APPLIED WHEN NO ALTERNATE ESCAPES IT and an EMPTY list of decisions escapes nothing, so a record with no alternate allele is filtered. THE AS_FilterStatus ATTRIBUTE IS WRITTEN WHENEVER ANY alternate is filtered, so a multiallelic record can carry the attribute without the site filter, AND WRITING IT THROWS WHEN THE RECORD HAS NO AS_FilterStatus TO MERGE INTO, since an absent attribute decodes to an empty list and getMergedASFilterString validates the lengths, so an ordinary VCF makes the tool throw. THE DEPTH COMPARED IS THE MAXIMUM ACROSS SAMPLES, not the sum. A GENOTYPE WITHOUT AD IS SKIPPED, leaving an empty list whose maximum is taken as zero. AN EXISTING ALLELE FILTER IS UNIONED THROUGH A LinkedHashSet, so a repeat is dropped and the SITE placeholder is replaced rather than added to. AND THE HEADER GAINS THE FILTER LINE whether or not anything is filtered.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "NuMTFilterDump",
+          "golden": null,
+          "why": "Twenty-one cutoffs over seven coverages and three copy counts, then seven runs over mitochondrial VCFs: at the defaults, at a coverage that splits the shallow alternates from the deep ones, at zero copies, at a coverage that swallows everything, on records with no AS_FilterStatus both while nothing is filtered and once something is, and on a record with no alternate allele at all. The GATKCommandLine header line is stripped, since it holds the temporary directory and the reference's own version."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/NuMTFilterDump.java
+++ b/tools/readfilter-conformance/NuMTFilterDump.java
@@ -1,0 +1,159 @@
+/*
+ * NuMTFilterTool's output, taken from the reference.
+ *
+ * A mitochondrial call filtered when its alternate depth is low enough to be a nuclear insertion of
+ * mitochondrial DNA rather than a real heteroplasmy. One hundred and five lines, and most of them
+ * are not what the name suggests.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - THE TOOL DOES NOTHING AT ITS DEFAULTS. `medianAutosomalCoverage` defaults to ZERO and the
+ *     cutoff is only computed when BOTH it and `maxNuMTAutosomalCopies` are above zero, so the
+ *     cutoff stays 0, `max(AD) < 0` is never true, and the output is the input with one more
+ *     header line;
+ *   - THE CUTOFF IS A POISSON QUANTILE, `PoissonDistribution(coverage * copies / 2)
+ *     .inverseCumulativeProbability(0.99)`, so it is an integer read off a distribution rather than
+ *     a depth the user gave;
+ *   - THE FILTER IS APPLIED WHEN NO ALTERNATE ESCAPES IT, `!appliedFilter.contains(FALSE)`, and an
+ *     EMPTY list contains no FALSE either, so a record with no alternate allele at all is filtered;
+ *   - THE AS_FilterStatus ATTRIBUTE IS WRITTEN WHENEVER ANY alternate is filtered, so a
+ *     multiallelic record can carry the attribute without carrying the site filter;
+ *   - AND WRITING IT THROWS WHEN THE RECORD HAS NO AS_FilterStatus TO MERGE INTO:
+ *     `getMergedASFilterString` validates that the decoded list is the same length as the list of
+ *     alternates, and an absent attribute decodes to an EMPTY list, so an ordinary VCF that has
+ *     never been through Mutect2's filtering makes the tool throw;
+ *   - THE DEPTH COMPARED IS THE MAXIMUM ACROSS SAMPLES for that allele, not the sum;
+ *   - A GENOTYPE WITHOUT AD IS SKIPPED ENTIRELY by the `Genotype::hasAD` precondition, so an allele
+ *     nobody reports leaves an empty list whose maximum is taken as ZERO and is therefore filtered;
+ *   - AN EXISTING ALLELE FILTER IS UNIONED THROUGH A LinkedHashSet, so order is insertion order and
+ *     a repeat is dropped, and the placeholder SITE is REPLACED rather than added to;
+ *   - AND THE HEADER GAINS THE FILTER LINE whether or not anything is filtered.
+ *
+ * Output:
+ *
+ *     cutoff\t<coverage>\t<copies>\t<the integer cutoff>
+ *     input\t<label>=<the whole input vcf, escaped>
+ *     filtered\t<label>=<the whole output vcf, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: NuMTFilterDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.mutect.filtering.NuMTFilterTool;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class NuMTFilterDump {
+
+    static final String HEADER =
+            "##fileformat=VCFv4.2\n"
+            + "##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allelic depths\">\n"
+            + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+            + "##INFO=<ID=AS_FilterStatus,Number=A,Type=String,Description=\"Filter status for each allele\">\n"
+            + "##contig=<ID=chrM,length=16569>\n"
+            + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tone\ttwo\n";
+
+    /** Records that already carry AS_FilterStatus, which is the only shape the tool can merge into. */
+    static final String WITH_STATUS =
+            // A deep alternate, above any cutoff these runs use.
+            "chrM\t100\t.\tA\tC\t50\t.\tAS_FilterStatus=SITE\tGT:AD\t0/1:100,100\t0/0:200,0\n"
+            // A shallow one, below them.
+            + "chrM\t200\t.\tA\tC\t50\t.\tAS_FilterStatus=SITE\tGT:AD\t0/1:200,5\t0/0:200,0\n"
+            // Two alternates, one deep and one shallow, so the attribute is written and the site
+            // filter is not.
+            + "chrM\t300\t.\tA\tC,G\t50\t.\tAS_FilterStatus=SITE|SITE\tGT:AD\t0/1:100,100,4\t0/0:200,0,0\n"
+            // The maximum across samples rather than the sum: two samples of fifty each, so the
+            // maximum is under the cutoff of seventy-nine while the sum is over it.
+            + "chrM\t400\t.\tA\tC\t50\t.\tAS_FilterStatus=SITE\tGT:AD\t0/1:100,50\t0/1:100,50\n"
+            // No AD anywhere, so the allele's list is empty and its maximum is taken as zero.
+            + "chrM\t500\t.\tA\tC\t50\t.\tAS_FilterStatus=SITE\tGT\t0/1\t0/0\n"
+            // An allele filter already set, which is unioned rather than replaced.
+            + "chrM\t600\t.\tA\tC\t50\t.\tAS_FilterStatus=weak_evidence\tGT:AD\t0/1:200,5\t0/0:200,0\n"
+            // The same filter already set, which the set drops.
+            + "chrM\t700\t.\tA\tC\t50\t.\tAS_FilterStatus=possible_numt\tGT:AD\t0/1:200,5\t0/0:200,0\n";
+
+    /** The same records without the attribute, which is what an ordinary VCF looks like. */
+    static final String WITHOUT_STATUS =
+            "chrM\t100\t.\tA\tC\t50\t.\t.\tGT:AD\t0/1:100,100\t0/0:200,0\n"
+            + "chrM\t200\t.\tA\tC\t50\t.\t.\tGT:AD\t0/1:200,5\t0/0:200,0\n";
+
+    /** A record whose ALT is absent, so the list of alternates is empty. */
+    static final String NO_ALT =
+            "chrM\t100\t.\tA\t.\t50\t.\tAS_FilterStatus=SITE\tGT:AD\t0/0:200\t0/0:200\n";
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("numt-filter-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# NuMTFilterDump: mitochondrial calls filtered by a Poisson depth cutoff");
+
+        // The cutoff on its own, which is the only arithmetic in the tool.
+        for (final double coverage : new double[] {1, 5, 10, 30, 100, 1000, 0.5}) {
+            for (final double copies : new double[] {1, 4, 0.5}) {
+                System.out.printf("cutoff\t%s\t%s\t%d%n", coverage, copies,
+                        cutoff(copies, coverage));
+            }
+        }
+
+        // The defaults, where the coverage is zero and nothing at all happens.
+        run(dir, "defaults", HEADER + WITH_STATUS);
+        // A coverage that puts the cutoff between the shallow and the deep alternates.
+        run(dir, "coverage-30", HEADER + WITH_STATUS, "--autosomal-coverage", "30");
+        // Copies of zero, which keeps the cutoff at zero however deep the coverage.
+        run(dir, "copies-0", HEADER + WITH_STATUS,
+                "--autosomal-coverage", "30", "--max-numt-autosomal-copies", "0");
+        // A cutoff so high that every alternate falls under it.
+        run(dir, "coverage-1000", HEADER + WITH_STATUS, "--autosomal-coverage", "1000");
+        // The same records without AS_FilterStatus: harmless while nothing is filtered.
+        run(dir, "no-status-defaults", HEADER + WITHOUT_STATUS);
+        // And the same, once something is.
+        run(dir, "no-status-filtered", HEADER + WITHOUT_STATUS, "--autosomal-coverage", "30");
+        // A record with no alternate allele, whose list of decisions is empty.
+        run(dir, "no-alt", HEADER + NO_ALT, "--autosomal-coverage", "30");
+    }
+
+    /**
+     * `getMaxAltDepthCutoff`, which is package-private and `@VisibleForTesting`, so it is reached
+     * reflectively rather than by moving this dump into the tool's package.
+     */
+    static int cutoff(final double copies, final double coverage) throws Exception {
+        final java.lang.reflect.Method method = NuMTFilterTool.class
+                .getDeclaredMethod("getMaxAltDepthCutoff", double.class, double.class);
+        method.setAccessible(true);
+        return (Integer) method.invoke(null, copies, coverage);
+    }
+
+    static void run(final Path dir, final String label, final String vcf, final String... extra)
+            throws Exception {
+        final Path in = dir.resolve(label + ".vcf");
+        Files.writeString(in, vcf, StandardCharsets.UTF_8);
+        System.out.printf("input\t%s=%s%n", label, ReferenceQueryDump.escape(vcf));
+
+        final Path out = dir.resolve(label + "-filtered.vcf");
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "-V", in.toString(), "-O", out.toString()));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            new NuMTFilterTool().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+            return;
+        }
+        if (Files.exists(out)) {
+            System.out.printf("filtered\t%s=%s%n", label,
+                    ReferenceQueryDump.escape(masked(Files.readString(out), dir)));
+        }
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>")
+                .replaceAll("##GATKCommandLine=<[^\n]*>\n", "");
+    }
+}


### PR DESCRIPTION
A mitochondrial call filtered when its alternate depth is low enough to be a nuclear insertion of mitochondrial DNA rather than a real heteroplasmy. One hundred and five lines, and most of them are not what the name suggests.

**The tool does nothing at its defaults.** The median autosomal coverage defaults to zero, and the cutoff is computed only when both it and the copy count are above zero, so the cutoff stays 0, `max(AD) < 0` is never true, and the output is the input with one more header line. The measured `defaults` and `copies-0` runs are the input, record for record.

**An ordinary VCF makes it throw.** `getMergedASFilterString` validates that the decoded `AS_FilterStatus` has one entry per alternate allele, and an absent attribute decodes to an *empty* list, so a VCF that has never been through Mutect2's filtering fails as soon as anything is filtered:

```
java.lang.IllegalArgumentException: lists are not the same size
```

The same file passes untouched while the cutoff is zero, so the failure depends on the data and on an argument, not on the file's shape alone.

**A record with no alternate allele is filtered.** The site filter is applied when no alternate escapes it, and an empty list of decisions escapes nothing, so `A -> .` comes out carrying `possible_numt`.

**The depth compared is the maximum across samples, not the sum**: two samples of fifty each, under a cutoff of seventy-nine, are filtered while their sum is a hundred. That fixture was 30 and 30 in the first draft, where both the maximum and the sum fall under the cutoff and the run proved nothing.

A genotype without `AD` is skipped by the precondition, so the allele's list is empty, its maximum is taken as zero, and it is filtered. An existing allele filter is unioned through a `LinkedHashSet`, so `weak_evidence` becomes `weak_evidence,possible_numt` and a repeat is dropped, while the `SITE` placeholder is replaced rather than added to.

Twenty-one cutoffs are measured beside the seven runs, over seven coverages and three copy counts, because the cutoff is a Poisson quantile and is the only arithmetic in the tool. The port will need `PoissonDistribution.inverseCumulativeProbability` in jmath, which does not have it yet.

`golden-pending`. The golden comes from the runner.

Part of #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)