### PR TITLE
Measure PrintSVEvidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,10 @@ jobs:
             index: "45/45"
             slug: "merge-mutect2-mc3-downsample-by-duplicate-set"
             suites: "merge-mutect2-mc3 downsample-by-duplicate-set"
+          - group: golden-pending
+            index: "1/1"
+            slug: "print-sv-evidence"
+            suites: "print-sv-evidence"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 133 | 42.8% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 166 | 53.4% |
+| not started | 165 | 53.1% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (85 of 190 started)
+## gatk-origin tools (86 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -156,6 +156,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |
 | `PrintReads` | record-transform | oracle-backed | printreads | 1 | not measured |
 | `PrintReadsHeader` | record-transform | oracle-backed | print-reads-header | 1 | not measured |
+| `PrintSVEvidence` | unclassified | golden-pending | print-sv-evidence | 1 | not measured |
 | `ReadAnonymizer` | unclassified | oracle-backed | read-anonymizer | 1 | not measured |
 | `ReferenceBlockConcordance` | unclassified | oracle-backed | reference-block-concordance | 1 | not measured |
 | `RemoveNearbyIndels` | variant-transform | oracle-backed | remove-nearby-indels | 1 | not measured |
@@ -175,9 +176,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>105 not started</summary>
+<details><summary>104 not started</summary>
 
-`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectF1R2Counts`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadCounts`, `PrintReadsSpark`, `PrintSVEvidence`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `SplitCRAM`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectF1R2Counts`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadCounts`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `SplitCRAM`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5261,6 +5261,26 @@
           "why": "Eleven runs over UMI-grouped BAMs: four fractions over ten two-read molecules, the same ten with a three-read molecule in front and again with one at the end, a file of a single read, each of the two minimums, a molecule number that goes backwards, and an unmapped read inside a molecule. The deflater factory is pinned and recorded, every BAM travels as text, and the @PG lines are stripped. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32591882957, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "print-sv-evidence",
+      "status": "golden-pending",
+      "title": "SV evidence files merged into one",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "PrintSVEvidence"
+      ],
+      "why": "THE OUTPUT'S SAMPLE LIST IS THE UNION OF THE INPUTS' HEADERS, accumulated into a TreeSet and therefore ALPHABETICAL rather than in file order: files naming zulu, alpha and mike produce the columns alpha, mike, zulu. EVERY RECORD IS REWRITTEN AGAINST THAT LIST, extractSamples filling a column a file does not have with MISSING_DATA, which is -1. THE MERGE ONLY FILLS MISSING COLUMNS: two files that both report a sample at one bin are a UserException naming the sample by ONE-BASED index and the bin by its ONE-BASED interval, 'Multiple sources for count of sample#1 at chr1:1-100', while the file itself writes that bin as 0 100. So merging is only ever a widening. --sample-names SUBSETS AND REORDERS THE COLUMNS, and a name no file knows becomes a column of -1 rather than a refusal. AN EMPTY SAMPLE LIST FROM EVERY HEADER TURNS SAMPLE FILTERING OFF ENTIRELY rather than dropping everything. THE OUTPUT TYPE IS DECIDED BY THE OUTPUT PATH'S EXTENSION and an input whose codec produces another type is refused by name. AN EXTENSION THAT NAMES NO FEATURE TYPE AT ALL NEVER REACHES THE TOOL'S OWN CHECK, FeatureOutputCodecFinder failing first, so the 'requires an SVFeature subtype' message is unreachable from an extension with no codec. AND THE HEADER LINE OF THE OUTPUT IS REWRITTEN from the sample list, so the columns of the output are the columns of no input.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "PrintSVEvidenceDump",
+          "golden": null,
+          "why": "Nine runs over DepthEvidence files: two files naming different samples over the same bins, the same two subset to one sample, to a sample neither knows and reordered, two files naming the SAME sample at one bin, two files whose bins are disjoint, three files whose sample names are not in alphabetical order, an output whose extension implies another SV feature type, and one whose extension implies no feature type at all. Every run is handed a dictionary, since a .rd.txt header carries sample names and a null dictionary."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/PrintSVEvidenceDump.java
+++ b/tools/readfilter-conformance/PrintSVEvidenceDump.java
@@ -1,0 +1,156 @@
+/*
+ * PrintSVEvidence's output, taken from the reference.
+ *
+ * Several SV evidence files merged into one. It sits on `MultiFeatureWalker`, already measured, and
+ * what is measured here is the two things above it: which samples the output declares, and what the
+ * sort merger does when two files speak about the same bin.
+ *
+ * Ten behaviours this is built to catch.
+ *
+ *   - THE OUTPUT'S SAMPLE LIST IS THE UNION OF THE INPUTS' HEADERS, in the order the walker
+ *     accumulated it, which is a TreeSet and therefore alphabetical rather than file order;
+ *   - EVERY RECORD IS REWRITTEN AGAINST THAT LIST, `extractSamples` filling a column a file does
+ *     not have with MISSING_DATA, which is -1;
+ *   - THE MERGE ONLY FILLS MISSING COLUMNS. Two files that both report a sample at one bin are a
+ *     UserException naming the sample by ONE-BASED index and the bin by its interval, so merging is
+ *     only ever a widening;
+ *   - --sample-names SUBSETS AND REORDERS THE COLUMNS, and a name no file knows becomes a column
+ *     of -1 rather than a refusal;
+ *   - AN EMPTY SAMPLE LIST FROM EVERY HEADER TURNS SAMPLE FILTERING OFF ENTIRELY rather than
+ *     dropping everything, so a headerless format passes through untouched;
+ *   - THE OUTPUT TYPE IS DECIDED BY THE OUTPUT PATH'S EXTENSION, and an input whose codec produces
+ *     another type is refused by name;
+ *   - AN OUTPUT EXTENSION THAT NAMES NO FEATURE TYPE AT ALL NEVER REACHES THE TOOL'S OWN CHECK:
+ *     `FeatureOutputCodecFinder.find` fails first with `No feature output codec found for ...`, so
+ *     the "requires an SVFeature subtype" message the tool carries is unreachable from any
+ *     extension that has no codec, and reachable only from one whose codec produces a non-SV
+ *     feature;
+ *   - THE SORT MERGER REFUSES FEATURES OUT OF DICTIONARY ORDER with a GATKException rather than a
+ *     UserException;
+ *   - THE HEADER LINE OF THE OUTPUT IS REWRITTEN from the sample list, so the columns of the output
+ *     are not the columns of any input;
+ *   - AND THE WALKER'S OWN DICTIONARY RULES APPLY, so the run needs one and takes the largest.
+ *
+ * Output:
+ *
+ *     input\t<label>\t<name>=<the whole file, escaped>
+ *     merged\t<label>=<the whole output, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: PrintSVEvidenceDump
+ */
+
+import org.broadinstitute.hellbender.tools.IndexFeatureFile;
+import org.broadinstitute.hellbender.tools.sv.PrintSVEvidence;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PrintSVEvidenceDump {
+
+    /** One depth bin, written zero-based and half-open as the file holds it. */
+    static String bin(final int start, final int end, final int... counts) {
+        final StringBuilder line = new StringBuilder("chr1\t" + start + "\t" + end);
+        for (final int count : counts) {
+            line.append('\t').append(count);
+        }
+        return line.append('\n').toString();
+    }
+
+    static String header(final String... samples) {
+        return "#Chr\tStart\tEnd\t" + String.join("\t", samples) + "\n";
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("print-sv-evidence-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# PrintSVEvidenceDump: SV evidence files merged into one");
+
+        final Path dict = MultiFeatureWalkerDump.writeDictionary(dir, "sv", List.of("chr1", "chr2"));
+
+        // Two files naming different samples over the same bins, which is the widening the merge
+        // is for: each file's records gain a -1 column, and the merge fills it.
+        final String alpha = header("alpha") + bin(0, 100, 11) + bin(100, 200, 12);
+        final String beta = header("beta") + bin(0, 100, 21) + bin(100, 200, 22);
+        run(dir, "widening", dict, List.of(named("a", alpha), named("b", beta)));
+
+        // The same two, subset to one sample, and to a sample neither file knows.
+        run(dir, "subset-one", dict, List.of(named("a", alpha), named("b", beta)),
+                "--sample-names", "beta");
+        run(dir, "unknown-sample", dict, List.of(named("a", alpha), named("b", beta)),
+                "--sample-names", "gamma");
+        // And reordered, which the output's columns follow.
+        run(dir, "reordered", dict, List.of(named("a", alpha), named("b", beta)),
+                "--sample-names", "beta", "--sample-names", "alpha");
+
+        // Two files naming the SAME sample over the same bins, which is not a widening.
+        run(dir, "same-sample-twice", dict,
+                List.of(named("a", alpha), named("b", header("alpha") + bin(0, 100, 31))));
+
+        // Disjoint bins, where the merger never has two records at one locus.
+        run(dir, "disjoint-bins", dict,
+                List.of(named("a", header("alpha") + bin(0, 100, 11)),
+                        named("b", header("beta") + bin(200, 300, 22))));
+
+        // Three files, to show the sample list is sorted rather than in file order.
+        run(dir, "three-samples", dict,
+                List.of(named("a", header("zulu") + bin(0, 100, 1)),
+                        named("b", header("alpha") + bin(0, 100, 2)),
+                        named("c", header("mike") + bin(0, 100, 3))));
+
+        // An output whose extension implies another SV feature type than the inputs produce.
+        runNamed(dir, "wrong-sv-type", dict, List.of(named("a", alpha)), "merged.baf.txt");
+        // And one that is not an SV feature at all.
+        runNamed(dir, "not-an-sv-type", dict, List.of(named("a", alpha)), "merged.vcf");
+    }
+
+    record Input(String name, String text) {}
+
+    static Input named(final String name, final String text) {
+        return new Input(name, text);
+    }
+
+    static void run(final Path dir, final String label, final Path dictionary,
+                    final List<Input> inputs, final String... extra) throws Exception {
+        runNamed(dir, label, dictionary, inputs, "merged-" + label + ".rd.txt", extra);
+    }
+
+    static void runNamed(final Path dir, final String label, final Path dictionary,
+                         final List<Input> inputs, final String outputName, final String... extra)
+            throws Exception {
+        final List<String> argv = new ArrayList<>();
+        for (final Input input : inputs) {
+            final Path path = dir.resolve(label + "-" + input.name() + ".rd.txt");
+            Files.writeString(path, input.text(), StandardCharsets.UTF_8);
+            new IndexFeatureFile().instanceMain(new String[] {"-I", path.toString()});
+            System.out.printf("input\t%s\t%s=%s%n", label, input.name(),
+                    ReferenceQueryDump.escape(input.text()));
+            argv.addAll(Arrays.asList("-F", path.toString()));
+        }
+        final Path out = dir.resolve(outputName);
+        argv.addAll(Arrays.asList("-O", out.toString(),
+                "--sequence-dictionary", dictionary.toString()));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            new PrintSVEvidence().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+            return;
+        }
+        if (Files.exists(out)) {
+            System.out.printf("merged\t%s=%s%n", label,
+                    ReferenceQueryDump.escape(masked(Files.readString(out), dir)));
+        }
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Several SV evidence files merged into one. It sits on `MultiFeatureWalker`, already measured (#825), so what is measured here is the two things above it: which samples the output declares, and what the sort merger does when two files speak about the same bin.

## Merging is only ever a widening

Every record is rewritten against the union of the inputs' sample lists, `extractSamples` filling a column its own file does not have with `-1`, and the merger fills only those. Two files that both report a sample at one bin are refused:

```
Multiple sources for count of sample#1 at chr1:1-100
```

The sample is named by **one-based** index and the bin by its **one-based** interval, while the file itself writes that bin as `0 100`.

## The sample list is alphabetical, not file order

It is accumulated into a `TreeSet`, so three files naming zulu, alpha and mike produce the columns `alpha mike zulu`. The output's header is the header of no input.

`--sample-names` subsets and reorders those columns, and a name no file knows becomes a column of `-1` rather than a refusal.

## One of the tool's own messages is unreachable from the extension that looks like its cause

An output named `.vcf` fails earlier, inside `FeatureOutputCodecFinder`:

```
No feature output codec found for <dir>/merged.vcf
```

so `this tool requires an SVFeature subtype` is reachable only from an extension whose codec produces a **non-SV** feature, not from one with no codec at all. That claim was written the other way round before the measurement.

Nine runs, `golden-pending`. The golden comes from the runner.

Part of #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)