### PR TITLE
Measure PrintReadCounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,10 @@ jobs:
             index: "45/45"
             slug: "merge-mutect2-mc3-downsample-by-duplicate-set-print-sv-evidence"
             suites: "merge-mutect2-mc3 downsample-by-duplicate-set print-sv-evidence"
+          - group: golden-pending
+            index: "1/1"
+            slug: "print-read-counts"
+            suites: "print-read-counts"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 134 | 43.1% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 165 | 53.1% |
+| not started | 164 | 52.7% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (86 of 190 started)
+## gatk-origin tools (87 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -154,6 +154,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `PrintBGZFBlockInformation` | unclassified | oracle-backed | print-bgzf-block-information | 1 | not measured |
 | `PrintDistantMates` | record-transform | oracle-backed | print-distant-mates | 1 | not measured |
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |
+| `PrintReadCounts` | sv-caller | golden-pending | print-read-counts | 1 | not measured |
 | `PrintReads` | record-transform | oracle-backed | printreads | 1 | not measured |
 | `PrintReadsHeader` | record-transform | oracle-backed | print-reads-header | 1 | not measured |
 | `PrintSVEvidence` | unclassified | oracle-backed | print-sv-evidence | 1 | not measured |
@@ -176,9 +177,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>104 not started</summary>
+<details><summary>103 not started</summary>
 
-`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectF1R2Counts`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadCounts`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `SplitCRAM`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectF1R2Counts`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `SplitCRAM`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5281,6 +5281,26 @@
           "why": "Nine runs over DepthEvidence files: two files naming different samples over the same bins, the same two subset to one sample, to a sample neither knows and reordered, two files naming the SAME sample at one bin, two files whose bins are disjoint, three files whose sample names are not in alphabetical order, an output whose extension implies another SV feature type, and one whose extension implies no feature type at all. Every run is handed a dictionary, since a .rd.txt header carries sample names and a null dictionary. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32631951385, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "print-read-counts",
+      "status": "golden-pending",
+      "title": "depth evidence rewritten as one counts file per sample",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "PrintReadCounts"
+      ],
+      "why": "ONE OUTPUT FILE PER SAMPLE, named by RAW CONCATENATION of outputPrefix, the sample name and '.counts.tsv', so a prefix that does not end in a separator glues onto the sample name. AN .rd.txt HEADER CARRIES SAMPLE NAMES BUT A NULL DICTIONARY, so the run needs --sequence-dictionary and refuses without one, with a message that misspells the argument: 'Supply one with --sequence-dictonary.'. THE OUTPUT IS ONE-BASED WHERE THE INPUT IS ZERO-BASED, the codec adding one to the start on read and the tool writing getStart() rather than re-encoding, so a bin written 0 100 comes back 1 100. THE OUTPUT HEADER IS BUILT, NOT COPIED: a fresh SAMFileHeader over the dictionary plus one read group whose ID is always GATKCopyNumber and whose SM is the sample, then the column line CONTIG START END COUNT, so a .counts.tsv input loses its @PG, its @CO and its read group's own ID, and the dictionary used is its own rather than the one --sequence-dictionary names. A .counts.tsv NAMES ITS SAMPLE THROUGH ITS READ GROUPS, and that refusal happens while the feature reader parses the header, so it reaches the caller WRAPPED TWICE, a GATKException 'Error initializing feature reader for path' over a TribbleException.MalformedFeatureFile 'Unable to parse header with error'. A READ GROUP WITH NO SM NEVER PRODUCES readSampleName's 'does not contain a sample name': the distinct list holds one null, which passes the emptiness test, and the refusal comes later from Utils.nonEmpty as 'The string is null', so that message is unreachable from a header that has read groups at all. --output-file-list WRITES <sample> TAB <filename> WITH THE SAME CONCATENATED NAME. A DUPLICATED COLUMN NAME IN AN .rd.txt HEADER IS NOT REFUSED: two writers open the same path, the list names it twice, and one file survives carrying the second writer's counts. A RECORD WITH FEWER COUNTS THAN THE HEADER HAS SAMPLES IS AN ArrayIndexOutOfBoundsException rather than a UserException, and one with more counts silently drops the extra. WHAT THAT CRASH LEAVES BEHIND IS HALF A HEADER, SAMTextHeaderCodec flushing as it encodes while the tool's own column line dies in the BufferedWriter. -L SUBSETS THE RECORDS BUT NOT THE FILES. AND ANY OTHER FEATURE TYPE IS REFUSED BY FeatureWalker BEFORE THE TOOL RUNS.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "PrintReadCountsDump",
+          "golden": null,
+          "why": "Thirteen runs: two samples over three bins, the same input with no dictionary, a prefix with no trailing separator, a single sample, the same column name twice, a record with fewer counts than samples and one with more, an interval that keeps one contig, a counts file round trip whose header carries an @RG of another ID plus @PG and @CO, a counts file with two disagreeing read groups, one with a read group naming no sample, one whose column header precedes its SAM header, and a BAF evidence file. Every output file is printed whole, so the built header, the one-based coordinates and the half-written header a crash leaves behind are all in the golden. Golden pending: to be produced by the pinned oracle container on an x86-64 CI runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/PrintReadCountsDump.java
+++ b/tools/readfilter-conformance/PrintReadCountsDump.java
@@ -1,0 +1,235 @@
+/*
+ * PrintReadCounts's output, taken from the reference.
+ *
+ * A depth-evidence file (.rd.txt), or a counts file (.counts.tsv), rewritten as one counts file per
+ * sample for the CNV callers. It is a `FeatureWalker`, and the two inputs it accepts arrive with two
+ * different kinds of header, which is where nearly everything measurable lives.
+ *
+ * Twelve behaviours this is built to catch.
+ *
+ *   - ONE OUTPUT FILE PER SAMPLE, named by RAW CONCATENATION: `outputPrefix + sampleName +
+ *     ".counts.tsv"`, so a prefix that does not end in a separator glues onto the sample name;
+ *   - AN .rd.txt HEADER CARRIES SAMPLE NAMES BUT A NULL DICTIONARY, so the run needs
+ *     --sequence-dictionary and refuses without one, with a message that misspells the argument:
+ *     "No dictionary available.  Supply one with --sequence-dictonary.";
+ *   - THE OUTPUT IS ONE-BASED WHERE THE INPUT IS ZERO-BASED: the codec adds one to the start on
+ *     read and the tool writes `getStart()` rather than re-encoding, so a bin written `0 100`
+ *     comes back `1 100`;
+ *   - THE OUTPUT HEADER IS BUILT, NOT COPIED: a fresh SAMFileHeader over the dictionary plus one
+ *     read group whose ID is always GATKCopyNumber and whose SM is the sample, then the column line
+ *     CONTIG START END COUNT;
+ *   - SO A .counts.tsv INPUT LOSES EVERYTHING ELSE ITS HEADER CARRIED, its @PG, its @CO and its
+ *     read group's own ID among them, while its records pass through unchanged and the dictionary
+ *     used is its own rather than the one --sequence-dictionary names;
+ *   - A .counts.tsv NAMES ITS SAMPLE THROUGH ITS READ GROUPS, and the refusal happens while the
+ *     feature reader parses the header, so it reaches the caller WRAPPED TWICE, as a GATKException
+ *     "Error initializing feature reader for path ..." over a TribbleException.MalformedFeatureFile
+ *     "Unable to parse header with error: ..., for input source: ...";
+ *   - AND A READ GROUP WITH NO SM DOES NOT PRODUCE readSampleName's "does not contain a sample
+ *     name": the distinct list holds one null, which passes the emptiness test, and the refusal
+ *     comes later from Utils.nonEmpty as "The string is null: string must not be null or empty",
+ *     so that message is unreachable from a header that has read groups at all;
+ *   - --output-file-list WRITES <sample>\t<filename> WITH THE SAME CONCATENATED NAME, and is closed
+ *     before a single record is written;
+ *   - A DUPLICATED COLUMN NAME IN AN .rd.txt HEADER IS NOT REFUSED: two writers open the same path,
+ *     the list names it twice, and one file survives carrying the second writer's counts;
+ *   - A RECORD WITH FEWER COUNTS THAN THE HEADER HAS SAMPLES IS AN ArrayIndexOutOfBoundsException
+ *     rather than a UserException, and one with more counts silently drops the extra;
+ *   - WHAT THAT CRASH LEAVES BEHIND IS HALF A HEADER: SAMTextHeaderCodec flushes as it encodes, so
+ *     the @HD, @SQ and @RG lines are on disk, while the tool's own column line is still in the
+ *     BufferedWriter and dies with it;
+ *   - -L SUBSETS THE RECORDS BUT NOT THE FILES, every sample still getting one;
+ *   - AND ANY OTHER FEATURE TYPE IS REFUSED BY FeatureWalker BEFORE THE TOOL RUNS, with
+ *     "contains features of the wrong type".
+ *
+ * Output:
+ *
+ *     input\t<label>\t<name>=<the whole file, escaped>
+ *     out\t<label>\t<file name>=<the whole file, escaped>
+ *     list\t<label>=<the whole output file list, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: PrintReadCountsDump
+ */
+
+import org.broadinstitute.hellbender.tools.IndexFeatureFile;
+import org.broadinstitute.hellbender.tools.sv.PrintReadCounts;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class PrintReadCountsDump {
+
+    /** One depth bin, written zero-based and half-open as an .rd.txt holds it. */
+    static String bin(final String contig, final int start, final int end, final int... counts) {
+        final StringBuilder line = new StringBuilder(contig + "\t" + start + "\t" + end);
+        for (final int count : counts) {
+            line.append('\t').append(count);
+        }
+        return line.append('\n').toString();
+    }
+
+    static String rdHeader(final String... samples) {
+        return "#Chr\tStart\tEnd\t" + String.join("\t", samples) + "\n";
+    }
+
+    /** One count, written one-based and closed as a .counts.tsv holds it. */
+    static String count(final String contig, final int start, final int end, final int count) {
+        return contig + "\t" + start + "\t" + end + "\t" + count + "\n";
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("print-read-counts-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# PrintReadCountsDump: depth evidence rewritten as one counts file per sample");
+
+        final Path dict = MultiFeatureWalkerDump.writeDictionary(dir, "counts", List.of("chr1", "chr2"));
+        final String samHeader = Files.readString(dict);
+
+        // Two samples over two bins, which is the shape the tool is for.
+        final String twoSamples = rdHeader("alpha", "beta")
+                + bin("chr1", 0, 100, 11, 21)
+                + bin("chr1", 100, 200, 12, 22)
+                + bin("chr2", 0, 100, 13, 23);
+        run(dir, "rd-two-samples", "rd.txt", twoSamples, dict, true);
+
+        // The same input with no dictionary at all, which an .rd.txt header cannot supply.
+        run(dir, "rd-no-dictionary", "rd.txt", twoSamples, null, false);
+
+        // A prefix that does not end in a separator, which is concatenated raw.
+        runPrefixed(dir, "rd-glued-prefix", "rd.txt", twoSamples, dict, "sample-", false);
+
+        // One sample, to show the smallest output whole.
+        run(dir, "rd-one-sample", "rd.txt",
+                rdHeader("solo") + bin("chr1", 0, 100, 7), dict, false);
+
+        // The same column name twice: two writers, one path.
+        run(dir, "rd-duplicate-sample", "rd.txt",
+                rdHeader("twin", "twin") + bin("chr1", 0, 100, 11, 22), dict, true);
+
+        // A record with fewer counts than the header has samples, and one with more.
+        run(dir, "rd-short-record", "rd.txt",
+                rdHeader("alpha", "beta") + bin("chr1", 0, 100, 11), dict, false);
+        run(dir, "rd-long-record", "rd.txt",
+                rdHeader("alpha") + bin("chr1", 0, 100, 11, 99), dict, false);
+
+        // Intervals, which drop records but never files.
+        runIntervals(dir, "rd-intervals", "rd.txt", twoSamples, dict, "chr2");
+
+        // A counts file, whose header names its own sample and its own dictionary, and whose
+        // records are already one-based.
+        final String countsIn = samHeader
+                + "@RG\tID:not-the-cnv-id\tSM:gamma\n"
+                + "@PG\tID:something\tPN:something\n"
+                + "@CO\ta comment the output will not carry\n"
+                + "CONTIG\tSTART\tEND\tCOUNT\n"
+                + count("chr1", 1, 100, 31)
+                + count("chr1", 101, 200, 32);
+        run(dir, "counts-round-trip", "counts.tsv", countsIn, dict, true);
+
+        // Two read groups naming two samples, and a read group naming none.
+        run(dir, "counts-two-samples", "counts.tsv",
+                samHeader + "@RG\tID:one\tSM:gamma\n@RG\tID:two\tSM:delta\n"
+                        + "CONTIG\tSTART\tEND\tCOUNT\n" + count("chr1", 1, 100, 31),
+                dict, false);
+        run(dir, "counts-no-sample", "counts.tsv",
+                samHeader + "@RG\tID:one\n" + "CONTIG\tSTART\tEND\tCOUNT\n" + count("chr1", 1, 100, 31),
+                dict, false);
+
+        // A counts file whose header does not come first.
+        run(dir, "counts-header-late", "counts.tsv",
+                "CONTIG\tSTART\tEND\tCOUNT\n" + samHeader + count("chr1", 1, 100, 31), dict, false);
+
+        // Another SV feature type entirely, which never reaches the tool.
+        run(dir, "wrong-feature-type", "baf.txt",
+                "chr1\t100\t0.50\talpha\n", dict, false);
+    }
+
+    static void run(final Path dir, final String label, final String extension, final String text,
+                    final Path dictionary, final boolean withList) throws Exception {
+        runPrefixed(dir, label, extension, text, dictionary, "", withList);
+    }
+
+    static void runPrefixed(final Path dir, final String label, final String extension,
+                            final String text, final Path dictionary, final String namePrefix,
+                            final boolean withList) throws Exception {
+        execute(dir, label, extension, text, dictionary, namePrefix, withList, new String[0]);
+    }
+
+    static void runIntervals(final Path dir, final String label, final String extension,
+                             final String text, final Path dictionary, final String interval)
+            throws Exception {
+        execute(dir, label, extension, text, dictionary, "", false, new String[] {"-L", interval});
+    }
+
+    static void execute(final Path dir, final String label, final String extension,
+                        final String text, final Path dictionary, final String namePrefix,
+                        final boolean withList, final String[] extra) throws Exception {
+        final Path work = dir.resolve(label);
+        Files.createDirectories(work);
+        final Path input = work.resolve("input." + extension);
+        Files.writeString(input, text, StandardCharsets.UTF_8);
+        try {
+            new IndexFeatureFile().instanceMain(new String[] {"-I", input.toString()});
+        } catch (final Exception e) {
+            System.out.printf("index\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+        }
+        System.out.printf("input\t%s\tinput.%s=%s%n", label, extension,
+                ReferenceQueryDump.escape(masked(text, dir)));
+
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "--input-counts", input.toString(),
+                "--output-prefix", work.toString() + "/" + namePrefix));
+        if (dictionary != null) {
+            argv.addAll(Arrays.asList("--sequence-dictionary", dictionary.toString()));
+        }
+        final Path list = work.resolve("outputs.list");
+        if (withList) {
+            argv.addAll(Arrays.asList("--output-file-list", list.toString()));
+        }
+        argv.addAll(Arrays.asList(extra));
+
+        Exception failure = null;
+        try {
+            new PrintReadCounts().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception e) {
+            failure = e;
+        }
+        if (failure != null) {
+            System.out.printf("error\t%s\t%s:%s%n", label, failure.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(failure.getMessage()), dir)));
+            for (Throwable cause = failure.getCause(); cause != null; cause = cause.getCause()) {
+                System.out.printf("cause\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                        ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            }
+        }
+        try (final Stream<Path> written = Files.list(work)) {
+            final List<Path> counts = written
+                    .filter(p -> p.getFileName().toString().endsWith(".counts.tsv"))
+                    .filter(p -> !p.equals(input))
+                    .sorted(Comparator.comparing(p -> p.getFileName().toString()))
+                    .toList();
+            for (final Path path : counts) {
+                System.out.printf("out\t%s\t%s=%s%n", label, path.getFileName(),
+                        ReferenceQueryDump.escape(masked(Files.readString(path), dir)));
+            }
+        }
+        if (Files.exists(list)) {
+            System.out.printf("list\t%s=%s%n", label,
+                    ReferenceQueryDump.escape(masked(Files.readString(list), dir)));
+        }
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
A depth-evidence file (`.rd.txt`), or a counts file (`.counts.tsv`), rewritten as one counts file per sample for the CNV callers. It is a `FeatureWalker` over two accepted feature types, and the two arrive with two different kinds of header, which is where nearly everything measurable lives.

Thirteen runs, and the whole of every output file in the golden.

An `.rd.txt` header carries sample names and a null dictionary, so the run needs `--sequence-dictionary` and refuses without one, through a message that misspells the argument it asks for. The output is one-based where the input is zero-based: the codec adds one to the start on read and the tool writes `getStart()` rather than re-encoding, so a bin written `0 100` comes back `1 100`. The output header is built rather than copied, a fresh `SAMFileHeader` over the dictionary plus one read group whose ID is always `GATKCopyNumber`, so a counts file fed back in loses its `@PG`, its `@CO` and its read group's own ID while its records pass through untouched.

Three findings the reading did not give.

A read group with no `SM` never produces `readSampleName`'s "does not contain a sample name": the distinct list holds one null, which passes the emptiness test, and the refusal comes later from `Utils.nonEmpty` as "The string is null". That message is unreachable from any header that has read groups at all. Both header refusals also reach the caller wrapped twice, a `GATKException` over a `TribbleException.MalformedFeatureFile`, because the parse happens inside the feature reader rather than in the tool.

A duplicated column name is not refused: two writers open the same path, the output file list names it twice, and one file survives carrying the second writer's counts.

And a record with fewer counts than the header has samples is an `ArrayIndexOutOfBoundsException` that leaves half a header behind: `SAMTextHeaderCodec` flushes as it encodes, so `@HD`, `@SQ` and `@RG` are on disk while the tool's own column line is still in the `BufferedWriter` and dies with it.

Golden pending: to be produced by the pinned oracle container on an x86-64 runner, then landed by the follow-up commit.

Part of #602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)