### PR TITLE
Measure SplitCRAM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,10 @@ jobs:
             index: "45/45"
             slug: "merge-mutect2-mc3-downsample-by-duplicate-set-print-sv-evidence-print-read-counts"
             suites: "merge-mutect2-mc3 downsample-by-duplicate-set print-sv-evidence print-read-counts"
+          - group: golden-pending
+            index: "1/1"
+            slug: "split-cram"
+            suites: "split-cram"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 135 | 43.4% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 164 | 52.7% |
+| not started | 163 | 52.4% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (87 of 190 started)
+## gatk-origin tools (88 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -165,6 +165,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `SelectVariants` | variant-transform | oracle-backed | select-variants-concordance, select-variants-filters, select-variants-output, select-variants-samples, select-variants-subset | 5 | not measured |
 | `ShiftFasta` | reference-utility | oracle-backed | shift-fasta | 1 | not measured |
 | `SiteDepthtoBAF` | sv-caller | oracle-backed | site-depth-to-baf | 1 | not measured |
+| `SplitCRAM` | unclassified | golden-pending | split-cram | 1 | not measured |
 | `SplitIntervals` | interval-utility | oracle-backed | split-intervals | 1 | not measured |
 | `SplitNCigarReads` | record-transform | oracle-backed | split-n-cigar-reads | 1 | not measured |
 | `SplitReads` | record-transform | oracle-backed | split-reads | 1 | not measured |
@@ -177,9 +178,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>103 not started</summary>
+<details><summary>102 not started</summary>
 
-`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectF1R2Counts`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `SplitCRAM`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectF1R2Counts`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5301,6 +5301,26 @@
           "why": "Thirteen runs: two samples over three bins, the same input with no dictionary, a prefix with no trailing separator, a single sample, the same column name twice, a record with fewer counts than samples and one with more, an interval that keeps one contig, a counts file round trip whose header carries an @RG of another ID plus @PG and @CO, a counts file with two disagreeing read groups, one with a read group naming no sample, one whose column header precedes its SAM header, and a BAF evidence file. Every output file is printed whole, so the built header, the one-based coordinates and the half-written header a crash leaves behind are all in the golden. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32635137166, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "split-cram",
+      "status": "golden-pending",
+      "title": "a CRAM cut into shards at container boundaries",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "SplitCRAM"
+      ],
+      "why": "THE CUT IS AT A CONTAINER BOUNDARY AND THE THRESHOLD IS A MINIMUM, NOT A MAXIMUM: the inner loop tests records < shardRecords BEFORE reading a container and adds its whole record count after, so a shard overshoots by up to one container. The test being strict, a threshold exactly the size of a container still gives one container per shard, and one above it gives two. EVERY SHARD IS A WHOLE CRAM, the CRAM header, a SAM header container and an EOF container written around each group, so a shard reads on its own and every shard repeats the input's header. THE OUTPUT NAME IS String.format ON A TEMPLATE with a counter that starts at zero. A TEMPLATE WITH NO %d IS REFUSED IN onStartup by an IllegalArgumentException rather than a UserException, against the pattern %[0-9]*d, so %04d passes and %-4d does not. --shard-max-output-count DOES NOT LIMIT ANYTHING ABOVE ONE: the counter it is compared with is declared inside the outer loop, reset to zero for every shard and therefore always one when tested, so only the value 1 ever stops the run and 2 and 3 leave all five shards standing. AND AN EMPTY CRAM PRODUCES NO SHARD AT ALL.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "SplitCRAMDump",
+          "golden": null,
+          "why": "Eleven runs over one CRAM of four contigs plus unmapped reads, written three reads to a slice and one slice to a container so that it holds five containers of three: a threshold of one, one exactly the size of a container, one above it, one no shard reaches, the maximum output count at one, two and three, a padded template, a template whose width carries a flag, a template with no formatter at all, and an empty CRAM. Each shard is reported by the record count of every container it holds and by the read names it gives back when read, so both where the cut fell and that the shard is a whole CRAM are in the golden. Golden pending: to be produced by the pinned oracle container on an x86-64 CI runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/SplitCRAMDump.java
+++ b/tools/readfilter-conformance/SplitCRAMDump.java
@@ -1,0 +1,228 @@
+/*
+ * SplitCRAM's output, taken from the reference.
+ *
+ * A CRAM cut into shards at container boundaries, without decoding a single record. The tool reads
+ * containers, counts the records each one declares, and starts a new output once the count reaches
+ * the threshold, so what is measurable is where the cuts fall and what the outputs are called.
+ *
+ * Six behaviours this is built to catch.
+ *
+ *   - THE CUT IS AT A CONTAINER BOUNDARY AND THE THRESHOLD IS A MINIMUM, NOT A MAXIMUM: the inner
+ *     loop tests `records < shardRecords` BEFORE reading a container and adds its whole record
+ *     count after, so a shard overshoots by up to one container. The test being strict, a threshold
+ *     exactly the size of a container still gives one container per shard, and one above it gives
+ *     two;
+ *   - EVERY SHARD IS A WHOLE CRAM: the CRAM header, a SAM header container and an EOF container are
+ *     written around each group, so a shard is readable on its own and every shard repeats the
+ *     input's header;
+ *   - THE OUTPUT NAME IS String.format ON A TEMPLATE, with a counter that starts at zero and is
+ *     incremented whether or not the shard turns out to be written;
+ *   - A TEMPLATE WITH NO %d IS REFUSED IN onStartup, by an IllegalArgumentException rather than a
+ *     UserException, and the pattern it is checked against is `%[0-9]*d`, so `%04d` passes and a
+ *     width with a flag such as `%-4d` does not;
+ *   - --shard-max-output-count DOES NOT LIMIT ANYTHING ABOVE ONE: the counter it is compared with
+ *     is declared inside the outer loop, so it is reset to zero for every shard and is always one
+ *     when tested, and only the value 1 ever stops the run;
+ *   - AND AN EMPTY CRAM PRODUCES NO SHARD AT ALL, the outer loop never running.
+ *
+ * Output:
+ *
+ *     fixture\t<label>\tcontainers=<records per container, comma separated>
+ *     shard\t<label>\t<file name>\trecords=<n>\tnames=<read names, comma separated>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: SplitCRAMDump
+ */
+
+import htsjdk.samtools.CRAMContainerStreamWriter;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.ValidationStringency;
+import htsjdk.samtools.cram.build.CramContainerIterator;
+import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.cram.structure.CRAMEncodingStrategy;
+import htsjdk.samtools.cram.structure.Container;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+import org.broadinstitute.hellbender.tools.SplitCRAM;
+
+import java.io.BufferedInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class SplitCRAMDump {
+
+    public static void main(final String[] args) throws Exception {
+        BlockCompressedOutputStream.setDefaultDeflaterFactory(new DeflaterFactory());
+
+        final Path dir = Path.of("split-cram-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# SplitCRAMDump: a CRAM cut into shards at container boundaries");
+
+        // Four contigs, so the CRAM writer closes a container at every reference change and the
+        // input has containers small enough to shard.
+        final Path dict = MultiFeatureWalkerDump.writeDictionary(dir, "split",
+                List.of("chr1", "chr2", "chr3", "chr4"));
+        final Path fasta = dir.resolve("split.fasta");
+        final Path cram = dir.resolve("reads.cram");
+        writeCram(cram, fasta, dict);
+        System.out.printf("fixture\tinput\tcontainers=%s%n", containerRecords(cram));
+
+        // One container per shard, which is what a threshold of one gives.
+        run(dir, "one-per-shard", cram, fasta, "shard_%d.cram", "--shard-records", "1");
+        // A threshold exactly the size of a container, which is still one container per shard:
+        // the test is strict, and a container that reaches the threshold ends the shard.
+        run(dir, "exact-threshold", cram, fasta, "exact_%d.cram", "--shard-records", "3");
+        // A threshold one above it, which the first container does not reach, so the shard takes a
+        // second and overshoots.
+        run(dir, "overshoot", cram, fasta, "pair_%d.cram", "--shard-records", "4");
+        // A threshold no shard reaches, which is one shard holding everything.
+        run(dir, "one-shard", cram, fasta, "all_%d.cram", "--shard-records", "1000");
+        // The maximum output count, at every value that could stop the run.
+        run(dir, "max-one", cram, fasta, "max1_%d.cram",
+                "--shard-records", "1", "--shard-max-output-count", "1");
+        run(dir, "max-two", cram, fasta, "max2_%d.cram",
+                "--shard-records", "1", "--shard-max-output-count", "2");
+        run(dir, "max-three", cram, fasta, "max3_%d.cram",
+                "--shard-records", "1", "--shard-max-output-count", "3");
+        // A padded template, which the pattern accepts, and two it does not.
+        run(dir, "padded-template", cram, fasta, "padded_%04d.cram", "--shard-records", "1000");
+        run(dir, "flagged-template", cram, fasta, "flagged_%-4d.cram", "--shard-records", "1000");
+        run(dir, "no-formatter", cram, fasta, "plain.cram", "--shard-records", "1000");
+
+        // A CRAM with no records at all, whose outer loop never runs.
+        final Path empty = dir.resolve("empty.cram");
+        writeEmptyCram(empty, fasta, dict);
+        System.out.printf("fixture\tempty\tcontainers=%s%n", containerRecords(empty));
+        run(dir, "empty-input", empty, fasta, "empty_%d.cram", "--shard-records", "1");
+    }
+
+    /** The record count each container of a CRAM declares, which is what the tool counts with. */
+    static String containerRecords(final Path cram) throws Exception {
+        final List<String> counts = new ArrayList<>();
+        try (final CramContainerIterator containers =
+                     new CramContainerIterator(new BufferedInputStream(Files.newInputStream(cram)))) {
+            while (containers.hasNext()) {
+                final Container container = containers.next();
+                counts.add(Integer.toString(container.getContainerHeader().getNumberOfRecords()));
+            }
+        }
+        return String.join(",", counts);
+    }
+
+    /** Three reads on each of four contigs, plus three unmapped, coordinate sorted.
+     *
+     * Written through CRAMContainerStreamWriter with three reads to a slice and one slice to a
+     * container, because the default is ten thousand and one container would not be a fixture. */
+    static void writeCram(final Path cram, final Path fasta, final Path dict) throws Exception {
+        final SAMFileHeader header = readHeader(dict);
+        final CRAMEncodingStrategy strategy = new CRAMEncodingStrategy()
+                .setMinimumSingleReferenceSliceSize(1)
+                .setReadsPerSlice(3)
+                .setSlicesPerContainer(1);
+        try (final java.io.OutputStream out = Files.newOutputStream(cram)) {
+            final CRAMContainerStreamWriter writer = new CRAMContainerStreamWriter(strategy,
+                    new ReferenceSource(fasta), header, out, null, cram.getFileName().toString());
+            writer.writeHeader();
+            for (final String contig : List.of("chr1", "chr2", "chr3", "chr4")) {
+                for (int index = 0; index < 3; index++) {
+                    writer.writeAlignment(read(header, contig + "-" + index, contig, 1 + index * 10));
+                }
+            }
+            for (int index = 0; index < 3; index++) {
+                writer.writeAlignment(read(header, "unmapped-" + index, null, 0));
+            }
+            writer.finish(true);
+        }
+    }
+
+    static void writeEmptyCram(final Path cram, final Path fasta, final Path dict) throws Exception {
+        final SAMFileHeader header = readHeader(dict);
+        try (final java.io.OutputStream out = Files.newOutputStream(cram)) {
+            final CRAMContainerStreamWriter writer = new CRAMContainerStreamWriter(
+                    new CRAMEncodingStrategy(), new ReferenceSource(fasta), header, out, null,
+                    cram.getFileName().toString());
+            writer.writeHeader();
+            writer.finish(true);
+        }
+    }
+
+    static SAMFileHeader readHeader(final Path dict) throws Exception {
+        try (final SamReader reader = SamReaderFactory.makeDefault()
+                .validationStringency(ValidationStringency.SILENT)
+                .open(dict.toFile())) {
+            final SAMFileHeader header = reader.getFileHeader();
+            header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+            return header;
+        }
+    }
+
+    static SAMRecord read(final SAMFileHeader header, final String name, final String contig,
+                          final int start) {
+        final SAMRecord record = new SAMRecord(header);
+        record.setReadName(name);
+        record.setReadBases("ACGTACGTAC".getBytes());
+        record.setBaseQualities(new byte[] {30, 30, 30, 30, 30, 30, 30, 30, 30, 30});
+        if (contig == null) {
+            record.setReadUnmappedFlag(true);
+        } else {
+            record.setReferenceName(contig);
+            record.setAlignmentStart(start);
+            record.setCigarString("10M");
+            record.setMappingQuality(60);
+        }
+        return record;
+    }
+
+    static void run(final Path dir, final String label, final Path cram, final Path fasta,
+                    final String template, final String... extra) throws Exception {
+        final Path work = dir.resolve(label);
+        Files.createDirectories(work);
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "-I", cram.toString(),
+                "-O", work.resolve(template).toString()));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            new SplitCRAM().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+        }
+        try (final Stream<Path> written = Files.list(work)) {
+            final List<Path> shards = written
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .toList();
+            for (final Path shard : shards) {
+                System.out.printf("shard\t%s\t%s\trecords=%s\tnames=%s%n", label,
+                        shard.getFileName(), containerRecords(shard), readNames(shard, fasta));
+            }
+        }
+    }
+
+    /** Every read name of a shard, in order, which says where the cut fell. */
+    static String readNames(final Path shard, final Path fasta) throws Exception {
+        final List<String> names = new ArrayList<>();
+        try (final SamReader reader = SamReaderFactory.makeDefault()
+                .referenceSequence(fasta)
+                .validationStringency(ValidationStringency.SILENT)
+                .open(shard.toFile())) {
+            for (final SAMRecord record : reader) {
+                names.add(record.getReadName());
+            }
+        }
+        return String.join(",", names);
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
A CRAM cut into shards at container boundaries, without a single record being decoded. The tool reads containers, counts the records each one declares and starts a new output once the count reaches a threshold, so what is measurable is where the cuts fall and what the outputs are called.

Eleven runs over one CRAM of four contigs plus unmapped reads, written through `CRAMContainerStreamWriter` with three reads to a slice and one slice to a container, because the default is ten thousand and the whole fixture would otherwise be one container and no fixture at all.

The threshold is a minimum, not a maximum: the inner loop tests `records < shardRecords` before reading a container and adds its whole record count after, so a shard overshoots by up to one container. The test being strict, a threshold of exactly three against containers of three still gives one container per shard, and a threshold of four gives two containers and six records. That is the correction the measurement made: reading the loop, a threshold a container reaches exactly looks like it should take a second one.

Every shard is a whole CRAM, header container and EOF container included, and reads back on its own, which is why the golden carries the read names of each.

`--shard-max-output-count` does not limit anything above one. The counter it is compared with is declared inside the outer loop, so it is reset to zero for every shard and is always one when tested: 1 stops the run after the first shard, and 2 and 3 leave all five standing.

A template with no `%d` is refused in `onStartup` by an `IllegalArgumentException` rather than a `UserException`, and the pattern is `%[0-9]*d`, so `%04d` passes and `%-4d` does not. An empty CRAM produces no shard at all.

Golden pending: to be produced by the pinned oracle container on an x86-64 runner, then landed by the follow-up commit.

Part of #791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)