### PR TITLE
Measure CollectF1R2Counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,10 @@ jobs:
             index: "45/45"
             slug: "merge-mutect2-mc3-downsample-by-duplicate-set-print-sv-evidence-print-read-counts-split-cram"
             suites: "merge-mutect2-mc3 downsample-by-duplicate-set print-sv-evidence print-read-counts split-cram"
+          - group: golden-pending
+            index: "1/1"
+            slug: "collect-f1r2-counts"
+            suites: "collect-f1r2-counts"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 136 | 43.7% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 163 | 52.4% |
+| not started | 162 | 52.1% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (88 of 190 started)
+## gatk-origin tools (89 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -105,6 +105,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CheckReferenceCompatibility` | reference-utility | oracle-backed | check-reference-compatibility | 1 | not measured |
 | `ClipReads` | record-transform | oracle-backed | clip-reads | 1 | not measured |
 | `CollectAllelicCounts` | locus-walker | oracle-backed | collect-allelic-counts | 1 | not measured |
+| `CollectF1R2Counts` | unclassified | golden-pending | collect-f1r2-counts | 1 | not measured |
 | `CollectReadCounts` | locus-walker | oracle-backed | collect-read-counts | 1 | not measured |
 | `CombineSegmentBreakpoints` | unclassified | oracle-backed | combine-segment-breakpoints | 1 | not measured |
 | `CompareBaseQualities` | reporting-walker | oracle-backed | compare-base-qualities | 1 | not measured |
@@ -178,9 +179,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>102 not started</summary>
+<details><summary>101 not started</summary>
 
-`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectF1R2Counts`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5321,6 +5321,26 @@
           "why": "Eleven runs over one CRAM of four contigs plus unmapped reads, written three reads to a slice and one slice to a container so that it holds five containers of three: a threshold of one, one exactly the size of a container, one above it, one no shard reaches, the maximum output count at one, two and three, a padded template, a template whose width carries a flag, a template with no formatter at all, and an empty CRAM. Each shard is reported by the record count of every container it holds and by the read names it gives back when read, so both where the cut fell and that the shard is a whole CRAM are in the golden. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32635845266, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "collect-f1r2-counts",
+      "status": "golden-pending",
+      "title": "the F1R2 counts the orientation-bias filter is trained on",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "CollectF1R2Counts"
+      ],
+      "why": "A SITE GOES TO ONE OF THREE PLACES: a reference site increments a depth histogram, an alt site with exactly one alt read increments a depth-one histogram keyed by context, alt base and orientation, and any other alt site becomes a row of the alt table. THE ALT BASE IS maxElementIndex OVER THE BASE COUNTS WITH THE REFERENCE SET TO -1, so a tie between two alt bases goes to the lower base index, and THE ALT TABLE'S DEPTH COLUMN IS refCount + altCount RATHER THAN THE PILEUP'S DEPTH, so that tied site reports four over a pileup of six and the second alt base counts nowhere. ORIENTATION IS isReverseStrand() != isFirstOfPair(), which for an UNPAIRED read makes a forward read F2R1 and a reverse read F1R2. THE BASE QUALITY TEST IS STRICT: a base at exactly --f1r2-min-bq is excluded from the pileup, so a lone alt base at that quality leaves a reference site behind and one below it turns the same site into a depth-one alt. THE SITE IS SKIPPED WHOLE when its median mapping quality is below --f1r2-median-mq, when more than a hundredth of the pileup is indel, or when the three-base context runs off the reference or holds an N. AND WHEN IT IS SKIPPED FOR ONE SAMPLE IT IS SKIPPED FOR EVERY SAMPLE AFTER IT: the loop over the split pileup RETURNS rather than continuing, and so do the reference-site and one-alt-read branches, so at any site only the samples up to the first one that returns are counted, in the order the split map hands them over, which is a HashMap order over the sample names and not the header's. Over alpha and bravo it is bravo first, and every one of alpha's alt sites is lost because bravo is reference at each of them. DEPTH IS CAPPED AT --f1r2-max-depth before it is counted. EVERY ONE OF THE 64 CONTEXTS IS PRESENT WHETHER OR NOT IT WAS SEEN. THE OUTPUT IS A TAR.GZ of one alt table, one reference histogram and one alt histogram per sample. AND THE ORDER OF THE REFERENCE HISTOGRAMS IS A HashMap ORDER OVER THE 64 CONTEXT STRINGS, which is reproducible, while the alt histograms are keyed by a pair holding an ENUM whose hashCode is an identity hash, so their order is not reproducible at all and the golden carries that file with its columns sorted.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "CollectF1R2CountsDump",
+          "golden": null,
+          "why": "Five runs over a BAM of four read blocks against a forty-base motif repeated: one sample where every branch is reachable, the same reads under two samples where the returns stop the loop, a depth cap low enough to be reached, a median mapping quality low enough to let the low-quality block through, and a base quality one below the default. Each run is reported by every file of its tar.gz, whole, the alt histogram with its columns sorted because their order is an identity hash order and is not reproducible. Golden pending: to be produced by the pinned oracle container on an x86-64 CI runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/CollectF1R2CountsDump.java
+++ b/tools/readfilter-conformance/CollectF1R2CountsDump.java
@@ -1,0 +1,345 @@
+/*
+ * CollectF1R2Counts's output, taken from the reference.
+ *
+ * The counts Mutect2's orientation-bias filter is trained on: for every three-base reference
+ * context, how deep the reference sites were, and what the alt sites looked like. The traversal is
+ * a LocusWalker; what is measured here is F1R2CountsCollector, which decides which pileups count
+ * at all and which of three places a site is written to.
+ *
+ * Eleven behaviours this is built to catch.
+ *
+ *   - A SITE GOES TO ONE OF THREE PLACES: a reference site increments a depth histogram, an alt
+ *     site with exactly one alt read increments a depth-one histogram keyed by context, alt base
+ *     and orientation, and any other alt site becomes a row of the alt table;
+ *   - THE ALT BASE IS maxElementIndex OVER THE BASE COUNTS WITH THE REFERENCE SET TO -1, so a tie
+ *     between two alt bases goes to the lower base index and a site with no alt read at all reads
+ *     as a reference site;
+ *   - AND THE ALT TABLE'S DEPTH COLUMN IS refCount + altCount, NOT THE PILEUP'S DEPTH, so that
+ *     tied site reports four over a pileup of six, the second alt base counting nowhere;
+ *   - ORIENTATION IS isReverseStrand() != isFirstOfPair(), which for an UNPAIRED read makes a
+ *     forward read F2R1 and a reverse read F1R2;
+ *   - THE BASE QUALITY TEST IS STRICT: a base at exactly --f1r2-min-bq is excluded from the
+ *     pileup, so a lone alt base at that quality leaves a reference site behind, and one below it
+ *     turns the same site into a depth-one alt;
+ *   - THE SITE IS SKIPPED WHOLE when its median mapping quality is below --f1r2-median-mq, when
+ *     more than a hundredth of the pileup is indel, or when the three-base context runs off the
+ *     reference or contains an N;
+ *   - AND WHEN IT IS SKIPPED FOR ONE SAMPLE IT IS SKIPPED FOR EVERY SAMPLE AFTER IT: the loop over
+ *     the split pileup RETURNS rather than continuing, and so do the reference-site and
+ *     one-alt-read branches, so at any site only the samples up to the first one that returns are
+ *     ever counted, in the order the split map hands them over. That order is a HashMap order over
+ *     the sample names and not the header's: over alpha and bravo it is bravo first, and every one
+ *     of alpha's alt sites is lost because bravo is reference at each of them;
+ *   - DEPTH IS CAPPED AT --f1r2-max-depth before it is counted, and the histograms are prefilled
+ *     with every bin from one to that depth;
+ *   - EVERY CONTEXT IS PRESENT WHETHER OR NOT IT WAS SEEN, all 64 of them, so the shape of the
+ *     output does not depend on the data;
+ *   - THE OUTPUT IS A TAR.GZ of one alt table, one reference histogram and one alt histogram per
+ *     sample, named by the URL-encoded sample name;
+ *   - AND THE ORDER OF THE REFERENCE HISTOGRAMS IS A java.util.HashMap ORDER OVER THE 64 CONTEXT
+ *     STRINGS, which is reproducible, while the alt histograms are keyed by a pair holding an ENUM,
+ *     whose hashCode is an identity hash, so their order is not. The alt histogram file is
+ *     therefore reported here with its columns sorted, and the reference histogram as it is.
+ *
+ * Output:
+ *
+ *     tar\t<label>=<entry names, comma separated>
+ *     file\t<label>\t<name>=<the whole file, escaped>
+ *     sorted\t<label>\t<name>=<the whole file with its histogram columns sorted, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: CollectF1R2CountsDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.broadinstitute.hellbender.tools.walkers.readorientation.CollectF1R2Counts;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class CollectF1R2CountsDump {
+
+    static final int LENGTH = 200;
+    static final int READ_LENGTH = 30;
+
+    /**
+     * The reference: a forty-base motif repeated, which gives many different three-base contexts
+     * where a four-base cycle would give four, with one N to make a context that is skipped.
+     */
+    static final String MOTIF = "ACGTTGCAAGGCTTACCATGGACTTCAGATCCGTAACGGT";
+
+    static String reference() {
+        final StringBuilder bases = new StringBuilder();
+        for (int index = 0; index < LENGTH; index++) {
+            bases.append(index == 99 ? 'N' : MOTIF.charAt(index % MOTIF.length()));
+        }
+        return bases.toString();
+    }
+
+    static char refBase(final int oneBased) {
+        return reference().charAt(oneBased - 1);
+    }
+
+    /** The rank-th base of ACGT that is not the reference base, counted from zero. */
+    static char altBase(final int oneBased, final int rank) {
+        int seen = 0;
+        for (final char base : new char[] {'A', 'C', 'G', 'T'}) {
+            if (base != refBase(oneBased) && seen++ == rank) {
+                return base;
+            }
+        }
+        throw new IllegalStateException("unreachable");
+    }
+
+    public static void main(final String[] args) throws Exception {
+        BlockCompressedOutputStream.setDefaultDeflaterFactory(new DeflaterFactory());
+
+        final Path dir = Path.of("collect-f1r2-counts-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# CollectF1R2CountsDump: the F1R2 counts the orientation-bias filter is trained on");
+
+        final Path fasta = writeReference(dir);
+
+        // One sample, where every branch of the collector is reachable.
+        final Path single = dir.resolve("single.bam");
+        writeBam(single, List.of("alpha"), true);
+        run(dir, "single-sample", single, fasta, 4);
+
+        // The same reads under two samples, where the returns stop the loop.
+        final Path pair = dir.resolve("pair.bam");
+        writeBam(pair, List.of("alpha", "bravo"), true);
+        run(dir, "two-samples", pair, fasta, 4);
+
+        // A depth cap low enough to be reached, and one high enough not to be.
+        run(dir, "max-depth-two", single, fasta, 2);
+        // A median mapping quality low enough to let the low-quality block through.
+        run(dir, "low-median-mq", single, fasta, 4, "--f1r2-median-mq", "20");
+        // A base quality one below the default, which lets the excluded base back in.
+        run(dir, "min-bq-nineteen", single, fasta, 4, "--f1r2-min-bq", "19");
+    }
+
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("f1r2.fasta");
+        final StringBuilder text = new StringBuilder(">chr1\n");
+        final String bases = reference();
+        for (int index = 0; index < bases.length(); index += 50) {
+            text.append(bases, index, Math.min(index + 50, bases.length())).append('\n');
+        }
+        Files.writeString(fasta, text.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        new picard.sam.CreateSequenceDictionary().instanceMain(new String[] {
+                "R=" + fasta, "O=" + dir.resolve("f1r2.dict")});
+        System.out.printf("reference\tchr1=%s%n", bases);
+        return fasta;
+    }
+
+    /**
+     * Four blocks of reads, each thirty bases long and every one unpaired.
+     *
+     * The first block is where the counting happens: three forward and three reverse reads per
+     * sample, with alt bases planted at four offsets. The second spans the N. The third carries a
+     * mapping quality the default median test refuses. The fourth carries a deletion.
+     */
+    static void writeBam(final Path bam, final List<String> samples, final boolean index)
+            throws Exception {
+        final SAMFileHeader header = new SAMFileHeader(new SAMSequenceDictionary(
+                List.of(new SAMSequenceRecord("chr1", LENGTH))));
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        for (final String sample : samples) {
+            final SAMReadGroupRecord group = new SAMReadGroupRecord("rg-" + sample);
+            group.setSample(sample);
+            header.addReadGroup(group);
+        }
+        final List<SAMRecord> records = new ArrayList<>();
+        for (final String sample : samples) {
+            records.addAll(block(header, sample, 41, 60, false));
+            records.addAll(block(header, sample, 91, 60, false));
+            records.addAll(block(header, sample, 131, 30, false));
+            records.addAll(block(header, sample, 161, 60, true));
+        }
+        records.sort((left, right) -> Integer.compare(left.getAlignmentStart(), right.getAlignmentStart()));
+        try (final SAMFileWriter writer = new SAMFileWriterFactory().setCreateIndex(index)
+                .makeBAMWriter(header, true, bam)) {
+            records.forEach(writer::addAlignment);
+        }
+    }
+
+    /** Six reads over one window, three forward and three reverse. */
+    static List<SAMRecord> block(final SAMFileHeader header, final String sample, final int start,
+                                 final int mappingQuality, final boolean deletion) {
+        final List<SAMRecord> records = new ArrayList<>();
+        for (int index = 0; index < 6; index++) {
+            final boolean reverse = index >= 3;
+            final SAMRecord record = new SAMRecord(header);
+            record.setReadName(sample + "-" + start + "-" + index);
+            record.setReferenceName("chr1");
+            record.setAlignmentStart(start);
+            record.setMappingQuality(mappingQuality);
+            record.setReadNegativeStrandFlag(reverse);
+            record.setAttribute("RG", "rg-" + sample);
+            final StringBuilder bases = new StringBuilder();
+            final byte[] quals = new byte[READ_LENGTH];
+            Arrays.fill(quals, (byte) 40);
+            for (int offset = 0; offset < READ_LENGTH; offset++) {
+                final int locus = start + offset + (deletion && offset >= 10 ? 2 : 0);
+                char base = refBase(locus);
+                // The first block carries the plants; every other block is pure reference.
+                if (start == 41) {
+                    // Two alt reads of the first sample, which is an alt table row.
+                    if (offset == 3 && sample.equals("alpha") && index < 2) {
+                        base = altBase(locus, 0);
+                    }
+                    // One alt read, on the reverse strand, which is a depth-one histogram entry.
+                    if (offset == 6 && sample.equals("alpha") && index == 3) {
+                        base = altBase(locus, 0);
+                    }
+                    // Two alt reads of the SECOND sample, at a locus where the first sample is
+                    // reference and returns before this one is reached.
+                    if (offset == 9 && sample.equals("bravo") && index < 2) {
+                        base = altBase(locus, 0);
+                    }
+                    // One alt read whose base quality is exactly the default threshold.
+                    if (offset == 14 && sample.equals("alpha") && index == 0) {
+                        base = altBase(locus, 0);
+                        quals[offset] = 20;
+                    }
+                    // Two alt reads of one base and two of another, which is a tie that
+                    // maxElementIndex settles on the lower base index.
+                    if (offset == 19 && sample.equals("alpha")) {
+                        if (index < 2) {
+                            base = altBase(locus, 0);
+                        } else if (index < 4) {
+                            base = altBase(locus, 1);
+                        }
+                    }
+                }
+                bases.append(base);
+            }
+            record.setReadString(bases.toString());
+            record.setBaseQualities(quals);
+            record.setCigarString(deletion ? "10M2D18M" : READ_LENGTH + "M");
+            records.add(record);
+        }
+        return records;
+    }
+
+    static void run(final Path dir, final String label, final Path bam, final Path fasta,
+                    final int maxDepth, final String... extra) throws Exception {
+        final Path work = dir.resolve(label);
+        Files.createDirectories(work);
+        final Path out = work.resolve("counts.tar.gz");
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "-I", bam.toString(), "-R", fasta.toString(), "-O", out.toString(),
+                "--f1r2-max-depth", Integer.toString(maxDepth)));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            new CollectF1R2Counts().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+            return;
+        }
+        final Map<String, String> entries = untar(out);
+        System.out.printf("tar\t%s=%s%n", label, String.join(",", entries.keySet()));
+        for (final Map.Entry<String, String> entry : entries.entrySet()) {
+            final String name = entry.getKey();
+            if (name.endsWith(".alt_histogram")) {
+                // The column order of this one is an identity hash order, so it is not stable
+                // from run to run and only the sorted form can be a golden.
+                System.out.printf("sorted\t%s\t%s=%s%n", label, name,
+                        ReferenceQueryDump.escape(sortColumns(entry.getValue())));
+            } else {
+                System.out.printf("file\t%s\t%s=%s%n", label, name,
+                        ReferenceQueryDump.escape(masked(entry.getValue(), dir)));
+            }
+        }
+    }
+
+    /**
+     * Every entry of the tar.gz, keyed by name and reported in name order.
+     *
+     * The order inside the archive is File.listFiles over a temporary directory, which is the
+     * filesystem's and not the tool's, so it is not what this compares.
+     */
+    static Map<String, String> untar(final Path archive) throws Exception {
+        final Map<String, String> entries = new TreeMap<>();
+        try (final InputStream raw = Files.newInputStream(archive);
+             final TarArchiveInputStream tar =
+                     new TarArchiveInputStream(new GzipCompressorInputStream(raw))) {
+            TarArchiveEntry entry;
+            while ((entry = tar.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                tar.transferTo(bytes);
+                entries.put(entry.getName(), bytes.toString(StandardCharsets.UTF_8));
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * A metrics file whose histogram table has its columns put in order.
+     *
+     * The bin column stays first; the rest are sorted by name, and every row is reordered with the
+     * header. Everything outside the table is left alone.
+     */
+    static String sortColumns(final String metrics) {
+        final List<String> lines = new ArrayList<>(Arrays.asList(metrics.split("\n", -1)));
+        int header = -1;
+        for (int index = 0; index < lines.size(); index++) {
+            if (lines.get(index).startsWith("## HISTOGRAM")) {
+                header = index + 1;
+                break;
+            }
+        }
+        if (header < 0 || header >= lines.size()) {
+            return metrics;
+        }
+        final String[] columns = lines.get(header).split("\t", -1);
+        final Integer[] order = new Integer[columns.length - 1];
+        for (int index = 0; index < order.length; index++) {
+            order[index] = index + 1;
+        }
+        Arrays.sort(order, (left, right) -> columns[left].compareTo(columns[right]));
+        for (int index = header; index < lines.size(); index++) {
+            final String line = lines.get(index);
+            if (line.isEmpty()) {
+                break;
+            }
+            final String[] fields = line.split("\t", -1);
+            final StringBuilder rebuilt = new StringBuilder(fields[0]);
+            for (final int column : order) {
+                rebuilt.append('\t').append(column < fields.length ? fields[column] : "");
+            }
+            lines.set(index, rebuilt.toString());
+        }
+        return String.join("\n", lines);
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
The counts Mutect2's orientation-bias filter is trained on: for every three-base reference context, how deep the reference sites were and what the alt sites looked like. The traversal is a `LocusWalker`; what is measured is `F1R2CountsCollector`, which decides which pileups count at all and which of three places a site is written to.

Five runs over a BAM of four read blocks against a forty-base motif repeated, one block carrying every plant, one spanning an `N`, one at a mapping quality the default median test refuses and one carrying a deletion.

A site goes to one of three places: a reference site increments a depth histogram, an alt site with exactly one alt read increments a depth-one histogram keyed by context, alt base and orientation, and any other alt site becomes a row of the alt table. The alt base is `maxElementIndex` over the base counts with the reference set to `-1`, so a tie between two alt bases goes to the lower base index.

Three findings the reading did not give.

The alt table's `depth` column is `refCount + altCount` rather than the pileup's depth, so the tied site reports four over a pileup of six and the second alt base counts nowhere.

When a site is skipped for one sample it is skipped for every sample after it. The loop over the split pileup `return`s rather than continuing, and so do the reference-site and one-alt-read branches, so only the samples up to the first one that returns are ever counted. The order is a `HashMap` order over the sample names rather than the header's: over `alpha` and `bravo` it is `bravo` first, and every one of alpha's alt sites is lost because bravo is reference at each of them.

And the order of the alt histograms is not reproducible at all. The reference histograms are held in a `HashMap` keyed by the 64 context strings, which is stable, but the alt histograms are keyed by a pair holding an enum, whose `hashCode` is an identity hash and therefore differs from one JVM to the next. The golden carries that one file with its columns sorted, and says so.

Golden pending: to be produced by the pinned oracle container on an x86-64 runner, then landed by the follow-up commit.

Part of #761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)