### PR TITLE
Measure CollectF1R2Counts again, with a deletion the reads carry

### DIFF
--- a/tools/readfilter-conformance/CollectF1R2CountsDump.java
+++ b/tools/readfilter-conformance/CollectF1R2CountsDump.java
@@ -158,8 +158,11 @@ public class CollectF1R2CountsDump {
      * Four blocks of reads, each thirty bases long and every one unpaired.
      *
      * The first block is where the counting happens: three forward and three reverse reads per
-     * sample, with alt bases planted at four offsets. The second spans the N. The third carries a
-     * mapping quality the default median test refuses. The fourth carries a deletion.
+     * sample, with alt bases planted at five offsets. The second spans the N. The third carries a
+     * mapping quality the default median test refuses. The fourth carries a deletion, and its
+     * cigar consumes exactly the thirty bases the read holds: a cigar that does not is dropped
+     * whole by WellformedReadFilter's read-length rule long before the collector sees it, and the
+     * block would then measure nothing at all.
      */
     static void writeBam(final Path bam, final List<String> samples, final boolean index)
             throws Exception {
@@ -202,7 +205,7 @@ public class CollectF1R2CountsDump {
             final byte[] quals = new byte[READ_LENGTH];
             Arrays.fill(quals, (byte) 40);
             for (int offset = 0; offset < READ_LENGTH; offset++) {
-                final int locus = start + offset + (deletion && offset >= 10 ? 2 : 0);
+                final int locus = start + offset + (deletion && offset >= 12 ? 2 : 0);
                 char base = refBase(locus);
                 // The first block carries the plants; every other block is pure reference.
                 if (start == 41) {
@@ -238,7 +241,7 @@ public class CollectF1R2CountsDump {
             }
             record.setReadString(bases.toString());
             record.setBaseQualities(quals);
-            record.setCigarString(deletion ? "10M2D18M" : READ_LENGTH + "M");
+            record.setCigarString(deletion ? "12M2D18M" : READ_LENGTH + "M");
             records.add(record);
         }
         return records;


### PR DESCRIPTION
The fourth block of the fixture was meant to be the indel case and measured nothing. Its cigar was `10M2D18M` over reads of thirty bases, which consumes twenty-eight, and `WellformedReadFilter`'s read-length rule dropped every one of those reads before the collector saw them. The block was invisible in the counts, and a port agreeing with that golden would only have meant that both ignored it.

Found while porting: the Rust model, which knew nothing of read filters, counted about thirty loci the golden did not, and removing the fourth block from the model made it agree exactly. That is what the block being dropped whole looks like from the other side.

The cigar is now `12M2D18M`, which consumes exactly the thirty bases the reads hold, and the block contributes: the two deleted reference positions are pileups whose base counts are empty, so the site is skipped for having no depth at all rather than for being an indel, and the position before them is skipped by the indel test, a hundredth of a depth of six being zero so that a single element is enough.

Golden pending again: to be produced by the pinned oracle container on an x86-64 runner, then landed with the port.

Part of #761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)