### PR TITLE
Measure FilterFuncotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,10 @@ jobs:
             index: "46/46"
             slug: "collect-f1r2-counts"
             suites: "collect-f1r2-counts"
+          - group: golden-pending
+            index: "1/1"
+            slug: "filter-funcotations"
+            suites: "filter-funcotations"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 137 | 44.1% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 162 | 52.1% |
+| not started | 161 | 51.8% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (89 of 190 started)
+## gatk-origin tools (90 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -126,6 +126,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ExampleMultiFeatureWalker` | unclassified | oracle-backed | multi-feature-walker | 1 | not measured |
 | `FastaAlternateReferenceMaker` | reference-utility | oracle-backed | fasta-alternate-reference-maker | 1 | not measured |
 | `FastaReferenceMaker` | reference-utility | oracle-backed | fasta-reference-maker | 1 | not measured |
+| `FilterFuncotations` | variant-walker | golden-pending | filter-funcotations | 1 | not measured |
 | `FilterIntervals` | cnv-segmentation | oracle-backed | filter-intervals | 1 | not measured |
 | `FilterMutectCalls` | variant-transform | oracle-backed | filter-mutect-calls | 1 | not measured |
 | `FilterVariantTranches` | variant-transform | oracle-backed | filter-variant-tranches | 1 | not measured |
@@ -179,9 +180,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>101 not started</summary>
+<details><summary>100 not started</summary>
 
-`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FilterFuncotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBuildReferenceTaxonomy`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5341,6 +5341,26 @@
           "why": "Five runs over a BAM of four read blocks against a forty-base motif repeated: one sample where every branch is reachable, the same reads under two samples where the returns stop the loop, a depth cap low enough to be reached, a median mapping quality low enough to let the low-quality block through, and a base quality one below the default. Each run is reported by every file of its tar.gz, whole, the alt histogram with its columns sorted because their order is an identity hash order and is not reproducible. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32637463498, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "filter-funcotations",
+      "status": "golden-pending",
+      "title": "a Funcotated VCF marked with the rules that match it",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "FilterFuncotations"
+      ],
+      "why": "A FILTER MATCHES ONLY WHEN EVERY ONE OF ITS RULES DOES, the rules being reduced with logicalAnd and a filter with no rules reducing to false. THE CLINSIG VALUE IS A HashSet OF THE MATCHING NAMES JOINED WITH A COMMA, so its order is the set's own rather than the order the filters were registered in, and the two autosomal recessive filters share one name and contribute one entry between them. A VARIANT THAT MATCHES NOTHING GETS CLINSIG=NONE AND THE FILTER NOT_CLINSIG, one that matches anything is passed. CLINVAR'S SIGNIFICANCE TEST IS AN EXACT STRING MATCH against three values, so a value carrying a qualifier does not match. AN ExAC SUB-POPULATION WITH AN ALLELE NUMBER OF ZERO IS A MAF OF ZERO rather than a division, so a variant never seen in ExAC PASSES the frequency rule, AND SO IS ONE WHOSE COUNTS DO NOT PARSE, the NumberFormatException being caught and turned into zero, and so is one whose allele count has no allele number beside it. ONLY SUB-POPULATIONS WHOSE ALLELE COUNT KEY IS PRESENT ARE CONSIDERED. THE GNOMAD PATH IS NOT THE SAME CODE: a dataset counts as present when it has no FILTER funcotation or when its FILTER says PASS, when neither dataset is present the rule fails whatever the frequencies say, AND A GNOMAD FREQUENCY THAT DOES NOT PARSE IS NOT CAUGHT, unlike ExAC's, so it takes the whole run down. THE LMM FILTER READS ITS FLAG WITH Boolean.valueOf, case-insensitive on 'true' and false for everything else including 'yes' and '1'. THE HOMVAR RULE ASKS THE VARIANT for its hom-var count and fires only for ATP7B and MUTYH. THE HETVAR RULE IS A SECOND PASS: a gene needs MORE THAN ONE het variant before any of them is compound het. AND EVERY KEY THE TOOL LOOKS FOR CARRIES THE GENCODE VERSION OF --ref-version, which is 19 for b37 and hg19 and 27 for hg38, so the same funcotations stop matching under another reference.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "FilterFuncotationsDump",
+          "golden": null,
+          "why": "Five runs over hand-written Funcotated VCFs: twenty-two variants against ExAC covering every rule of the four filters and their joined value, six against gnomAD covering the present-dataset rule, one gnomAD frequency that does not parse and therefore stands alone because it takes the run down, one run under hg38 whose keys no longer match, and one VCF with no FUNCOTATION header line at all. Each run is reported by its whole input and its whole output. Golden pending: to be produced by the pinned oracle container on an x86-64 CI runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/FilterFuncotationsDump.java
+++ b/tools/readfilter-conformance/FilterFuncotationsDump.java
@@ -1,0 +1,305 @@
+/*
+ * FilterFuncotations's output, taken from the reference.
+ *
+ * A Funcotated VCF read back and marked with the clinical-significance rules that match it. The
+ * tool is five filters over the funcotations of each transcript, and what comes out is one INFO
+ * field naming the filters that matched and one FILTER value when none did.
+ *
+ * Twelve behaviours this is built to catch.
+ *
+ *   - A FILTER MATCHES ONLY WHEN EVERY ONE OF ITS RULES DOES, the rules being reduced with
+ *     logicalAnd and a filter with no rules at all reducing to false;
+ *   - THE CLINSIG VALUE IS A HashSet OF THE MATCHING NAMES JOINED WITH A COMMA, so its order is
+ *     not the order the filters were registered in but the set's own, which over AR, CLINVAR, LOF
+ *     and LMM happens to read alphabetically, and the two autosomal recessive filters share one
+ *     name and so contribute one entry between them;
+ *   - A VARIANT THAT MATCHES NOTHING GETS CLINSIG=NONE AND THE FILTER NOT_CLINSIG, and one that
+ *     matches anything is passed rather than left with whatever filters it arrived with;
+ *   - CLINVAR'S SIGNIFICANCE TEST IS AN EXACT STRING MATCH against three values, so a ClinVar
+ *     value carrying anything else, a qualifier or a second term, does not match;
+ *   - AN ExAC SUB-POPULATION WITH AN ALLELE NUMBER OF ZERO IS A MAF OF ZERO rather than a
+ *     division, so a variant never seen in ExAC PASSES the frequency rule;
+ *   - AND SO IS ONE WHOSE COUNTS DO NOT PARSE: the NumberFormatException is caught and turned into
+ *     zero, so a malformed allele count makes the variant pass;
+ *   - ONLY SUB-POPULATIONS WHOSE ALLELE COUNT KEY IS PRESENT ARE CONSIDERED, and the maximum over
+ *     no sub-population at all is zero;
+ *   - THE GNOMAD PATH IS NOT THE SAME CODE: a dataset counts as present when it has no FILTER
+ *     funcotation or when its FILTER says PASS, and when neither dataset is present the rule fails
+ *     whatever the frequencies say;
+ *   - AND A GNOMAD FREQUENCY THAT DOES NOT PARSE IS NOT CAUGHT, unlike ExAC's;
+ *   - THE LMM FILTER READS ITS FLAG WITH Boolean.valueOf, which is case-insensitive on "true" and
+ *     false for everything else, including "yes" and "1";
+ *   - THE HOMVAR RULE ASKS THE VARIANT, NOT THE FUNCOTATIONS, for its hom-var count, and fires only
+ *     for the two genes the tool knows;
+ *   - AND THE HETVAR RULE IS A SECOND PASS: a gene needs MORE THAN ONE het variant before any of
+ *     them is compound het, so a lone het variant in the same gene matches nothing.
+ *
+ * Output:
+ *
+ *     input\t<label>=<the whole VCF, escaped>
+ *     output\t<label>=<the whole VCF, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: FilterFuncotationsDump
+ */
+
+import org.broadinstitute.hellbender.tools.IndexFeatureFile;
+import org.broadinstitute.hellbender.tools.funcotator.FilterFuncotations;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FilterFuncotationsDump {
+
+    /** The funcotation keys the fixture declares, in the order the values are written. */
+    static final List<String> KEYS = List.of(
+            "Gencode_19_hugoSymbol",
+            "Gencode_19_variantClassification",
+            "Gencode_19_annotationTranscript",
+            "ACMG_recommendation_Disease_Name",
+            "ClinVar_VCF_CLNSIG",
+            "ACMGLMMLof_LOF_Mechanism",
+            "LMMKnown_LMM_FLAGGED",
+            "ExAC_AC_AFR",
+            "ExAC_AN_AFR",
+            "ExAC_AC_NFE",
+            "ExAC_AN_NFE",
+            "gnomAD_genome_AF_afr",
+            "gnomAD_genome_FILTER",
+            "gnomAD_exome_AF_nfe",
+            "gnomAD_exome_FILTER");
+
+    /** One transcript's funcotations, in key order, missing values written empty. */
+    static String funcotation(final String... values) {
+        final String[] fields = new String[KEYS.size()];
+        Arrays.fill(fields, "");
+        for (int index = 0; index < values.length; index += 2) {
+            final int position = KEYS.indexOf(values[index]);
+            if (position < 0) {
+                throw new IllegalArgumentException("no such key: " + values[index]);
+            }
+            fields[position] = values[index + 1];
+        }
+        return "[" + String.join("|", fields) + "]";
+    }
+
+    record Variant(int position, String genotype, String funcotation) {}
+
+    static Variant variant(final int position, final String genotype, final String funcotation) {
+        return new Variant(position, genotype, funcotation);
+    }
+
+    static String vcf(final List<Variant> variants) {
+        final StringBuilder text = new StringBuilder();
+        text.append("##fileformat=VCFv4.2\n");
+        text.append("##contig=<ID=chr1,length=100000>\n");
+        text.append("##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n");
+        text.append("##INFO=<ID=FUNCOTATION,Number=A,Type=String,Description=\"Funcotation fields are: ")
+                .append(String.join("|", KEYS)).append("\">\n");
+        text.append("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n");
+        for (final Variant variant : variants) {
+            text.append("chr1\t").append(variant.position()).append("\t.\tA\tC\t100\t.\tFUNCOTATION=")
+                    .append(variant.funcotation()).append("\tGT\t").append(variant.genotype())
+                    .append('\n');
+        }
+        return text.toString();
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("filter-funcotations-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# FilterFuncotationsDump: a Funcotated VCF marked with the rules that match it");
+
+        // Every ExAC-side rule, one variant each.
+        run(dir, "exac", "hg19", "exac", List.of(
+                // ClinVar: the gene is on the ACMG list, the significance is one of the three
+                // matching values and the frequency is under five per cent.
+                variant(100, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "ExAC_AC_AFR", "1", "ExAC_AN_AFR", "1000")),
+                // The same, with the third matching value.
+                variant(200, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic/Likely_pathogenic",
+                        "ExAC_AC_AFR", "1", "ExAC_AN_AFR", "1000")),
+                // A significance that carries a qualifier, which is not one of the three.
+                variant(300, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic_low_penetrance",
+                        "ExAC_AC_AFR", "1", "ExAC_AN_AFR", "1000")),
+                // A frequency above the ClinVar threshold, taken as the maximum over two
+                // sub-populations.
+                variant(400, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "ExAC_AC_AFR", "1", "ExAC_AN_AFR", "1000",
+                        "ExAC_AC_NFE", "60", "ExAC_AN_NFE", "1000")),
+                // An allele number of zero, which is a frequency of zero and not a division.
+                variant(500, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "ExAC_AC_AFR", "5", "ExAC_AN_AFR", "0")),
+                // An allele count that does not parse, which is caught and read as zero.
+                variant(600, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "ExAC_AC_AFR", "many", "ExAC_AN_AFR", "1000")),
+                // An allele count with no allele number beside it, which is the same zero.
+                variant(700, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "ExAC_AC_AFR", "5")),
+                // No ACMG gene at all, so the first ClinVar rule fails.
+                variant(800, "0/1", funcotation(
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "ExAC_AC_AFR", "1", "ExAC_AN_AFR", "1000")),
+                // Loss of function: a matching classification, the mechanism and a frequency under
+                // one per cent.
+                variant(900, "0/1", funcotation(
+                        "Gencode_19_variantClassification", "FRAME_SHIFT_DEL",
+                        "ACMGLMMLof_LOF_Mechanism", "YES",
+                        "ExAC_AC_AFR", "1", "ExAC_AN_AFR", "1000")),
+                // A classification that is not one of the five.
+                variant(1000, "0/1", funcotation(
+                        "Gencode_19_variantClassification", "MISSENSE",
+                        "ACMGLMMLof_LOF_Mechanism", "YES",
+                        "ExAC_AC_AFR", "1", "ExAC_AN_AFR", "1000")),
+                // A frequency between the two thresholds, which passes ClinVar and fails LOF.
+                variant(1100, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "Gencode_19_variantClassification", "NONSENSE",
+                        "ACMGLMMLof_LOF_Mechanism", "YES",
+                        "ExAC_AC_AFR", "30", "ExAC_AN_AFR", "1000")),
+                // LMM, whose flag is read with Boolean.valueOf.
+                variant(1200, "0/1", funcotation("LMMKnown_LMM_FLAGGED", "true")),
+                variant(1300, "0/1", funcotation("LMMKnown_LMM_FLAGGED", "TRUE")),
+                variant(1400, "0/1", funcotation("LMMKnown_LMM_FLAGGED", "yes")),
+                variant(1500, "0/1", funcotation("LMMKnown_LMM_FLAGGED", "1")),
+                // A hom-var in one of the two genes the tool knows, and a het in the same gene,
+                // which is alone and therefore not compound.
+                variant(1600, "1/1", funcotation("Gencode_19_hugoSymbol", "ATP7B")),
+                variant(1700, "0/1", funcotation("Gencode_19_hugoSymbol", "ATP7B")),
+                // A hom-var in a gene the tool does not know.
+                variant(1800, "1/1", funcotation("Gencode_19_hugoSymbol", "BRCA1")),
+                // Two hets in the other known gene, which makes both of them compound.
+                variant(1900, "0/1", funcotation("Gencode_19_hugoSymbol", "MUTYH")),
+                variant(2000, "0/1", funcotation("Gencode_19_hugoSymbol", "MUTYH")),
+                // Everything at once, to show what the joined CLINSIG value looks like.
+                variant(2100, "1/1", funcotation(
+                        "Gencode_19_hugoSymbol", "ATP7B",
+                        "ACMG_recommendation_Disease_Name", "Wilson",
+                        "ClinVar_VCF_CLNSIG", "Likely_pathogenic",
+                        "Gencode_19_variantClassification", "SPLICE_SITE",
+                        "ACMGLMMLof_LOF_Mechanism", "YES",
+                        "LMMKnown_LMM_FLAGGED", "true",
+                        "ExAC_AC_AFR", "1", "ExAC_AN_AFR", "1000")),
+                // Nothing at all.
+                variant(2200, "0/1", funcotation("Gencode_19_hugoSymbol", "BRCA1"))));
+
+        // The gnomAD path, which is different code with different rules.
+        run(dir, "gnomad", "hg19", "gnomad", List.of(
+                // No FILTER funcotation at all, so both datasets count as present.
+                variant(100, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "gnomAD_genome_AF_afr", "0.01")),
+                // A FILTER that says PASS, which also counts as present.
+                variant(200, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "gnomAD_genome_AF_afr", "0.01",
+                        "gnomAD_genome_FILTER", "PASS")),
+                // A frequency over the threshold.
+                variant(300, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "gnomAD_genome_AF_afr", "0.06",
+                        "gnomAD_genome_FILTER", "PASS")),
+                // Both datasets filtered out, which fails the rule whatever the frequency says.
+                variant(400, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "gnomAD_genome_AF_afr", "0.01",
+                        "gnomAD_genome_FILTER", "RF",
+                        "gnomAD_exome_FILTER", "AC0")),
+                // One filtered out and one not.
+                variant(500, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "gnomAD_genome_AF_afr", "0.01",
+                        "gnomAD_genome_FILTER", "RF",
+                        "gnomAD_exome_AF_nfe", "0.02",
+                        "gnomAD_exome_FILTER", "PASS"))));
+
+        // A gnomAD frequency that does not parse, which nothing catches, so it takes the whole
+        // run down and has to stand on its own.
+        run(dir, "gnomad-unparseable", "hg19", "gnomad", List.of(
+                variant(100, "0/1", funcotation(
+                        "ACMG_recommendation_Disease_Name", "Cardiomyopathy",
+                        "ClinVar_VCF_CLNSIG", "Pathogenic",
+                        "gnomAD_genome_AF_afr", "many",
+                        "gnomAD_genome_FILTER", "PASS"))));
+
+        // The other reference versions, whose gencode number is part of every key the tool looks
+        // for, so the same funcotations stop matching.
+        run(dir, "hg38-keys", "hg38", "exac", List.of(
+                variant(100, "0/1", funcotation(
+                        "Gencode_19_variantClassification", "NONSENSE",
+                        "ACMGLMMLof_LOF_Mechanism", "YES",
+                        "ExAC_AC_AFR", "1", "ExAC_AN_AFR", "1000"))));
+
+        // A VCF with no FUNCOTATION header line at all.
+        final Path bare = dir.resolve("bare.vcf");
+        Files.writeString(bare, "##fileformat=VCFv4.2\n##contig=<ID=chr1,length=100000>\n"
+                + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+                + "chr1\t100\t.\tA\tC\t100\t.\t.\n", StandardCharsets.UTF_8);
+        execute(dir, "no-funcotation-header", bare, "hg19", "exac");
+    }
+
+    static void run(final Path dir, final String label, final String reference,
+                    final String dataSource, final List<Variant> variants) throws Exception {
+        final Path input = dir.resolve(label + ".vcf");
+        Files.writeString(input, vcf(variants), StandardCharsets.UTF_8);
+        execute(dir, label, input, reference, dataSource);
+    }
+
+    static void execute(final Path dir, final String label, final Path input,
+                        final String reference, final String dataSource) throws Exception {
+        System.out.printf("input\t%s=%s%n", label,
+                ReferenceQueryDump.escape(Files.readString(input)));
+        try {
+            new IndexFeatureFile().instanceMain(new String[] {"-I", input.toString()});
+        } catch (final Exception e) {
+            System.out.printf("index\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+        }
+        final Path out = dir.resolve(label + ".filtered.vcf");
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "-V", input.toString(), "-O", out.toString(),
+                "--ref-version", reference,
+                "--allele-frequency-data-source", dataSource));
+        try {
+            new FilterFuncotations().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+            return;
+        }
+        if (Files.exists(out)) {
+            System.out.printf("output\t%s=%s%n", label,
+                    ReferenceQueryDump.escape(masked(Files.readString(out), dir)));
+        }
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
A Funcotated VCF read back and marked with the clinical-significance rules that match it. Five filters over the funcotations of each transcript, and what comes out is one INFO field naming the filters that matched and one FILTER value when none did.

Five runs over hand-written Funcotated VCFs: twenty-two variants against ExAC covering every rule of the four filters and their joined value, six against gnomAD, one gnomAD frequency that does not parse, one run under hg38 whose keys no longer match, and one VCF with no `FUNCOTATION` header line.

Three findings the reading did not settle.

An ExAC sub-population with an allele number of zero is a MAF of zero rather than a division, so a variant never seen in ExAC **passes** the frequency rule. So is one whose allele count does not parse, the `NumberFormatException` being caught and turned into zero, and so is one whose allele count arrives with no allele number beside it. Three different kinds of missing data all read as the safest possible frequency.

The gnomAD path is not the same code and does not catch anything: an unparseable frequency there takes the whole run down, which is why that case stands alone in the fixture. It also has a rule ExAC has not, a dataset counting as present only when it carries no `FILTER` funcotation or when that `FILTER` says `PASS`, and when neither dataset is present the rule fails whatever the frequencies say.

And the two autosomal recessive filters share one name, so a variant matching both contributes one entry to `CLINSIG`. The value is a `HashSet` joined with a comma, so its order is the set's own rather than the order the filters were registered in.

Golden pending: to be produced by the pinned oracle container on an x86-64 runner, then landed by the follow-up commit.

Part of #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)