### PR TITLE
Measure PathSeqBuildKmers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,10 @@ jobs:
             index: "46/46"
             slug: "collect-f1r2-counts-filter-funcotations-pathseq-build-reference-taxonomy"
             suites: "collect-f1r2-counts filter-funcotations pathseq-build-reference-taxonomy"
+          - group: golden-pending
+            index: "1/1"
+            slug: "pathseq-build-kmers"
+            suites: "pathseq-build-kmers"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 139 | 44.7% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 160 | 51.4% |
+| not started | 159 | 51.1% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (91 of 190 started)
+## gatk-origin tools (92 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -150,6 +150,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `MergeMutectStats` | unclassified | oracle-backed | mutect-gathers | 1 | not measured |
 | `MethylationTypeCaller` | record-transform | oracle-backed | methylation-type-caller | 1 | not measured |
 | `NuMTFilterTool` | unclassified | oracle-backed | numt-filter | 1 | not measured |
+| `PathSeqBuildKmers` | metagenomics | golden-pending | pathseq-build-kmers | 1 | not measured |
 | `PathSeqBuildReferenceTaxonomy` | metagenomics | oracle-backed | pathseq-build-reference-taxonomy | 1 | not measured |
 | `Pileup` | locus-walker | oracle-backed | pileup-tool | 1 | not measured |
 | `PostProcessReadsForRSEM` | record-transform | oracle-backed | post-process-reads-for-rsem | 1 | not measured |
@@ -181,9 +182,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>99 not started</summary>
+<details><summary>98 not started</summary>
 
-`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBuildKmers`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5381,6 +5381,26 @@
           "why": "Nine runs over one taxonomy of seven nodes and one reference of six contigs named in every form the parser knows: both catalogs, both with a minimum contig length of five hundred, each catalog alone, neither, a catalog truncated by a blank line, a catalog line with too few columns, a reference name whose taxon id is not a number, and a reference whose contigs are in no catalog. The Kryo database is read back and reported as its tree, node by node with parent, rank, name and total length, and as its contig-to-taxon map. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32641778950, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "pathseq-build-kmers",
+      "status": "golden-pending",
+      "title": "a host reference turned into a k-mer set",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "PathSeqBuildKmers"
+      ],
+      "why": "A K-MER IS TWO BITS PER BASE, A=0 C=1 G=2 T=3, the first base in the HIGH bits, and the long is the whole of it. THE SET IS CANONICAL: a k-mer whose middle base is G or T is replaced by its reverse complement, which is why the size must be odd, and AN EVEN SIZE IS REFUSED BY canonical() ITSELF rather than by the argument parser, with 'Kmer length must be odd to canonicalize.'. MASKING IS AN AND WITH A LONG BUILT FROM THE MASKED POSITIONS, counted from the START of the k-mer, and it HAPPENS AFTER CANONICALISATION, so which bases a mask clears depends on which strand won. A MASK INDEX OUTSIDE THE K-MER IS REFUSED with the index it was given. ANY BASE THAT IS NOT ACGT RESTARTS THE COUNT, the valid-base counter being set to -1 and then incremented, so an N costs a whole window, while LOWER CASE COUNTS. --kmer-spacing IS APPLIED BY REWINDING THE VALID-BASE COUNTER to kSize minus the spacing. THE SET HOLDS EACH DISTINCT LONG ONCE. A K LONGER THAN EVERY CONTIG PRODUCES NOTHING AND IS THEN REFUSED BY THE SET ITSELF, 'Number of elements must be greater than 0', so no empty set is ever written. AND A BLOOM FILTER ANSWERS THE SAME QUESTIONS with a theoretical false positive probability far below the one asked for, 6.179020492442123E-13 for a request of 0.01 over twenty k-mers.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "PathSeqBuildKmersDump",
+          "golden": null,
+          "why": "Ten runs over two short contigs, one plain and one carrying an N and a lower-case run: k of five with no mask, with the middle base masked, with the first and last masked, at spacings of three and five, k of seven, a Bloom filter, an even k, a mask index outside the k-mer, and a k longer than every contig. Each set is reported whole, every k-mer as the long it is stored as and the bases that long spells, in order. Golden pending: to be produced by the pinned oracle container on an x86-64 CI runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/PathSeqBuildKmersDump.java
+++ b/tools/readfilter-conformance/PathSeqBuildKmersDump.java
@@ -1,0 +1,168 @@
+/*
+ * PathSeqBuildKmers's output, taken from the reference.
+ *
+ * A host reference turned into the k-mer set PathSeq subtracts against. The output is a Kryo
+ * serialisation, so what is printed here is the set read back: every k-mer as the long it is stored
+ * as, in order, with the bases that long spells.
+ *
+ * Eleven behaviours this is built to catch.
+ *
+ *   - A K-MER IS TWO BITS PER BASE, A=0 C=1 G=2 T=3, the first base in the HIGH bits, and the long
+ *     is the whole of it;
+ *   - THE SET IS CANONICAL: a k-mer whose middle base is G or T is replaced by its reverse
+ *     complement, which is why the size must be odd, and an even size is refused by canonical()
+ *     itself rather than by the argument parser;
+ *   - MASKING IS AN AND WITH A LONG BUILT FROM THE MASKED POSITIONS, and the positions are counted
+ *     from the START of the k-mer, so masking position 0 clears the first base's bits;
+ *   - MASKING HAPPENS AFTER CANONICALISATION, so which bases a mask clears depends on which strand
+ *     won;
+ *   - A MASK INDEX OUTSIDE THE K-MER IS REFUSED with the index it was given;
+ *   - ANY BASE THAT IS NOT ACGT RESTARTS THE COUNT, the valid-base counter being set to -1 and
+ *     then incremented, so a k-mer is emitted only after k good bases in a row and an N costs a
+ *     whole window;
+ *   - LOWER CASE COUNTS, a and A being the same base;
+ *   - --kmer-spacing IS APPLIED BY REWINDING THE VALID-BASE COUNTER to kSize - spacing, so a
+ *     spacing of one is every position and a spacing of k is non-overlapping windows;
+ *   - THE SET HOLDS EACH DISTINCT LONG ONCE, however many places it came from;
+ *   - A K LONGER THAN EVERY CONTIG PRODUCES NOTHING AND IS THEN REFUSED BY THE SET ITSELF, so no
+ *     empty set is ever written;
+ *   - AND A BLOOM FILTER ANSWERS THE SAME QUESTIONS with a theoretical false positive probability
+ *     the tool computes and reports.
+ *
+ * Output:
+ *
+ *     fixture\t<name>=<the whole file, escaped>
+ *     count\t<label>=<number of distinct k-mers>
+ *     kmer\t<label>\t<long>\t<bases>
+ *     bloom\t<label>\t<key>=<value>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: PathSeqBuildKmersDump
+ */
+
+import org.broadinstitute.hellbender.tools.spark.pathseq.PSKmerBloomFilter;
+import org.broadinstitute.hellbender.tools.spark.pathseq.PSKmerCollection;
+import org.broadinstitute.hellbender.tools.spark.pathseq.PSKmerSet;
+import org.broadinstitute.hellbender.tools.spark.pathseq.PSKmerUtils;
+import org.broadinstitute.hellbender.tools.spark.pathseq.PathSeqBuildKmers;
+import org.broadinstitute.hellbender.tools.spark.utils.LongIterator;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVKmerShort;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PathSeqBuildKmersDump {
+
+    /**
+     * Two contigs: one plain, one carrying an N and a lower-case run, both short enough that every
+     * k-mer can be printed.
+     */
+    static final String CONTIG_ONE = "ACGTTGCAAGGCTTACCATGG";
+    static final String CONTIG_TWO = "ACGTNACGTacgtTTTTT";
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("pathseq-kmers-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# PathSeqBuildKmersDump: a host reference turned into a k-mer set");
+
+        final Path fasta = writeReference(dir);
+
+        run(dir, "k5", fasta, 5, "", 1, 0);
+        run(dir, "k5-mask-middle", fasta, 5, "2", 1, 0);
+        run(dir, "k5-mask-first-and-last", fasta, 5, "0,4", 1, 0);
+        run(dir, "k5-spacing-three", fasta, 5, "", 3, 0);
+        run(dir, "k5-spacing-five", fasta, 5, "", 5, 0);
+        run(dir, "k7", fasta, 7, "", 1, 0);
+        run(dir, "k5-bloom", fasta, 5, "", 1, 0.01);
+        // An even k, which canonical() refuses.
+        run(dir, "even-k", fasta, 4, "", 1, 0);
+        // A mask index the k-mer does not have.
+        run(dir, "mask-out-of-range", fasta, 5, "9", 1, 0);
+        // A k longer than either contig, which produces nothing at all.
+        run(dir, "k-longer-than-reference", fasta, 31, "", 1, 0);
+    }
+
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("host.fasta");
+        Files.writeString(fasta, ">one\n" + CONTIG_ONE + "\n>two\n" + CONTIG_TWO + "\n",
+                StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        new picard.sam.CreateSequenceDictionary().instanceMain(new String[] {
+                "R=" + fasta, "O=" + dir.resolve("host.dict")});
+        System.out.printf("fixture\tone=%s%n", CONTIG_ONE);
+        System.out.printf("fixture\ttwo=%s%n", CONTIG_TWO);
+        return fasta;
+    }
+
+    static void run(final Path dir, final String label, final Path fasta, final int kmerSize,
+                    final String mask, final int spacing, final double bloomFpp) throws Exception {
+        final Path out = dir.resolve(label + (bloomFpp > 0 ? ".bfi" : ".hss"));
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "--reference", fasta.toString(),
+                "--output", out.toString(),
+                "--kmer-size", Integer.toString(kmerSize),
+                "--kmer-mask", mask,
+                "--kmer-spacing", Integer.toString(spacing),
+                "--bloom-false-positive-probability", Double.toString(bloomFpp)));
+        try {
+            new PathSeqBuildKmers().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+            return;
+        }
+        final PSKmerCollection collection = PSKmerUtils.readKmerFilter(out.toString());
+        if (collection instanceof PSKmerBloomFilter) {
+            final PSKmerBloomFilter filter = (PSKmerBloomFilter) collection;
+            System.out.printf("bloom\t%s\tkmer-size=%d%n", label, filter.kmerSize());
+            System.out.printf("bloom\t%s\tfalse-positive-probability=%s%n", label,
+                    Double.toString(filter.getFalsePositiveProbability()));
+            // Every k-mer the plain set holds must be in the filter, and a few that are not in the
+            // reference at all are asked as well.
+            for (final long value : sortedKmers(dir, label, fasta, filter.kmerSize())) {
+                System.out.printf("bloom\t%s\tcontains-%d=%b%n", label, value,
+                        filter.contains(new SVKmerShort(value)));
+            }
+            return;
+        }
+        final PSKmerSet set = (PSKmerSet) collection;
+        final List<Long> values = new ArrayList<>();
+        final LongIterator iterator = set.iterator();
+        while (iterator.hasNext()) {
+            values.add(iterator.next());
+        }
+        values.sort(Long::compareTo);
+        System.out.printf("count\t%s=%d%n", label, values.size());
+        for (final long value : values) {
+            System.out.printf("kmer\t%s\t%d\t%s%n", label, value,
+                    new SVKmerShort(value).toString(kmerSize));
+        }
+    }
+
+    /** The k-mers of the plain run of the same size, which the Bloom filter is asked about. */
+    static List<Long> sortedKmers(final Path dir, final String label, final Path fasta,
+                                  final int kmerSize) throws Exception {
+        final Path plain = dir.resolve("k" + kmerSize + ".hss");
+        final List<Long> values = new ArrayList<>();
+        if (!Files.exists(plain)) {
+            return values;
+        }
+        final PSKmerSet set = (PSKmerSet) PSKmerUtils.readKmerFilter(plain.toString());
+        final LongIterator iterator = set.iterator();
+        while (iterator.hasNext()) {
+            values.add(iterator.next());
+        }
+        values.sort(Long::compareTo);
+        return values;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
A host reference turned into the k-mer set PathSeq subtracts against. The output is a Kryo serialisation, so the dump reads it back and prints the set whole: every k-mer as the long it is stored as and the bases that long spells, in order.

Ten runs over two short contigs, one plain and one carrying an `N` and a lower-case run.

A k-mer is two bits per base with the first base in the high bits, and the set is canonical: a k-mer whose middle base is G or T is replaced by its reverse complement. That is why the size must be odd, and an even size is refused by `canonical()` itself rather than by the argument parser. Masking is an AND with a long built from the masked positions, counted from the start of the k-mer, and it happens after canonicalisation, so which bases a mask clears depends on which strand won.

Two findings the reading did not give.

A k longer than every contig produces nothing and is then refused by the set itself, `Number of elements must be greater than 0`, so no empty set is ever written and the failure comes from a container rather than from the tool.

And the Bloom filter's theoretical false positive probability is nowhere near the one asked for: `6.179020492442123E-13` for a request of `0.01` over twenty k-mers. The argument is an upper limit on a filter sized in whole words, not a target.

Golden pending: to be produced by the pinned oracle container on an x86-64 runner, then landed by the follow-up commit.

Part of #569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)