### PR TITLE
Measure GtfToBed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,10 @@ jobs:
             index: "46/46"
             slug: "collect-f1r2-counts-filter-funcotations-pathseq-build-reference-taxonomy-pathseq-build-kmers"
             suites: "collect-f1r2-counts filter-funcotations pathseq-build-reference-taxonomy pathseq-build-kmers"
+          - group: golden-pending
+            index: "1/1"
+            slug: "gtf-to-bed"
+            suites: "gtf-to-bed"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 140 | 45.0% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 159 | 51.1% |
+| not started | 158 | 50.8% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (92 of 190 started)
+## gatk-origin tools (93 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -140,6 +140,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |
 | `GetPileupSummaries` | locus-walker | oracle-backed | get-pileup-summaries | 1 | not measured |
 | `GetSampleName` | reporting-walker | oracle-backed | get-sample-name | 1 | not measured |
+| `GtfToBed` | assembly-caller | golden-pending | gtf-to-bed | 1 | not measured |
 | `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file | 1 | not measured |
 | `LeftAlignAndTrimVariants` | variant-transform | oracle-backed | left-align-and-trim-variants | 1 | not measured |
 | `LeftAlignIndels` | record-transform | oracle-backed | left-align-indels-tool | 1 | not measured |
@@ -182,9 +183,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>98 not started</summary>
+<details><summary>97 not started</summary>
 
-`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `GtfToBed`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5401,6 +5401,26 @@
           "why": "Ten runs over two short contigs, one plain and one carrying an N and a lower-case run: k of five with no mask, with the middle base masked, with the first and last masked, at spacings of three and five, k of seven, a Bloom filter, an even k, a mask index outside the k-mer, and a k longer than every contig. Each set is reported whole, every k-mer as the long it is stored as and the bases that long spells, in order. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32642616657, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "gtf-to-bed",
+      "status": "golden-pending",
+      "title": "a Gencode GTF reduced to one row per gene or transcript",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "GtfToBed"
+      ],
+      "why": "THE OUTPUT IS NOT ZERO-BASED: the start written is the GTF's own start, so what is called a BED file is one-based and every coordinate is off by one against every other BED. A GENE'S INTERVAL IS WIDENED BY ITS TRANSCRIPTS, the start taken down and the end taken up, so a gene row can be wider than the gene line the file carried. --sort-by-transcript DOES NOT SORT, IT SELECTS which of the two kinds of row is written; the order is the same either way, and it is the dictionary's CONTIG INDEX, then the START, then the KEY, so two features at one position are separated by their gene or transcript id as a STRING. A gene row is four columns and so is a transcript row, the transcript's fourth being the gene name and the transcript id joined with a COMMA rather than a fifth column. --use-basic-transcript KEEPS ONLY TRANSCRIPTS CARRYING A tag WHOSE VALUE IS basic, and it processes such a transcript ONCE PER MATCHING TAG. AND A TRANSCRIPT IT DROPS NEVER WIDENS ITS GENE, so the GENE rows change with the flag too: a gene whose only wide transcript is not basic comes back to the interval its own line declared. THE DICTIONARY IS REQUIRED, its absence a UserException naming the argument, and a contig the dictionary does not know is refused by the comparator with 'could not get sequence for', which is an IllegalArgumentException rather than a UserException.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "GtfToBedDump",
+          "golden": null,
+          "why": "Six runs over one GTF of four genes on two contigs: gene rows, transcript rows, each again with --use-basic-transcript, a run with no dictionary and a run whose dictionary is missing a contig. The first gene's transcript reaches past it at both ends, two genes start at the same position so their order is settled by their ids, and one transcript carries the basic tag twice. Each run is reported by its whole output. Golden pending: to be produced by the pinned oracle container on an x86-64 CI runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/GtfToBedDump.java
+++ b/tools/readfilter-conformance/GtfToBedDump.java
@@ -1,0 +1,151 @@
+/*
+ * GtfToBed's output, taken from the reference.
+ *
+ * A Gencode GTF reduced to one row per gene, or one per transcript. The whole tool is a map keyed
+ * by gene or transcript id, a comparator, and four columns.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - THE OUTPUT IS NOT ZERO-BASED: the start written is the GTF's own start, so what is called a
+ *     BED file is one-based and half its coordinates are off by one against every other BED;
+ *   - A GENE'S INTERVAL IS WIDENED BY ITS TRANSCRIPTS, the start taken down and the end taken up,
+ *     so a gene row can be wider than the gene line the file carried;
+ *   - --sort-by-transcript DOES NOT SORT, IT SELECTS: it decides which of the two kinds of row is
+ *     written, and the rows are sorted the same way either way;
+ *   - THE ORDER IS THE DICTIONARY'S CONTIG INDEX, THEN THE START, THEN THE KEY, so two features at
+ *     one position are separated by their gene or transcript id as a STRING;
+ *   - A GENE ROW IS FOUR COLUMNS AND A TRANSCRIPT ROW IS FOUR, the transcript's fourth being the
+ *     gene name and the transcript id joined with a COMMA rather than a fifth column;
+ *   - --use-basic-transcript KEEPS ONLY TRANSCRIPTS CARRYING A tag WHOSE VALUE IS basic, and it
+ *     processes such a transcript ONCE PER MATCHING TAG;
+ *   - AND A TRANSCRIPT IT DROPS NEVER WIDENS ITS GENE, so the gene rows change with the flag too;
+ *   - THE DICTIONARY IS REQUIRED, and its absence is a UserException naming the argument;
+ *   - AND A CONTIG THE DICTIONARY DOES NOT KNOW IS A refusal from the comparator rather than from
+ *     the traversal.
+ *
+ * Output:
+ *
+ *     input\t<label>=<the whole GTF, escaped>
+ *     bed\t<label>=<the whole output, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: GtfToBedDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.conversion.GtfToBed;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class GtfToBedDump {
+
+    /** One GTF line, whose attributes are the ones the codec needs and the tags asked for. */
+    static String gene(final String contig, final int start, final int end, final String geneId,
+                       final String geneName) {
+        return contig + "\tHAVANA\tgene\t" + start + "\t" + end + "\t.\t+\t.\t"
+                + "gene_id \"" + geneId + "\"; gene_type \"protein_coding\"; gene_name \"" + geneName
+                + "\"; level 2; havana_gene \"OTTHUMG00000000001.1\";\n";
+    }
+
+    static String transcript(final String contig, final int start, final int end,
+                             final String geneId, final String geneName, final String transcriptId,
+                             final String... tags) {
+        final StringBuilder line = new StringBuilder(contig + "\tHAVANA\ttranscript\t" + start + "\t"
+                + end + "\t.\t+\t.\t"
+                + "gene_id \"" + geneId + "\"; transcript_id \"" + transcriptId + "\"; "
+                + "gene_type \"protein_coding\"; gene_name \"" + geneName + "\"; "
+                + "transcript_type \"protein_coding\"; transcript_name \"" + transcriptId + "\"; "
+                + "level 2;");
+        for (final String tag : tags) {
+            line.append(" tag \"").append(tag).append("\";");
+        }
+        return line.append(" havana_gene \"OTTHUMG00000000001.1\";\n").toString();
+    }
+
+    static String exon(final String contig, final int start, final int end, final String geneId,
+                       final String geneName, final String transcriptId) {
+        return contig + "\tHAVANA\texon\t" + start + "\t" + end + "\t.\t+\t.\t"
+                + "gene_id \"" + geneId + "\"; transcript_id \"" + transcriptId + "\"; "
+                + "gene_type \"protein_coding\"; gene_name \"" + geneName + "\"; "
+                + "transcript_type \"protein_coding\"; transcript_name \"" + transcriptId + "\"; "
+                + "exon_number 1; exon_id \"" + transcriptId + ".1\"; level 2;\n";
+    }
+
+    /**
+     * Two contigs and four genes.
+     *
+     * The first gene's transcripts reach past it at both ends, so its row is wider than its line.
+     * The second gene has one basic transcript and one that is not. The third and fourth start at
+     * the same position, so their order is settled by their ids as strings.
+     */
+    static String gtf() {
+        return gene("chr1", 100, 200, "GENE_B.1", "beta")
+                + transcript("chr1", 50, 250, "GENE_B.1", "beta", "TX_B1.1", "basic")
+                + exon("chr1", 50, 250, "GENE_B.1", "beta", "TX_B1.1")
+                + transcript("chr1", 120, 180, "GENE_B.1", "beta", "TX_B2.1")
+                + exon("chr1", 120, 180, "GENE_B.1", "beta", "TX_B2.1")
+                + gene("chr1", 300, 400, "GENE_A.1", "alpha")
+                + transcript("chr1", 300, 400, "GENE_A.1", "alpha", "TX_A1.1", "basic", "basic")
+                + exon("chr1", 300, 400, "GENE_A.1", "alpha", "TX_A1.1")
+                + gene("chr1", 300, 400, "GENE_C.1", "gamma")
+                + transcript("chr1", 300, 500, "GENE_C.1", "gamma", "TX_C1.1")
+                + exon("chr1", 300, 500, "GENE_C.1", "gamma", "TX_C1.1")
+                + gene("chr2", 10, 20, "GENE_D.1", "delta")
+                + transcript("chr2", 10, 20, "GENE_D.1", "delta", "TX_D1.1")
+                + exon("chr2", 10, 20, "GENE_D.1", "delta", "TX_D1.1");
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("gtf-to-bed-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# GtfToBedDump: a Gencode GTF reduced to one row per gene or transcript");
+
+        final Path dict = MultiFeatureWalkerDump.writeDictionary(dir, "gtf", List.of("chr1", "chr2"));
+        final Path gtf = dir.resolve("annotation.gtf");
+        Files.writeString(gtf, gtf(), StandardCharsets.UTF_8);
+        System.out.printf("input\tannotation=%s%n", ReferenceQueryDump.escape(gtf()));
+
+        run(dir, "genes", gtf, dict);
+        run(dir, "transcripts", gtf, dict, "--sort-by-transcript", "true");
+        run(dir, "genes-basic-only", gtf, dict, "--use-basic-transcript", "true");
+        run(dir, "transcripts-basic-only", gtf, dict,
+                "--sort-by-transcript", "true", "--use-basic-transcript", "true");
+        // No dictionary at all.
+        run(dir, "no-dictionary", gtf, null);
+        // A contig the dictionary does not know.
+        final Path narrow = MultiFeatureWalkerDump.writeDictionary(dir, "chr1only", List.of("chr1"));
+        run(dir, "unknown-contig", gtf, narrow);
+    }
+
+    static void run(final Path dir, final String label, final Path gtf, final Path dictionary,
+                    final String... extra) throws Exception {
+        final Path out = dir.resolve(label + ".bed");
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "--gtf-path", gtf.toString(), "--output", out.toString()));
+        if (dictionary != null) {
+            argv.addAll(Arrays.asList("--sequence-dictionary", dictionary.toString()));
+        }
+        argv.addAll(Arrays.asList(extra));
+        try {
+            new GtfToBed().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+            return;
+        }
+        if (Files.exists(out)) {
+            System.out.printf("bed\t%s=%s%n", label,
+                    ReferenceQueryDump.escape(masked(Files.readString(out), dir)));
+        }
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
A Gencode GTF reduced to one row per gene, or one per transcript. The whole tool is a map keyed by gene or transcript id, a comparator and four columns.

Six runs over one GTF of four genes on two contigs, whose first gene has a transcript reaching past it at both ends, whose third and fourth start at the same position, and one of whose transcripts carries the `basic` tag twice.

**The output is not zero-based.** The start written is the GTF's own start, so what the tool calls a BED file is one-based and every coordinate in it is off by one against every other BED. Nothing in the tool converts, and the golden says so on every row.

A gene's interval is widened by its transcripts, the start taken down and the end taken up, so a gene row can be wider than the gene line the file carried.

And `--use-basic-transcript` changes the **gene** rows too. A transcript it drops never widens its gene, so a gene whose only wide transcript is not basic comes back to the interval its own line declared: `gamma` is `300 500` with the flag off and `300 400` with it on, though `gamma` is a gene row in both.

`--sort-by-transcript` does not sort, it selects which of the two kinds of row is written; the order is the same either way, and it is the dictionary's contig index, then the start, then the key as a string, which is what separates the two genes that begin at 300.

Golden pending: to be produced by the pinned oracle container on an x86-64 runner, then landed by the follow-up commit.

Part of #611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)