### PR TITLE
Measure ComposeSTRTableFile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,10 @@ jobs:
             index: "46/46"
             slug: "collect-f1r2-counts-filter-funcotations-pathseq-build-reference-taxonomy-pathseq-build-kmers-gtf-to-bed"
             suites: "collect-f1r2-counts filter-funcotations pathseq-build-reference-taxonomy pathseq-build-kmers gtf-to-bed"
+          - group: golden-pending
+            index: "1/1"
+            slug: "compose-str-table-file"
+            suites: "compose-str-table-file"
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 141 | 45.3% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 158 | 50.8% |
+| not started | 157 | 50.5% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (93 of 190 started)
+## gatk-origin tools (94 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -111,6 +111,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CompareBaseQualities` | reporting-walker | oracle-backed | compare-base-qualities | 1 | not measured |
 | `CompareIntervalLists` | unclassified | oracle-backed | compare-interval-lists | 1 | not measured |
 | `CompareReferences` | reference-utility | oracle-backed | compare-references | 1 | not measured |
+| `ComposeSTRTableFile` | reference-utility | golden-pending | compose-str-table-file | 1 | not measured |
 | `Concordance` | variant-walker | oracle-backed | concordance-annotated-vcfs, concordance-filter-analysis, concordance-summary | 3 | not measured |
 | `CondenseDepthEvidence` | unclassified | oracle-backed | condense-depth-evidence | 1 | not measured |
 | `ConvertHeaderlessHadoopBamShardToBam` | record-transform | oracle-backed | convert-headerless-shard | 1 | not measured |
@@ -183,9 +184,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>97 not started</summary>
+<details><summary>96 not started</summary>
 
-`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `ComposeSTRTableFile`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AddFlowBaseQuality`, `AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CRAMIssue8768Detector`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `FuncotatorDataSourceDownloader`, `GeneExpressionEvaluation`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5421,6 +5421,26 @@
           "why": "Six runs over one GTF of four genes on two contigs: gene rows, transcript rows, each again with --use-basic-transcript, a run with no dictionary and a run whose dictionary is missing a contig. The first gene's transcript reaches past it at both ends, two genes start at the same position so their order is settled by their ids, and one transcript carries the basic tag twice. Each run is reported by its whole output. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32645294319, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "compose-str-table-file",
+      "status": "golden-pending",
+      "title": "a reference scanned for short tandem repeats",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "ComposeSTRTableFile"
+      ],
+      "why": "EVERY POSITION IS TRIED AS THE START OF A REPEAT UNIT and the scan JUMPS TO THE END of a site it finds, so no position is looked at twice, BUT THE SITES STILL OVERLAP because the search reaches BACKWARDS: a homopolymer ending at 9 and a dinucleotide repeat beginning at 9 are both reported. THE BEST PERIOD IS THE ONE WITH THE MOST REPEATS, ties going to the SHORTER period, and the repeat count is an INTEGER DIVISION of the span by the period. PERIOD ONE IS SPECIAL-CASED and is the only period tried when the base is not ACGT, in which case NOTHING is emitted, which is why an N leaves a gap. THE MASK IS A PER-CONTIG COUNTER PER PERIOD AND REPEAT, INITIALISED TO THE CONTIG'S INDEX rather than to zero, so the first site of the second contig carries mask 1. DECIMATION IS A BIT TEST between that mask and the table's entry, so it keeps one site in every 2^n rather than a fraction, and under the default table the second contig's homopolymer is the one that goes. --max-repeat CAPS THE INDEX THE MASK COUNTER IS KEPT UNDER, not the repeat reported, so lowering it makes distinct sites share a counter, CHANGES THE MASKS and therefore changes which sites decimation removes. --max-period CAPS THE SEARCH, so a region whose true period is longer breaks into one site per base when period one with a single repeat is all that is left. -L RESTRICTS WHERE THE SCAN STARTS BUT NOT HOW FAR A SITE REACHES, so a site can begin before the interval and end after it. AND THE SUMMARY COUNTS BOTH WHAT WAS EMITTED AND WHAT WAS DECIMATED.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "ComposeSTRTableFileDump",
+          "golden": null,
+          "why": "Five runs over two contigs carrying a homopolymer, a dinucleotide repeat, a trinucleotide repeat, an N, a second homopolymer, a four-base repeat and a tail: the default decimation table, no decimation at all, a maximum period of two, a maximum repeat of three, and an interval that starts and ends inside repeats. Each run is reported by its whole sites table and its whole summary. Golden pending: to be produced by the pinned oracle container on an x86-64 CI runner."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/ComposeSTRTableFileDump.java
+++ b/tools/readfilter-conformance/ComposeSTRTableFileDump.java
@@ -1,0 +1,155 @@
+/*
+ * ComposeSTRTableFile's output, taken from the reference.
+ *
+ * A reference scanned for short tandem repeats, every site reported with the period and the number
+ * of repeats that fit it best. The output is a zip; what is printed here is its sites table and its
+ * summary.
+ *
+ * Eleven behaviours this is built to catch.
+ *
+ *   - EVERY POSITION IS TRIED AS THE START OF A REPEAT UNIT, and when one is found THE SCAN JUMPS
+ *     TO ITS END, so no position is looked at twice;
+ *   - BUT THE SITES STILL OVERLAP, because the search reaches BACKWARDS from the position it
+ *     started at: a homopolymer ending at 9 and a dinucleotide repeat beginning at 9 are both
+ *     reported, sharing that base;
+ *   - THE BEST PERIOD IS THE ONE WITH THE MOST REPEATS, ties going to the SHORTER period, and the
+ *     repeat count is an INTEGER DIVISION of the span by the period, so trailing bases that do not
+ *     complete a unit are inside the interval and count for nothing;
+ *   - PERIOD ONE IS SPECIAL-CASED and is the only period tried when the base at the position is
+ *     not ACGT, in which case NOTHING is emitted at all, which is why an N leaves a gap;
+ *   - A PERIOD IS ABANDONED AS SOON AS ITS UNIT CONTAINS A NON-STANDARD BASE;
+ *   - THE MASK IS A PER-CONTIG COUNTER PER PERIOD AND REPEAT, initialised to the CONTIG'S INDEX
+ *     rather than to zero, so the first site of the second contig carries mask 1;
+ *   - DECIMATION IS A BIT TEST between that mask and the table's entry for the period and repeat,
+ *     so it keeps one site in every 2^n rather than a fraction, and under the default table the
+ *     second contig's homopolymer is the one that goes;
+ *   - --max-repeat CAPS THE INDEX THE MASK COUNTER IS KEPT UNDER, not the repeat reported, so
+ *     lowering it makes distinct sites share a counter and CHANGES THE MASKS, and therefore which
+ *     sites decimation removes;
+ *   - --max-period CAPS THE SEARCH, so a region whose true period is longer breaks into whatever
+ *     shorter period won, one site per base when that is period one with a single repeat;
+ *   - -L RESTRICTS WHERE THE SCAN STARTS BUT NOT HOW FAR A SITE REACHES, so a site can begin before
+ *     the interval and end after it;
+ *   - AND THE SUMMARY COUNTS BOTH WHAT WAS EMITTED AND WHAT WAS DECIMATED, per period and repeat.
+ *
+ * Output:
+ *
+ *     fixture\tchr1=<the sequence>
+ *     sites\t<label>=<the whole sites table, escaped>
+ *     summary\t<label>=<the whole summary, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: ComposeSTRTableFileDump
+ */
+
+import org.broadinstitute.hellbender.tools.dragstr.ComposeSTRTableFile;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class ComposeSTRTableFileDump {
+
+    /**
+     * One contig carrying a homopolymer, a dinucleotide repeat, a trinucleotide repeat, an N, a
+     * second homopolymer, a four-base repeat and a short tail.
+     */
+    static final String CHR1 = "AAAAAAAA"
+            + "ACACACACACACACAC"
+            + "GTCGTCGTCGTC"
+            + "N"
+            + "TTTTTTTT"
+            + "ACGTACGTACGTACG"
+            + "CCCCC";
+
+    /** A second contig, so the mask's per-contig initial value is visible. */
+    static final String CHR2 = "GGGGGGGGTATATATATA";
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("compose-str-table-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# ComposeSTRTableFileDump: a reference scanned for short tandem repeats");
+        System.out.printf("fixture\tchr1=%s%n", CHR1);
+        System.out.printf("fixture\tchr2=%s%n", CHR2);
+
+        final Path fasta = writeReference(dir);
+
+        run(dir, "default", fasta, "DEFAULT", 8, 20);
+        run(dir, "no-decimation", fasta, "NONE", 8, 20);
+        run(dir, "max-period-two", fasta, "NONE", 2, 20);
+        run(dir, "max-repeat-three", fasta, "NONE", 8, 3);
+        run(dir, "interval", fasta, "NONE", 8, 20, "-L", "chr1:20-40");
+    }
+
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("str.fasta");
+        Files.writeString(fasta, ">chr1\n" + CHR1 + "\n>chr2\n" + CHR2 + "\n",
+                StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        new picard.sam.CreateSequenceDictionary().instanceMain(new String[] {
+                "R=" + fasta, "O=" + dir.resolve("str.dict")});
+        return fasta;
+    }
+
+    static void run(final Path dir, final String label, final Path fasta, final String decimation,
+                    final int maxPeriod, final int maxRepeat, final String... extra)
+            throws Exception {
+        final Path out = dir.resolve(label + ".zip");
+        final List<String> argv = new ArrayList<>(Arrays.asList(
+                "-R", fasta.toString(),
+                "-O", out.toString(),
+                "--decimation", decimation,
+                "--max-period", Integer.toString(maxPeriod),
+                "--max-repeats", Integer.toString(maxRepeat),
+                "--generate-sites-text-output", "true"));
+        argv.addAll(Arrays.asList(extra));
+        try {
+            new ComposeSTRTableFile().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+            return;
+        }
+        final Map<String, String> entries = unzip(out);
+        for (final String name : List.of("sites.txt", "summary.txt")) {
+            final String content = entries.get(name);
+            if (content != null) {
+                System.out.printf("%s\t%s=%s%n", name.replace(".txt", ""), label,
+                        ReferenceQueryDump.escape(masked(content, dir)));
+            }
+        }
+    }
+
+    /** Every entry of the zip, keyed by name. */
+    static Map<String, String> unzip(final Path archive) throws Exception {
+        final Map<String, String> entries = new TreeMap<>();
+        try (final InputStream raw = Files.newInputStream(archive);
+             final ZipInputStream zip = new ZipInputStream(raw)) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                zip.transferTo(bytes);
+                entries.put(entry.getName(), bytes.toString(StandardCharsets.UTF_8));
+            }
+        }
+        return entries;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
A reference scanned for short tandem repeats, every site reported with the period and the number of repeats that fit it best. The output is a zip; the dump reads its sites table and its summary back out.

Five runs over two contigs carrying a homopolymer, a dinucleotide repeat, a trinucleotide repeat, an `N`, a second homopolymer, a four-base repeat and a tail.

The scan jumps to the end of every site it finds, so no position is looked at twice, but the sites still overlap: the search reaches backwards from the position that started it, so a homopolymer ending at 9 and a dinucleotide repeat beginning at 9 are both reported and share that base.

Three findings the reading did not give.

**The mask is initialised to the contig's index**, not to zero. The first site of the second contig therefore carries mask 1, and under the default decimation table that is exactly what removes it: the same homopolymer on the first contig is kept.

`--max-repeat` caps the index the counter is kept under rather than the repeat reported, so lowering it makes distinct sites share a counter. The masks change, and with them which sites decimation removes: the second homopolymer of contig one carries mask 0 at the default and mask 1 at a maximum repeat of three.

And `-L` restricts where the scan starts, not how far a site reaches. An interval of 20 to 40 reports a site beginning at 9 and another ending at 45.

Golden pending: to be produced by the pinned oracle container on an x86-64 runner, then landed by the follow-up commit.

Part of #554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)