### PR TITLE
Let the workflow own the action pins the generator reads

### DIFF
--- a/tools/conformance/generate_ci.py
+++ b/tools/conformance/generate_ci.py
@@ -18,6 +18,7 @@ Usage:
 """
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -179,6 +180,32 @@ def oracle_jobs(manifest):
     return "\n".join(out)
 
 
+# `uses: owner/action@ref`, over the two shapes the workflow writes: a step that is only a `uses`,
+# and one that names itself first.
+USES = re.compile(r"(?P<lead>uses: )(?P<action>[\w.-]+/[\w./-]+)@(?P<ref>\S+)")
+
+
+def repin(rendered, current):
+    """Take every action ref from the committed workflow rather than from the template.
+
+    The generator owns the job matrix. It does not own which version of `actions/checkout` runs,
+    because `.github/workflows/` is the only place Dependabot can write, and a ref hard-coded here
+    would make every grouped actions bump fail this file's own `--check`.
+
+    An action pinned to two different refs in the committed file is left alone, so that
+    disagreement reaches the guard as a diff instead of being quietly resolved to one of them.
+    """
+    seen = {}
+    for match in USES.finditer(current):
+        seen.setdefault(match.group("action"), set()).add(match.group("ref"))
+    pins = {action: refs.pop() for action, refs in seen.items() if len(refs) == 1}
+    return USES.sub(
+        lambda m: m.group("lead") + m.group("action") + "@"
+        + pins.get(m.group("action"), m.group("ref")),
+        rendered,
+    )
+
+
 def render(manifest):
     template = TEMPLATE.read_text()
     if MARKER not in template:
@@ -197,10 +224,10 @@ def main(argv):
     args = ap.parse_args(argv)
 
     manifest = comparator.load_manifest()
-    rendered = render(manifest)
+    current = WORKFLOW.read_text() if WORKFLOW.exists() else ""
+    rendered = repin(render(manifest), current)
 
     if args.check:
-        current = WORKFLOW.read_text() if WORKFLOW.exists() else ""
         if current != rendered:
             print("ci.yml is stale: regenerate with tools/conformance/generate_ci.py")
             import difflib


### PR DESCRIPTION
The first grouped actions bump ([#855](https://github.com/IPNP-BIPN/gatk-rs/pull/855)) failed `Repository invariants`, and it was right to. `ci.yml` is generated from `manifest.json`; the action refs in it were written into `generate_ci.py`; and `.github/workflows/` is the only place Dependabot can write. So the bump arrived as a file the generator immediately disagreed with, and `generate_ci.py --check` called the workflow stale when nothing about the manifest had moved.

The generator owns the job matrix. It does not own which version of `actions/checkout` runs. The refs are now read back out of the committed workflow and substituted into the rendered text, so a bump is self-consistent while the guard still compares the jobs, their names, their steps and the suites they come from byte for byte.

An action pinned to two different refs in the committed file is left alone rather than quietly resolved to one of them, so a half-applied bump still reaches the guard as a diff.

Verified both directions locally:

* every `actions/checkout` moved to `v7`, `--check` exits 0;
* one occurrence left behind at `v4`, `--check` exits 1 and names the line.

`tools/preflight.py` exits 0. Once this is on main, #855 needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)