### PR TITLE
Queue Dependabot's bumps behind one generated gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,3 +515,42 @@ jobs:
             echo "pairwise sizing changed; update docs/what-pairwise-coverage-costs.md"
             exit 1
           }
+
+  ci:
+    name: CI complete
+    # The single context main's ruleset requires, and the single context an automatic merge waits
+    # on. It runs whatever the jobs above did, because a gate that is skipped when something fails
+    # reports nothing and blocks nothing.
+    needs:
+      - guard
+      - test
+      - determinism
+      - oracle-image
+      - oracle
+      - inventory
+      - dashboard
+      - coverage
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Every job above succeeded
+        # A skipped job is not a failure. A cancelled one is: a cancelled run has proved nothing,
+        # and `success` on an empty result is how a green tick comes to mean less than it looks.
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          results = json.loads(os.environ["RESULTS"])
+          bad = sorted(
+              name for name, job in results.items()
+              if job["result"] not in ("success", "skipped")
+          )
+          for name in bad:
+              print(f"{name}: {results[name]['result']}")
+          print(f"{len(results) - len(bad)}/{len(results)} jobs green")
+          sys.exit(1 if bad else 0)
+          PY

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,45 @@
+# Dependabot's pull requests, queued behind CI rather than merged by hand.
+#
+# `--auto` does NOT mean "merge when the checks pass" on its own. It means "merge as soon as
+# nothing blocks", and on an unprotected branch nothing does, so it would merge immediately. What
+# makes it wait is the ruleset on main requiring the `CI complete` context, which the generated
+# workflow produces once every other job has reported. Remove that rule and this file stops being
+# a queue and becomes a rubber stamp.
+#
+# Majors are left alone. A major is a decision: it can change an API, a default, or the bytes a
+# golden pins, and the conformance suite passing tells you the bytes held, not that the change was
+# the one you wanted. Everything below a major is what the suite is good at judging.
+#
+# pull_request_target runs this file as it stands on main and never checks out the branch under
+# test, so the write token here is never handed to code from the pull request.
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  queue:
+    name: Queue the bump behind CI
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Queue everything but a major
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --merge --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Say why a major was left alone
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: echo "$NAMES is a major bump, left for a human"

--- a/tools/conformance/generate_ci.py
+++ b/tools/conformance/generate_ci.py
@@ -206,6 +206,60 @@ def repin(rendered, current):
     )
 
 
+GATE = "ci"
+
+# A job id: two spaces, a name, a colon, nothing else on the line. Job keys sit at four spaces, so
+# this cannot match one of them.
+JOB_ID = re.compile(r"^  (?P<id>[a-z][\w-]*):$", re.M)
+
+
+def gate_job(rendered):
+    """Append the one check that stands for the whole run.
+
+    The oracle matrix names a check per suite, so a required-checks list written by hand would go
+    stale the moment a suite is added, and a branch rule built on it would be guarding a set of
+    jobs that no longer exists. This job needs every other one and is generated alongside them,
+    which is what keeps the list honest with nobody maintaining it.
+    """
+    body = rendered.split("\njobs:\n", 1)[1]
+    ids = [match.group("id") for match in JOB_ID.finditer(body) if match.group("id") != GATE]
+    needs = "\n".join(f"      - {job}" for job in ids)
+    return rendered.rstrip("\n") + f"""
+
+  {GATE}:
+    name: CI complete
+    # The single context main's ruleset requires, and the single context an automatic merge waits
+    # on. It runs whatever the jobs above did, because a gate that is skipped when something fails
+    # reports nothing and blocks nothing.
+    needs:
+{needs}
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Every job above succeeded
+        # A skipped job is not a failure. A cancelled one is: a cancelled run has proved nothing,
+        # and `success` on an empty result is how a green tick comes to mean less than it looks.
+        env:
+          RESULTS: ${{{{ toJSON(needs) }}}}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          results = json.loads(os.environ["RESULTS"])
+          bad = sorted(
+              name for name, job in results.items()
+              if job["result"] not in ("success", "skipped")
+          )
+          for name in bad:
+              print(f"{{name}}: {{results[name]['result']}}")
+          print(f"{{len(results) - len(bad)}}/{{len(results)}} jobs green")
+          sys.exit(1 if bad else 0)
+          PY
+"""
+
+
 def render(manifest):
     template = TEMPLATE.read_text()
     if MARKER not in template:
@@ -225,7 +279,7 @@ def main(argv):
 
     manifest = comparator.load_manifest()
     current = WORKFLOW.read_text() if WORKFLOW.exists() else ""
-    rendered = repin(render(manifest), current)
+    rendered = gate_job(repin(render(manifest), current))
 
     if args.check:
         if current != rendered:


### PR DESCRIPTION
Auto-merge for Dependabot, and the two things it needs before it means anything.

`gh pr merge --auto` does not mean "merge when the checks pass". It means "merge as soon as nothing blocks", and `main` is not protected in this repository, so today it would merge on the spot. So this adds:

* **`ci` / `CI complete`**, generated by `generate_ci.py` with a `needs` on every other job. The oracle matrix names one check per suite, 47 of them right now, so a required-checks list written by hand would go stale the moment a suite is added. Generating it is what keeps the list honest with nobody maintaining it. It runs `if: always()` and fails on any result that is not `success` or `skipped`, so a cancelled job blocks rather than passing quietly.
* **`.github/workflows/dependabot-auto-merge.yml`**, which enables auto-merge on Dependabot's pull requests and nothing else. Majors are excluded: a major can change an API, a default, or the bytes a golden pins, and a green suite tells you the bytes held, not that the change was the one you wanted.

`pull_request_target` runs the file as it stands on main and never checks out the branch under test, so the write token is never handed to code from the pull request.

Once this is on main, two repository settings follow and are not in the diff: `allow_auto_merge`, and a ruleset on `main` requiring the `CI complete` context. Without that rule the workflow is a rubber stamp, which is why the file says so at the top.

`tools/preflight.py` exits 0, and `generate_ci.py --check` exits 0 against the regenerated file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)