### PR TITLE
Measure SVStratify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,10 @@ jobs:
             index: "47/47"
             slug: "compose-str-table-file-cram-issue-8768-detector-add-flow-base-quality-gene-expression-evaluation-funcotator-data-source-downloader"
             suites: "compose-str-table-file cram-issue-8768-detector add-flow-base-quality gene-expression-evaluation funcotator-data-source-downloader"
+          - group: golden-pending
+            index: "1/1"
+            slug: "sv-stratify"
+            suites: "sv-stratify"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 146 | 46.9% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 153 | 49.2% |
+| not started | 152 | 48.9% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (98 of 190 started)
+## gatk-origin tools (99 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -172,6 +172,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ReferenceBlockConcordance` | unclassified | oracle-backed | reference-block-concordance | 1 | not measured |
 | `RemoveNearbyIndels` | variant-transform | oracle-backed | remove-nearby-indels | 1 | not measured |
 | `RevertBaseQualityScores` | record-transform | oracle-backed | record-transform | 1 | not measured |
+| `SVStratify` | sv-caller | golden-pending | sv-stratify | 1 | not measured |
 | `SelectVariants` | variant-transform | oracle-backed | select-variants-concordance, select-variants-filters, select-variants-output, select-variants-samples, select-variants-subset | 5 | not measured |
 | `ShiftFasta` | reference-utility | oracle-backed | shift-fasta | 1 | not measured |
 | `SiteDepthtoBAF` | sv-caller | oracle-backed | site-depth-to-baf | 1 | not measured |
@@ -188,9 +189,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>92 not started</summary>
+<details><summary>91 not started</summary>
 
-`AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `SVStratify`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5521,6 +5521,26 @@
           "why": "Eighteen runs against a hand-written one-entry tar.gz and six spellings of its sha256, through the tool's own testing override so the bucket is never reached: an explicit destination, a missing one, the default one, four checksum spellings that all have to match, a wrong checksum, an empty checksum file, an existing destination with and without --overwrite-output-file, extraction, and six argument refusals. The four bucket paths and the constants they are built from are reported beside the runs. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32959158621, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "sv-stratify",
+      "status": "golden-pending",
+      "title": "structural variants sorted into strata",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "SVStratify"
+      ],
+      "why": "THE STRATA ARE HELD IN A java.util.HashMap, so the order a record's matches come back in, the order the refusal message lists them, and the order the split-output files are created are all HashMap iteration order over the stratum NAMES rather than the configuration's order. MIN IS INCLUSIVE AND MAX IS EXCLUSIVE. A RECORD WITH NO LENGTH MATCHES ONLY A STRATUM WITH NEITHER BOUND, which is how BND and INS records reach a stratum at all. `-1` IS THE ONLY NEGATIVE THAT MEANS NULL, the null set being {\"-1\", \"\", \"NULL\", \"NA\"}, so -2 parses as a number and is then refused as a negative bound. AN INSERTION IGNORES BOTH THE OVERLAP FRACTION AND --stratify-num-breakpoint-overlaps and requires exactly ONE end in a track. A BREAKPOINT COUNTS ONCE PER END, NOT ONCE PER TRACK. THE OVERLAP FRACTION IS MEASURED AGAINST THE MERGED UNION OF EVERY NAMED TRACK and compared with >=. BND AND CTX CANNOT CARRY A SIZE. THE COLUMN-COUNT MESSAGE PRINTS THE SAME NUMBER TWICE, both halves of it reading columns.columnCount(), so an extra column is reported as \"Expected 6 columns but found 6\". WITHOUT --split-output EVERY STRATUM WRITES TO THE SAME FILE, so a record matching two strata under --allow-multiple-matches appears TWICE with two different STRAT values. AND THE RESERVED NAME default IS REFUSED IN THE CONFIG.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "SVStratifyDump",
+          "golden": null,
+          "why": "Seven structural variants over two reference tracks and six strata, run nine ways and refused eleven: the default, two overlap fractions, two required breakpoints, multiple matches allowed and refused, split output both ways, and every configuration and argument refusal the engine has. The tracks, the configuration tables and the whole input VCF are reported beside the outputs."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/SVStratifyDump.java
+++ b/tools/readfilter-conformance/SVStratifyDump.java
@@ -1,0 +1,324 @@
+/*
+ * SVStratify's strata, taken from the reference.
+ *
+ * Structural variants sorted into groups by type, size and reference-track overlap. What a stratum
+ * matches is three independent tests, and two of the three ignore some of the thresholds they are
+ * handed.
+ *
+ * Ten behaviours this is built to catch.
+ *
+ *   - MIN IS INCLUSIVE AND MAX IS EXCLUSIVE, so a stratum of [1000, 5000) takes a 1000 bp deletion
+ *     and refuses a 5000 bp one;
+ *   - A RECORD WITH NO LENGTH MATCHES ONLY A STRATUM WITH NEITHER BOUND, whatever its type, which
+ *     is how BND records reach a stratum at all;
+ *   - `-1` IS THE ONLY NEGATIVE THAT MEANS NULL: the null set is {"-1", "", "NULL", "NA"}, so -2
+ *     parses as a number and is then refused as a negative bound;
+ *   - AN INSERTION IGNORES --stratify-num-breakpoint-overlaps and requires exactly ONE end in a
+ *     track, whatever the argument said;
+ *   - A BREAKPOINT COUNTS ONCE PER END, NOT ONCE PER TRACK: countAnyTrackOverlap returns 1 as soon
+ *     as any track overlaps, so two tracks over one end still count one;
+ *   - THE OVERLAP FRACTION IS MEASURED AGAINST THE MERGED UNION OF EVERY NAMED TRACK, and compared
+ *     with >=, so a stratum naming two tracks is easier to match than either alone;
+ *   - BND AND CTX CANNOT CARRY A SIZE, and a config that gives them one is refused by name;
+ *   - THE COLUMN-COUNT MESSAGE PRINTS THE SAME NUMBER TWICE, because both halves of it read
+ *     columns.columnCount();
+ *   - WITHOUT --split-output EVERY STRATUM WRITES TO THE SAME FILE, so a record matching two
+ *     strata under --allow-multiple-matches appears TWICE, once per stratum name;
+ *   - AND THE RESERVED NAME `default` IS REFUSED IN THE CONFIG, because it is the group unmatched
+ *     records go to.
+ *
+ * Output:
+ *
+ *     config\t<label>=<the whole stratification table, escaped>
+ *     track\t<name>=<the whole bed, escaped>
+ *     vcf\tinput=<the whole input vcf, escaped>
+ *     out\t<label>\t<file name>=<the whole output vcf, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: SVStratifyDump
+ */
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.tools.walkers.sv.SVStratify;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class SVStratifyDump {
+
+    /**
+     * Two tracks over chr1, chosen so that one variant's ends land in different tracks.
+     *
+     * RM covers the left half of the measured deletions and SD the right, which is what separates
+     * a stratum naming one track from a stratum naming both.
+     */
+    static final String RM_BED = String.join("\n",
+            "chr1\t900\t1100",
+            "chr1\t4900\t5100",
+            "");
+
+    static final String SD_BED = String.join("\n",
+            "chr1\t1900\t2100",
+            "chr1\t2500\t3500",
+            "");
+
+    /** The strata every successful run is measured against. */
+    static final String CONFIG = String.join("\n",
+            "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE\tTRACKS",
+            "DEL_small_RM\tDEL\t-1\t5000\tRM",
+            "DEL_large_RM\tDEL\t5000\t-1\tRM",
+            "DEL_small_both\tDEL\t-1\t5000\tRM,SD",
+            "DUP_any\tDUP\t-1\t-1\t-1",
+            "INS_RM\tINS\t-1\t-1\tRM",
+            "BND_RM\tBND\t-1\t-1\tRM",
+            "");
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("sv-stratify-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# SVStratifyDump: structural variants sorted into strata");
+
+        final Path dict = writeDictionary(dir);
+        final Path rm = write(dir, "rm.bed", RM_BED);
+        final Path sd = write(dir, "sd.bed", SD_BED);
+        System.out.printf("track\tRM=%s%n", ReferenceQueryDump.escape(RM_BED));
+        System.out.printf("track\tSD=%s%n", ReferenceQueryDump.escape(SD_BED));
+
+        final Path config = write(dir, "strata.tsv", CONFIG);
+        System.out.printf("config\tmain=%s%n", ReferenceQueryDump.escape(CONFIG));
+
+        final String vcf = buildVcf();
+        final Path input = write(dir, "input.vcf", vcf);
+        System.out.printf("vcf\tinput=%s%n", ReferenceQueryDump.escape(vcf));
+
+        final List<String> tracks = List.of(
+                "--track-name", "RM", "--track-intervals", rm.toString(),
+                "--track-name", "SD", "--track-intervals", sd.toString());
+
+        // The default: one output file, the breakpoint threshold at one and no overlap fraction.
+        run(dir, "default", input, dict, config, tracks, List.of(), false);
+        // The same with the overlap fraction raised, which is the test the breakpoint count does
+        // not make.
+        run(dir, "overlap-half", input, dict, config, tracks,
+                List.of("--stratify-overlap-fraction", "0.5"), false);
+        run(dir, "overlap-full", input, dict, config, tracks,
+                List.of("--stratify-overlap-fraction", "1.0"), false);
+        // Two breakpoints required, which an insertion still ignores.
+        run(dir, "two-breakpoints", input, dict, config, tracks,
+                List.of("--stratify-num-breakpoint-overlaps", "2"), false);
+        // Multiple matches, allowed and refused.
+        run(dir, "multiple-allowed", input, dict, config, tracks,
+                List.of("--allow-multiple-matches", "true"), false);
+        run(dir, "multiple-refused", input, dict, config, tracks, List.of(), false);
+        // One file per stratum, which is the only mode where the stratum's own writer is used.
+        // Refused on the first record, which still leaves every file created and headed.
+        run(dir, "split", input, dict, config, tracks,
+                List.of("--split-output", "true", "--output-prefix", "strat"), true);
+        // And the same allowing multiple matches, which is where the records actually land in
+        // more than one file.
+        run(dir, "split-allowed", input, dict, config, tracks,
+                List.of("--split-output", "true", "--output-prefix", "strat",
+                        "--allow-multiple-matches", "true"), true);
+
+        // The configuration refusals, each its own table.
+        refuse(dir, "reserved-name", input, dict, tracks, String.join("\n",
+                "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE\tTRACKS",
+                "default\tDEL\t-1\t-1\tRM",
+                ""));
+        refuse(dir, "unknown-track", input, dict, tracks, String.join("\n",
+                "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE\tTRACKS",
+                "DEL_XX\tDEL\t-1\t-1\tXX",
+                ""));
+        refuse(dir, "negative-min", input, dict, tracks, String.join("\n",
+                "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE\tTRACKS",
+                "DEL_neg\tDEL\t-2\t5000\tRM",
+                ""));
+        refuse(dir, "min-over-max", input, dict, tracks, String.join("\n",
+                "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE\tTRACKS",
+                "DEL_bad\tDEL\t5000\t1000\tRM",
+                ""));
+        refuse(dir, "bnd-with-size", input, dict, tracks, String.join("\n",
+                "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE\tTRACKS",
+                "BND_sized\tBND\t100\t5000\tRM",
+                ""));
+        refuse(dir, "extra-column", input, dict, tracks, String.join("\n",
+                "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE\tTRACKS\tEXTRA",
+                "DEL_x\tDEL\t-1\t-1\tRM\tx",
+                ""));
+        refuse(dir, "missing-column", input, dict, tracks, String.join("\n",
+                "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE",
+                "DEL_x\tDEL\t-1\t-1",
+                ""));
+
+        // A duplicate track name, and a count mismatch between names and files.
+        run(dir, "duplicate-track", input, dict, config, List.of(
+                "--track-name", "RM", "--track-intervals", rm.toString(),
+                "--track-name", "RM", "--track-intervals", sd.toString()), List.of(), false);
+        run(dir, "track-count-mismatch", input, dict, config, List.of(
+                "--track-name", "RM", "--track-intervals", rm.toString(),
+                "--track-name", "SD"), List.of(), false);
+
+        // Both thresholds at zero, which the engine refuses rather than matching everything.
+        run(dir, "both-thresholds-zero", input, dict, config, tracks,
+                List.of("--stratify-overlap-fraction", "0", "--stratify-num-breakpoint-overlaps",
+                        "0"), false);
+    }
+
+    /**
+     * The measured variants.
+     *
+     * The deletions differ in where their ends fall and how long they are; the duplication carries
+     * no track at all in its stratum; the insertion has no length of its own; and the breakend has
+     * neither length nor a second contig on chr1.
+     */
+    static String buildVcf() {
+        final List<String> lines = new ArrayList<>(List.of(
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=100000>",
+                "##contig=<ID=chr2,length=100000>",
+                "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type\">",
+                "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length\">",
+                "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End\">",
+                "##INFO=<ID=CHR2,Number=1,Type=String,Description=\"Second contig\">",
+                "##INFO=<ID=END2,Number=1,Type=Integer,Description=\"Second position\">",
+                "##INFO=<ID=STRANDS,Number=1,Type=String,Description=\"Strands\">",
+                "##INFO=<ID=ALGORITHMS,Number=.,Type=String,Description=\"Algorithms\">",
+                "##ALT=<ID=DEL,Description=\"Deletion\">",
+                "##ALT=<ID=DUP,Description=\"Duplication\">",
+                "##ALT=<ID=INS,Description=\"Insertion\">",
+                "##ALT=<ID=BND,Description=\"Breakend\">",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"));
+        // Both ends in RM, 4001 long: small, and its interval covers only a little of any track.
+        lines.add(record("del_small_rm", 1000, "DEL", 5000, 4001, null, null));
+        // Both ends in RM as well but long enough for the large stratum.
+        lines.add(record("del_large_rm", 1000, "DEL", 9000, 8001, null, null));
+        // One end in RM and the other in SD, which is the record that matches two strata.
+        lines.add(record("del_both", 1000, "DEL", 2000, 1001, null, null));
+        // Neither end in any track.
+        lines.add(record("del_no_track", 20000, "DEL", 21000, 1001, null, null));
+        // A duplication, whose stratum names no track at all.
+        lines.add(record("dup_any", 30000, "DUP", 31000, 1001, null, null));
+        // An insertion, which has one locus and no length.
+        lines.add("chr1\t1000\tins_rm\tN\t<INS>\t.\t.\t"
+                + "SVTYPE=INS;END=1000;SVLEN=-1;ALGORITHMS=depth");
+        // A breakend from chr1 into chr2, which has no length either.
+        lines.add("chr1\t1000\tbnd_rm\tN\t<BND>\t.\t.\t"
+                + "SVTYPE=BND;END=1000;CHR2=chr2;END2=5000;STRANDS=+-;ALGORITHMS=depth");
+        lines.add("");
+        return String.join("\n", lines);
+    }
+
+    static String record(final String id, final int start, final String type, final int end,
+                         final int length, final String contig2, final Integer end2) {
+        // ALGORITHMS is not optional: SVCallRecordUtils.create refuses a record without it.
+        final StringBuilder info = new StringBuilder("SVTYPE=" + type + ";END=" + end
+                + ";SVLEN=" + length + ";ALGORITHMS=depth");
+        if (contig2 != null) {
+            info.append(";CHR2=").append(contig2).append(";END2=").append(end2);
+        }
+        return "chr1\t" + start + "\t" + id + "\tN\t<" + type + ">\t.\t.\t" + info;
+    }
+
+    static void run(final Path dir, final String label, final Path input, final Path dict,
+                    final Path config, final List<String> tracks, final List<String> extra,
+                    final boolean split) throws Exception {
+        final Path output = split ? dir.resolve("split-" + label) : dir.resolve(label + ".vcf");
+        if (split) {
+            Files.createDirectories(output);
+        }
+        final List<String> argv = new ArrayList<>(List.of(
+                "-V", input.toString(),
+                "-O", output.toString(),
+                "--sequence-dictionary", dict.toString(),
+                "--stratify-config", config.toString()));
+        argv.addAll(tracks);
+        argv.addAll(extra);
+        invoke(dir, label, argv);
+        report(dir, label, output, split);
+    }
+
+    static void refuse(final Path dir, final String label, final Path input, final Path dict,
+                       final List<String> tracks, final String table) throws Exception {
+        final Path config = write(dir, label + ".tsv", table);
+        System.out.printf("config\t%s=%s%n", label, ReferenceQueryDump.escape(table));
+        run(dir, label, input, dict, config, tracks, List.of(), false);
+    }
+
+    static void invoke(final Path dir, final String label, final List<String> argv) {
+        try {
+            new SVStratify().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+        }
+    }
+
+    static void report(final Path dir, final String label, final Path output, final boolean split)
+            throws Exception {
+        if (!split) {
+            if (Files.exists(output)) {
+                System.out.printf("out\t%s\t%s=%s%n", label, output.getFileName(),
+                        ReferenceQueryDump.escape(masked(body(output), dir)));
+            }
+            return;
+        }
+        try (final Stream<Path> entries = Files.list(output)) {
+            for (final Path entry : entries.sorted(Comparator.comparing(Path::toString)).toList()) {
+                if (entry.toString().endsWith(".vcf.gz")) {
+                    System.out.printf("out\t%s\t%s=%s%n", label, entry.getFileName(),
+                            ReferenceQueryDump.escape(masked(body(entry), dir)));
+                }
+            }
+        }
+    }
+
+    /** A VCF without its header, which is where the stratum annotation lands. */
+    static String body(final Path path) throws Exception {
+        final String text = path.toString().endsWith(".gz")
+                ? new String(new java.util.zip.GZIPInputStream(
+                        Files.newInputStream(path)).readAllBytes(), StandardCharsets.UTF_8)
+                : Files.readString(path);
+        final StringBuilder out = new StringBuilder();
+        for (final String line : text.split("\n", -1)) {
+            if (!line.startsWith("##") && !line.isEmpty()) {
+                out.append(line).append("\n");
+            }
+        }
+        return out.toString();
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static Path writeDictionary(final Path dir) throws Exception {
+        final SAMSequenceDictionary dictionary = new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", 100000),
+                new SAMSequenceRecord("chr2", 100000)));
+        final Path path = dir.resolve("reference.dict");
+        final htsjdk.samtools.SAMFileHeader header = new htsjdk.samtools.SAMFileHeader();
+        header.setSequenceDictionary(dictionary);
+        try (final java.io.Writer writer = Files.newBufferedWriter(path)) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, header);
+        }
+        return path;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Seven structural variants over two reference tracks and six strata, run nine ways and refused eleven.

**The strata live in a `java.util.HashMap`.** So the order a record's matches come back in, the order the refusal message lists them, and the order the split-output files are created are all HashMap iteration order over the stratum *names*, not the configuration's order. The configuration declares `DEL_small_RM` before `DEL_small_both`; the refusal reads:

```
Record del_small_rm matched multiple groups: DEL_small_both, DEL_small_RM.
```

**Without `--split-output` every stratum writes to the same file.** A record matching two strata under `--allow-multiple-matches` therefore appears **twice**, same position, same ID, two different `STRAT` values. The golden carries both lines.

**An insertion ignores both thresholds.** `matchesTracks` short-circuits for INS to `matchesTrackBreakpointOverlap(record, 1)`, so neither `--stratify-overlap-fraction` nor `--stratify-num-breakpoint-overlaps` reaches it: at a fraction of 1.0 every deletion falls to `default` and the insertion still matches.

**The column-count message prints the same number twice**, because both halves of it read `columns.columnCount()`:

```
format error in '<dir>/extra-column.tsv' at line 1: Expected 6 columns but found 6
```

The rest: min is inclusive and max exclusive; a record with no length matches only a stratum with neither bound, which is how BND and INS reach a stratum at all; `-1` is the only negative that means null, so `-2` parses as a number and is then refused as a negative bound; a breakpoint counts once per end and not once per track; the overlap fraction is measured against the merged union of every named track; BND and CTX cannot carry a size; and the reserved name `default` is refused in the config.

`ALGORITHMS` is not optional in the input, which the fixture had to learn: `SVCallRecordUtils.create` refuses a record without it.

Ran twice in the pinned container and diffed: identical. The golden is `null` here and comes from this run's artefact.

Part of #637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)