### PR TITLE
Measure AddFlowSNVQuality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,10 @@ jobs:
             index: "48/48"
             slug: "sv-stratify"
             suites: "sv-stratify"
+          - group: golden-pending
+            index: "1/1"
+            slug: "add-flow-snv-quality"
+            suites: "add-flow-snv-quality"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 147 | 47.3% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 152 | 48.9% |
+| not started | 151 | 48.6% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,12 +85,13 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (99 of 190 started)
+## gatk-origin tools (100 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
 | `ASEReadCounter` | locus-walker | oracle-backed | ase-read-counter | 1 | not measured |
 | `AddFlowBaseQuality` | unclassified | oracle-backed | add-flow-base-quality | 1 | not measured |
+| `AddFlowSNVQuality` | flow-based | golden-pending | add-flow-snv-quality | 1 | not measured |
 | `AddOriginalAlignmentTags` | unclassified | oracle-backed | add-oa-tags | 1 | not measured |
 | `AnalyzeCovariates` | reporting-walker | oracle-backed | analyze-covariates | 1 | not measured |
 | `AnnotateIntervals` | cnv-segmentation | oracle-backed | annotate-intervals | 1 | not measured |
@@ -189,9 +190,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>91 not started</summary>
+<details><summary>90 not started</summary>
 
-`AddFlowSNVQuality`, `AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5541,6 +5541,26 @@
           "why": "Seven structural variants over two reference tracks and six strata, run nine ways and refused eleven: the default, two overlap fractions, two required breakpoints, multiple matches allowed and refused, split output both ways, and every configuration and argument refusal the engine has. The tracks, the configuration tables and the whole input VCF are reported beside the outputs. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 32981957600, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "add-flow-snv-quality",
+      "status": "golden-pending",
+      "title": "a probability for every base that was not called",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "AddFlowSNVQuality"
+      ],
+      "why": "THE COMPUTED BASE QUALITY IS DISCARDED: after the hmer loop fills baseProbs, the last loop overwrites EVERY entry with 1 - snvqProbs[calledIndex][ofs], which is itself 1 - sum of the alternate probabilities, and the reference's own comment on that line reads \"at this point, bq becomes trivial (?)\". THE PHRED CONVERSION ROUNDS where AddFlowBaseQuality TRUNCATES the same expression. THE SIDE WALK IS BOUNDED BY THE SLICE, which is the bound the sibling lacks, so a flow order whose cycle is ONE gets past the enumeration here; it then dies in the normalisation instead, because only the first base of the order is considered and a read carrying any other leaves calledIndex at -1, which indexes the array. The guard above it tests calledBase < 0, which an ASCII base never is, so it never fires. THE SNVQ MODE IS A CHOICE OF FOUR FORMULAE over the same two probabilities, Geometric being the default. THE ALT PROBABILITIES ARE KEYED BY BASE, NOT BY FLOW, so two side flows carrying the same base overwrite each other and the last wins. EVERY MIDDLE BASE OF AN HMER TAKES THE MINIMUM RATE, and the called base's own slot takes max(0, 1 - altP). --max-phred-score MOVES BOTH THE CLAMP AND THE FLOOR, and at 10 it is the FLOOR that decides: every base comes out at 5 rather than at the clamp. THE OUTPUT ATTRIBUTES ARE NAMED FOR THE FLOW ORDER, lower-cased and prefixed with q. AND --output-quality-attribute LEAVES QUAL ALONE.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "AddFlowSNVQualityDump",
+          "golden": null,
+          "why": "Six flow-based reads under a four-flow order, run seven ways, plus one read under a flow order whose cycle is one: the default Geometric mode, the three other snvq modes, two maximum phred scores, and the base quality written to a tag. Every read's flow key and the three raw probabilities the tool bands are reported beside the outputs, so the port computes the bands and the whole enumeration without a flow matrix of its own."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/AddFlowSNVQualityDump.java
+++ b/tools/readfilter-conformance/AddFlowSNVQualityDump.java
@@ -1,0 +1,278 @@
+/*
+ * AddFlowSNVQuality's qualities, taken from the reference.
+ *
+ * The sibling of AddFlowBaseQuality: the same enumeration over the ways a flow key could have been
+ * misread, but producing a probability for each of the three bases that were NOT called, and then
+ * throwing away the base quality it just computed.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - THE COMPUTED BASE QUALITY IS DISCARDED. After the hmer loop fills baseProbs, the last loop
+ *     overwrites EVERY entry with `1 - snvqProbs[calledIndex][ofs]`, which is itself
+ *     `1 - sum(alt probabilities)`. The reference's own comment reads "at this point, bq becomes
+ *     trivial (?)";
+ *   - THE PHRED CONVERSION ROUNDS, `(byte)Math.round(-10 * log10(p))`, where the sibling tool
+ *     TRUNCATES the same expression;
+ *   - THE SIDE WALK IS BOUNDED BY THE SLICE, `if (sideFlow < minIndex || sideFlow > maxIndex)
+ *     break`, which is exactly the bound AddFlowBaseQuality lacks, so a flow order whose cycle is
+ *     ONE runs here and throws there;
+ *   - THE SNVQ MODE IS A CHOICE OF FOUR FORMULAE over the same two probabilities: Legacy takes the
+ *     slice probability, Optimistic their product, Pessimistic one minus the product of the
+ *     complements, and Geometric the square root of the two, which is the default;
+ *   - THE ALT PROBABILITIES ARE KEYED BY BASE, NOT BY FLOW, so two side flows carrying the same
+ *     base overwrite each other in a LinkedHashMap and the LAST one wins;
+ *   - EVERY MIDDLE BASE OF AN HMER TAKES THE MINIMUM RATE rather than a computed one, and the
+ *     called base's own slot takes `max(0, 1 - altP)`;
+ *   - --max-phred-score MOVES BOTH THE CLAMP AND THE FLOOR, since it sets maxQualityScore and
+ *     minLikelihoodProbRate together;
+ *   - THE OUTPUT ATTRIBUTES ARE NAMED FOR THE FLOW ORDER, lower-cased and prefixed with q, so a
+ *     read group ordered TGCA writes qt, qg, qc and qa;
+ *   - AND --output-quality-attribute LEAVES QUAL ALONE, writing the base quality into a tag
+ *     instead, where the default overwrites QUAL.
+ *
+ * Output:
+ *
+ *     read\t<name>\tgroup=<rg>\tbases=<bases>\tqual=<phred string>\ttp=<comma separated>
+ *     group\t<rg>\torder=<flow order>\tmaxClass=<n>
+ *     flow\t<name>\tkey=<comma separated>\tmaxHmer=<n>
+ *     prob\t<name>\t<flow>\tminus=<double>\tkey=<double>\tplus=<double>
+ *     qual\t<label>\t<name>=<the quality string after the run>
+ *     attr\t<label>\t<name>\t<tag>=<the attribute>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: AddFlowSNVQualityDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.ValidationStringency;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+import org.broadinstitute.hellbender.tools.FlowBasedArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.featuremapping.AddFlowSNVQuality;
+import org.broadinstitute.hellbender.utils.read.FlowBasedRead;
+import org.broadinstitute.hellbender.utils.read.FlowBasedReadUtils;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AddFlowSNVQualityDump {
+
+    /** A four-flow order, whose four bases are the four output attributes. */
+    static final String FOUR = "TGCA";
+    /**
+     * A flow order whose first base repeats immediately. calcFlowOrderLength answers ONE, and this
+     * tool survives it where AddFlowBaseQuality throws, because its side walk stops at the slice.
+     */
+    static final String ONE = "TTGCA";
+
+    record Read(String name, String group, String bases, String quals, byte[] tp) { }
+
+    public static void main(final String[] args) throws Exception {
+        BlockCompressedOutputStream.setDefaultDeflaterFactory(new DeflaterFactory());
+
+        final Path dir = Path.of("add-flow-snv-quality-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# AddFlowSNVQualityDump: a probability for every base that was not called");
+
+        final List<Read> reads = List.of(
+                // Every hmer of length one, so every hmer walks both sides.
+                new Read("singles", "rg4", "TGCATGCA", "IIIIIIII", tp(8)),
+                // Hmers of length two, the shortest with a computed last base.
+                new Read("doubles", "rg4", "TTGGCCAA", "IIIIIIII", tp(8)),
+                // A five-base run, whose middle bases take the minimum rate.
+                new Read("long-hmer", "rg4", "TTTTTGCA", "IIIIIIII", tp(8)),
+                // A read opening on a zero flow.
+                new Read("leading-zero", "rg4", "GCATGCA", "IIIIIII", tp(7)),
+                // A read ending inside an hmer.
+                new Read("trailing-hmer", "rg4", "TGCAAAA", "IIIIIII", tp(7)),
+                // Qualities that differ per base, so the bands are not all equal.
+                new Read("varied-quality", "rg4", "TTGCAA", "I5+I5+", tp(6)));
+
+        final Path bam = dir.resolve("reads.bam");
+        writeBam(bam, reads);
+        describe(bam);
+
+        run(dir, "default", bam, List.of());
+        run(dir, "legacy", bam, List.of("--snvq-mode", "Legacy"));
+        run(dir, "optimistic", bam, List.of("--snvq-mode", "Optimistic"));
+        run(dir, "pessimistic", bam, List.of("--snvq-mode", "Pessimistic"));
+        // The clamp and the floor move together.
+        run(dir, "max-phred-20", bam, List.of("--max-phred-score", "20"));
+        run(dir, "max-phred-10", bam, List.of("--max-phred-score", "10"));
+        // The base quality written to a tag rather than over QUAL.
+        run(dir, "attribute", bam, List.of("--output-quality-attribute", "BQ"));
+
+        // A flow order whose cycle is ONE. The side walk survives it, unlike the sibling tool's,
+        // but the normalisation does not: with a cycle of one only the first base of the order is
+        // considered, so a read carrying any other base leaves calledIndex at -1 and the array is
+        // indexed with it. The guard above it tests `calledBase < 0`, which an ASCII base never
+        // is, so it never fires.
+        final Path cycle = dir.resolve("cycle-one.bam");
+        writeBam(cycle, List.of(new Read("cycle-one", "rg1", "TGCATGCA", "IIIIIIII", tp(8))));
+        describe(cycle);
+        run(dir, "cycle-one", cycle, List.of());
+    }
+
+    /** A `tp` of all zeros: every base's quality is the probability of the hmer's own length. */
+    static byte[] tp(final int length) {
+        return new byte[length];
+    }
+
+    /**
+     * The key and the three raw probabilities the tool bands, per read.
+     *
+     * Read off a FlowBasedRead built as the tool builds it, so the port can compute the bands and
+     * the whole enumeration from them without a flow matrix of its own.
+     */
+    static void describe(final Path bam) throws Exception {
+        try (final SamReader reader = SamReaderFactory.makeDefault()
+                .validationStringency(ValidationStringency.SILENT)
+                .open(bam.toFile())) {
+            final SAMFileHeader header = reader.getFileHeader();
+            for (final SAMReadGroupRecord group : header.getReadGroups()) {
+                System.out.printf("group\t%s\torder=%s\tmaxClass=%s%n",
+                        group.getId(),
+                        group.getFlowOrder(),
+                        new FlowBasedReadUtils.ReadGroupInfo(group).maxClass);
+            }
+            for (final SAMRecord record : reader) {
+                final StringBuilder tpText = new StringBuilder();
+                for (final byte value : record.getSignedByteArrayAttribute(
+                        FlowBasedRead.FLOW_MATRIX_TAG_NAME)) {
+                    tpText.append(tpText.length() == 0 ? "" : ",").append(value);
+                }
+                System.out.printf("read\t%s\tgroup=%s\tbases=%s\tqual=%s\ttp=%s%n",
+                        record.getReadName(),
+                        record.getReadGroup().getId(),
+                        record.getReadString(),
+                        record.getBaseQualityString(),
+                        tpText);
+                final FlowBasedReadUtils.ReadGroupInfo info = FlowBasedReadUtils.getReadGroupInfo(
+                        header, new SAMRecordToGATKReadAdapter(record));
+                // This tool leaves the flow arguments at their defaults, unlike its sibling, so
+                // the key measured here is the default one.
+                final FlowBasedRead flowRead = new FlowBasedRead(record, info.flowOrder,
+                        info.maxClass, new FlowBasedArgumentCollection());
+                final int[] key = flowRead.getKey();
+                final StringBuilder keyText = new StringBuilder();
+                for (final int hmer : key) {
+                    keyText.append(keyText.length() == 0 ? "" : ",").append(hmer);
+                }
+                System.out.printf("flow\t%s\tkey=%s\tmaxHmer=%d%n",
+                        record.getReadName(), keyText, flowRead.getMaxHmer());
+                for (int flow = 0; flow < key.length; flow++) {
+                    System.out.printf("prob\t%s\t%d\tminus=%s\tkey=%s\tplus=%s%n",
+                            record.getReadName(),
+                            flow,
+                            key[flow] > 0
+                                    ? Double.toString(flowRead.getProb(flow, key[flow] - 1))
+                                    : "none",
+                            Double.toString(flowRead.getProb(flow, key[flow])),
+                            key[flow] < flowRead.getMaxHmer()
+                                    ? Double.toString(flowRead.getProb(flow, key[flow] + 1))
+                                    : "none");
+                }
+            }
+        }
+    }
+
+    static void run(final Path dir, final String label, final Path bam, final List<String> extra)
+            throws Exception {
+        final Path out = dir.resolve("out-" + label + ".bam");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-I", bam.toString(), "-O", out.toString()));
+        argv.addAll(extra);
+        try {
+            new AddFlowSNVQuality().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        try (final SamReader reader = SamReaderFactory.makeDefault()
+                .validationStringency(ValidationStringency.SILENT)
+                .open(out.toFile())) {
+            final SAMFileHeader header = reader.getFileHeader();
+            for (final SAMRecord record : reader) {
+                System.out.printf("qual\t%s\t%s=%s%n", label, record.getReadName(),
+                        ReferenceQueryDump.escape(record.getBaseQualityString()));
+                final String order = record.getReadGroup().getFlowOrder();
+                final int cycle = FlowBasedReadUtils.calcFlowOrderLength(order);
+                for (int i = 0; i < cycle; i++) {
+                    final String tag = AddFlowSNVQuality.attrNameForNonCalledBase(order.charAt(i));
+                    final String value = record.getStringAttribute(tag);
+                    if (value != null) {
+                        System.out.printf("attr\t%s\t%s\t%s=%s%n", label, record.getReadName(),
+                                tag, ReferenceQueryDump.escape(value));
+                    }
+                }
+                final String bq = record.getStringAttribute("BQ");
+                if (bq != null) {
+                    System.out.printf("attr\t%s\t%s\tBQ=%s%n", label, record.getReadName(),
+                            ReferenceQueryDump.escape(bq));
+                }
+                // The flow order of the group, so the attribute names are derivable rather than
+                // guessed.
+                System.out.printf("order\t%s\t%s=%s%n", label, record.getReadName(), order);
+            }
+        }
+    }
+
+    static void writeBam(final Path file, final List<Read> reads) {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", 10000))));
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        header.addReadGroup(group("rg4", FOUR));
+        header.addReadGroup(group("rg1", ONE));
+        try (final SAMFileWriter writer = new SAMFileWriterFactory()
+                .setCreateIndex(true)
+                .makeBAMWriter(header, true, file.toFile())) {
+            int start = 100;
+            for (final Read read : reads) {
+                final SAMRecord record = new SAMRecord(header);
+                record.setReadName(read.name());
+                record.setReferenceName("chr1");
+                record.setAlignmentStart(start);
+                start += 100;
+                record.setCigarString(read.bases().length() + "M");
+                record.setReadBases(read.bases().getBytes(StandardCharsets.UTF_8));
+                record.setBaseQualityString(read.quals());
+                record.setMappingQuality(60);
+                record.setAttribute("RG", read.group());
+                record.setAttribute(FlowBasedRead.FLOW_MATRIX_TAG_NAME, read.tp());
+                writer.addAlignment(record);
+            }
+        }
+    }
+
+    static SAMReadGroupRecord group(final String id, final String flowOrder) {
+        final SAMReadGroupRecord group = new SAMReadGroupRecord(id);
+        group.setPlatform("ULTIMA");
+        group.setFlowOrder(flowOrder);
+        group.setSample("sample");
+        return group;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
The sibling of `AddFlowBaseQuality` ([#863](https://github.com/IPNP-BIPN/gatk-rs/pull/863)): the same enumeration over the ways a flow key could have been misread, but producing a probability for each base that was **not** called. Six reads run seven ways, plus one read under a flow order whose cycle is one.

**The computed base quality is discarded.** After the hmer loop fills `baseProbs`, the last loop overwrites every entry with `1 - snvqProbs[calledIndex][ofs]`, which is itself `1 - sum(alt)`. The reference's own comment on that line:

```java
// at this point, bq becomes trivial (?)
baseProbs[ofs] = 1 - snvqProbs[calledIndex][ofs];
```

**The phred conversion rounds where the sibling truncates.** Same expression, `-10 * log10(p)`, `Math.round` here and a cast there.

**The side walk is bounded by the slice**, which is exactly the bound `AddFlowBaseQuality` lacks:

```java
if ( sideFlow < minIndex || sideFlow > maxIndex ) { break; }
```

So a flow order of cycle one gets *past* the enumeration here. It then dies in the normalisation instead: with a cycle of one only the first base of the order is considered, a read carrying any other leaves `calledIndex` at -1, and `snvqProbs[-1]` throws `Index -1 out of bounds for length 1`. The guard above it tests `calledBase < 0`, which an ASCII base never is, so it never fires. Two siblings, two different crashes on the same input, from two different lines.

**`--max-phred-score` moves both the clamp and the floor**, and at 10 it is the floor that decides: `minLikelihoodProbRate` becomes 0.1, so three alternates take 0.3 of the mass and every base comes out at **5**, not at the clamp.

The rest: the four snvq modes over the same two probabilities; the alternate probabilities keyed by base rather than by flow, so two side flows carrying the same base overwrite each other; the middle bases of an hmer taking the minimum rate; the output attributes named for the flow order (`qt`, `qg`, `qc`, `qa`); and `--output-quality-attribute` leaving `QUAL` alone.

Ran twice in the pinned container and diffed: identical. The golden is `null` here and comes from this run's artefact.

Part of #618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)