### PR TITLE
Measure CalculateGenotypePosteriors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,10 @@ jobs:
             index: "48/48"
             slug: "sv-stratify-add-flow-snv-quality"
             suites: "sv-stratify add-flow-snv-quality"
+          - group: golden-pending
+            index: "1/1"
+            slug: "calculate-genotype-posteriors"
+            suites: "calculate-genotype-posteriors"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 148 | 47.6% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 151 | 48.6% |
+| not started | 150 | 48.2% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (100 of 190 started)
+## gatk-origin tools (101 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -101,6 +101,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `BaseRecalibrator` | record-transform | oracle-backed | base-recalibrator | 1 | not measured |
 | `CRAMIssue8768Detector` | unclassified | oracle-backed | cram-issue-8768-detector | 1 | not measured |
 | `CalculateAverageCombinedAnnotations` | unclassified | oracle-backed | calculate-average-combined-annotations | 1 | not measured |
+| `CalculateGenotypePosteriors` | variant-walker | golden-pending | calculate-genotype-posteriors | 1 | not measured |
 | `CalculateMixingFractions` | variant-walker | oracle-backed | calculate-mixing-fractions | 1 | not measured |
 | `CallCopyRatioSegments` | cnv-segmentation | oracle-backed | call-copy-ratio-segments | 1 | not measured |
 | `CallableLoci` | locus-walker | oracle-backed | callable-loci | 1 | not measured |
@@ -190,9 +191,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>90 not started</summary>
+<details><summary>89 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalculateGenotypePosteriors`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5561,6 +5561,26 @@
           "why": "Six flow-based reads under a four-flow order, run seven ways, plus one read under a flow order whose cycle is one: the default Geometric mode, the three other snvq modes, two maximum phred scores, and the base quality written to a tag. Every read's flow key and the three raw probabilities the tool bands are reported beside the outputs, so the port computes the bands and the whole enumeration without a flow matrix of its own. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33006186675, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "calculate-genotype-posteriors",
+      "status": "golden-pending",
+      "title": "likelihoods turned into posteriors under a dirichlet prior",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "CalculateGenotypePosteriors"
+      ],
+      "why": "A SITE MISSING FROM EVERY PANEL FALLS BACK TO FLAT PRIORS unless something supplies counts: useFlatPriors is true when the resources are empty AND the input samples are not used AND --num-reference-samples-if-no-call is zero, and then the PP comes out equal to the PL and PG is all zeros. THE INPUT SAMPLES ARE ONLY USED FOR A MISSING SITE IF THERE ARE TEN OF THEM, or if reference samples were assumed, so a three-sample callset reaches the flat-prior fallback. THE PANEL IS READ THROUGH MLEAC FIRST AND AC SECOND, and the two disagree here on purpose: the run reading MLEAC comes out with a FLAT prior at every site while the run reading AC does not, which is measured rather than explained. --num-reference-samples-if-no-call ENTERS AS CHROMOSOMES, twice the number of samples given, and only when the resources are empty. THE SNP PRIOR IS CHOSEN BY ALLELE LENGTH rather than by the site's type, so one site can mix the SNP and indel pseudocounts, and THE NON-REF ALLELE TAKES THE LARGER OF THE TWO plus every count belonging to an allele the input did not carry. GENOTYPES ARE RECALLED FROM THE POSTERIORS, so a GT can change and the GQ is recomputed from the PP. A HOM-REF BLOCK IS LEFT ALONE, keeping its AC, AF and AN and gaining no PG. A SUPPORTING PANEL MUST BE INDEXED, because it is queried by interval. AND THE TWO MLEAC HEADER CHECKS ARE SEPARATE, one for the count type and one for the field type, as is the refusal of a VCF with no genotypes at all.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "CalculateGenotypePosteriorsDump",
+          "golden": null,
+          "why": "Six sites over three samples, run ten ways and refused four: no panel, a panel, assumed reference samples with and without the panel, AC instead of MLEAC, external counts only, discovered counts off, flat priors for indels, changed pseudocounts, and population priors skipped; then an unindexed panel, a VCF with no genotypes and the two malformed MLEAC headers. The whole input and the whole panel are reported beside the outputs, and each output is compared as its whole body plus the FORMAT and INFO header lines the tool added."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/CalculateGenotypePosteriorsDump.java
+++ b/tools/readfilter-conformance/CalculateGenotypePosteriorsDump.java
@@ -1,0 +1,224 @@
+/*
+ * CalculateGenotypePosteriors' output, taken from the reference.
+ *
+ * Genotype likelihoods turned into posteriors under a Dirichlet-multinomial prior built from allele
+ * counts. Where those counts come from is the whole of the tool: a supporting panel, the input
+ * samples themselves, an assumed number of hom-ref samples, or nothing at all, and each choice is
+ * a different prior.
+ *
+ * Ten behaviours this is built to catch.
+ *
+ *   - A SITE MISSING FROM EVERY PANEL FALLS BACK TO FLAT PRIORS unless something supplies counts:
+ *     useFlatPriors is true when the resources are empty AND the input samples are not used AND
+ *     --num-reference-samples-if-no-call is zero, so the PP comes out equal to the PL;
+ *   - THE INPUT SAMPLES ARE ONLY USED FOR A MISSING SITE IF THERE ARE TEN OF THEM, or if reference
+ *     samples were assumed: `vc1.getNSamples() >= 10 || numRefSamplesFromMissingResources != 0`;
+ *   - THE PANEL IS READ THROUGH MLEAC FIRST AND AC SECOND, which --default-to-allele-count flips;
+ *   - --num-reference-samples-if-no-call IS DOUBLED, because the count is of diploid samples and
+ *     what enters the prior is chromosomes;
+ *   - THE SNP PRIOR IS CHOSEN BY ALLELE LENGTH, not by the site's type: an allele the same length
+ *     as the reference takes the SNP pseudocount and every other allele the indel one, so one site
+ *     can mix the two;
+ *   - THE NON-REF ALLELE TAKES THE LARGER OF THE TWO PRIORS plus every count belonging to an
+ *     allele the input did not carry;
+ *   - GENOTYPES ARE RECALLED FROM THE POSTERIORS, so a sample's GT can change and its GQ is
+ *     recomputed from the PP rather than the PL;
+ *   - A HOM-REF BLOCK IS LEFT ALONE: a record whose only alternate is <NON_REF> keeps its AC, AF
+ *     and AN and gains no GENOTYPE_PRIOR;
+ *   - A MALFORMED MLEAC HEADER IS A REFUSAL rather than a fallback, checked for count type A and
+ *     type Integer separately;
+ *   - AND A VCF WITH NO GENOTYPES AT ALL IS REFUSED IN onTraversalStart.
+ *
+ * Output:
+ *
+ *     vcf\t<name>=<the whole input, escaped>
+ *     out\t<label>=<the whole output vcf without its header, escaped>
+ *     header\t<label>=<the output's own header lines, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: CalculateGenotypePosteriorsDump
+ */
+
+import org.broadinstitute.hellbender.tools.IndexFeatureFile;
+import org.broadinstitute.hellbender.tools.walkers.variantutils.CalculateGenotypePosteriors;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CalculateGenotypePosteriorsDump {
+
+    /**
+     * The measured input.
+     *
+     * Three samples, so the ten-sample rule for missing sites is NOT met and the fallback to flat
+     * priors is reachable. A biallelic SNP, a multiallelic SNP, an indel, a mixed-length site, a
+     * hom-ref block ending in NON_REF, and a site the panel does not carry.
+     */
+    static final String INPUT = String.join("\n",
+            "##fileformat=VCFv4.2",
+            "##contig=<ID=chr1,length=100000>",
+            "##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count\">",
+            "##INFO=<ID=AN,Number=1,Type=Integer,Description=\"Allele number\">",
+            "##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele frequency\">",
+            "##INFO=<ID=MLEAC,Number=A,Type=Integer,Description=\"MLE allele count\">",
+            "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+            "##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Quality\">",
+            "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Depth\">",
+            "##FORMAT=<ID=PL,Number=G,Type=Integer,Description=\"Likelihoods\">",
+            "##ALT=<ID=NON_REF,Description=\"Non-reference\">",
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts1\ts2\ts3",
+            // A biallelic SNP the panel carries.
+            "chr1\t100\tsnp\tA\tG\t50\t.\t.\tGT:GQ:DP:PL\t0/0:30:20:0,30,300"
+                    + "\t0/1:40:20:40,0,400\t1/1:20:20:300,20,0",
+            // Multiallelic, so the prior is a triangle over three alleles.
+            "chr1\t200\tmulti\tA\tG,T\t50\t.\t.\tGT:GQ:DP:PL\t0/0:30:20:0,30,300,30,300,300"
+                    + "\t0/1:40:20:40,0,400,40,400,400\t1/2:20:20:300,200,100,200,0,100",
+            // An indel, which takes the indel pseudocount.
+            "chr1\t300\tindel\tAT\tA\t50\t.\t.\tGT:GQ:DP:PL\t0/0:30:20:0,30,300"
+                    + "\t0/1:40:20:40,0,400\t0/0:20:20:0,20,200",
+            // Reference-length and non-reference-length alternates at one site.
+            "chr1\t400\tmixed\tAT\tGT,A\t50\t.\t.\tGT:GQ:DP:PL\t0/0:30:20:0,30,300,30,300,300"
+                    + "\t0/1:40:20:40,0,400,40,400,400\t0/2:20:20:100,200,300,0,200,300",
+            // A hom-ref block, whose only alternate is NON_REF.
+            "chr1\t500\thomref\tA\t<NON_REF>\t.\t.\t.\tGT:GQ:DP:PL\t0/0:30:20:0,30,300"
+                    + "\t0/0:40:20:0,40,400\t0/0:20:20:0,20,200",
+            // A site no panel carries.
+            "chr1\t600\tabsent\tC\tT\t50\t.\t.\tGT:GQ:DP:PL\t0/0:30:20:0,30,300"
+                    + "\t0/1:40:20:40,0,400\t1/1:20:20:300,20,0",
+            "");
+
+    /** The supporting panel: AC and MLEAC that disagree, so which one is read is observable. */
+    static final String PANEL = String.join("\n",
+            "##fileformat=VCFv4.2",
+            "##contig=<ID=chr1,length=100000>",
+            "##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count\">",
+            "##INFO=<ID=AN,Number=1,Type=Integer,Description=\"Allele number\">",
+            "##INFO=<ID=MLEAC,Number=A,Type=Integer,Description=\"MLE allele count\">",
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO",
+            "chr1\t100\t.\tA\tG\t.\t.\tAC=200;AN=2000;MLEAC=20",
+            "chr1\t200\t.\tA\tG,T\t.\t.\tAC=100,300;AN=2000;MLEAC=10,30",
+            "chr1\t300\t.\tAT\tA\t.\t.\tAC=400;AN=2000;MLEAC=40",
+            "chr1\t400\t.\tAT\tGT,A\t.\t.\tAC=100,200;AN=2000;MLEAC=10,20",
+            "chr1\t500\t.\tA\tG\t.\t.\tAC=50;AN=2000;MLEAC=5",
+            "");
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("calculate-genotype-posteriors-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# CalculateGenotypePosteriorsDump: likelihoods turned into posteriors");
+
+        final Path input = write(dir, "input.vcf", INPUT);
+        final Path panel = write(dir, "panel.vcf", PANEL);
+        // A supporting panel is QUERIED BY INTERVAL, so it has to be indexed: without an index the
+        // run is refused rather than falling back to a linear read. Measured once, below.
+        new IndexFeatureFile().instanceMain(new String[] {"-I", panel.toString()});
+        final Path unindexed = write(dir, "unindexed.vcf", PANEL);
+        System.out.printf("vcf\tinput=%s%n", ReferenceQueryDump.escape(INPUT));
+        System.out.printf("vcf\tpanel=%s%n", ReferenceQueryDump.escape(PANEL));
+
+        // No panel at all, which is where the flat-prior fallback lives.
+        run(dir, "no-panel", input, List.of());
+        // With the panel, which is the ordinary path.
+        run(dir, "panel", input, List.of("--supporting", panel.toString()));
+        // The panel plus assumed reference samples, which also turns the input samples on.
+        run(dir, "ref-samples", input, List.of("--num-reference-samples-if-no-call", "1000"));
+        run(dir, "panel-and-ref", input, List.of("--supporting", panel.toString(),
+                "--num-reference-samples-if-no-call", "1000"));
+        // AC instead of MLEAC, which the panel makes observable.
+        run(dir, "default-to-ac", input, List.of("--supporting", panel.toString(),
+                "--default-to-allele-count", "true"));
+        // External counts only.
+        run(dir, "ignore-input", input, List.of("--supporting", panel.toString(),
+                "--ignore-input-samples", "true"));
+        // And the discovered counts turned off for missing sites.
+        run(dir, "discovered-off", input, List.of("--supporting", panel.toString(),
+                "--num-reference-samples-if-no-call", "1000",
+                "--discovered-allele-count-priors-off", "true"));
+        // Flat priors for indels, which reaches the mixed-length site too.
+        run(dir, "flat-indels", input, List.of("--supporting", panel.toString(),
+                "--use-flat-priors-for-indels", "true"));
+        // The pseudocounts themselves.
+        run(dir, "priors", input, List.of("--supporting", panel.toString(),
+                "--global-prior-snp", "0.01", "--global-prior-indel", "0.0001"));
+        // Nothing applied at all.
+        run(dir, "skip-population", input, List.of("--supporting", panel.toString(),
+                "--skip-population-priors", "true"));
+        // The same panel without an index.
+        run(dir, "unindexed-panel", input, List.of("--supporting", unindexed.toString()));
+
+        // A VCF with no genotype columns.
+        final Path sites = write(dir, "sites.vcf", String.join("\n",
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=100000>",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO",
+                "chr1\t100\t.\tA\tG\t50\t.\t.",
+                ""));
+        run(dir, "no-genotypes", sites, List.of());
+
+        // Two malformed MLEAC headers, each checked separately and in order.
+        run(dir, "mleac-count", write(dir, "mleac-count.vcf",
+                INPUT.replace("##INFO=<ID=MLEAC,Number=A,Type=Integer",
+                        "##INFO=<ID=MLEAC,Number=1,Type=Integer")), List.of());
+        run(dir, "mleac-type", write(dir, "mleac-type.vcf",
+                INPUT.replace("##INFO=<ID=MLEAC,Number=A,Type=Integer",
+                        "##INFO=<ID=MLEAC,Number=A,Type=Float")), List.of());
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path input, final List<String> extra)
+            throws Exception {
+        final Path out = dir.resolve(label + ".vcf");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-V", input.toString(), "-O", out.toString()));
+        argv.addAll(extra);
+        try {
+            new CalculateGenotypePosteriors().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            return;
+        }
+        final String text = Files.readString(out);
+        final StringBuilder body = new StringBuilder();
+        final StringBuilder header = new StringBuilder();
+        for (final String line : text.split("\n", -1)) {
+            if (line.isEmpty()) {
+                continue;
+            }
+            if (line.startsWith("##")) {
+                // The command line the tool stamps carries paths and a version; the header lines
+                // that matter are the ones it ADDS, which are the FORMAT and INFO ones.
+                if (line.startsWith("##FORMAT") || line.startsWith("##INFO")) {
+                    header.append(line).append("\n");
+                }
+            } else {
+                body.append(line).append("\n");
+            }
+        }
+        System.out.printf("header\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(header.toString(), dir)));
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(body.toString(), dir)));
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Six sites over three samples, run ten ways and refused four. Every output is compared as its whole body plus the `FORMAT` and `INFO` header lines the tool adds.

**Three samples is deliberately below the threshold.** The input samples' own allele counts are only used for a site missing from every panel when there are at least ten of them, or when `--num-reference-samples-if-no-call` is non-zero. So this callset reaches the flat-prior fallback, where `PP` comes out equal to `PL` and `PG` is all zeros.

**A supporting panel must be indexed.** It is queried by interval, so an unindexed one is a refusal rather than a linear read. That cost the first run of this measurement: every `--supporting` run came back as the same refusal, and the outputs looked plausible because they were the no-panel outputs.

**MLEAC and AC disagree here on purpose**, and the result is not what the reading suggests: the run reading `MLEAC` comes out with a flat prior at *every* site, while `--default-to-allele-count` gives `PG=2,0,2` at the first one. The panel is definitely being read in both (the two runs differ), and the counts differ by a factor of ten. That is measured, not explained: the port is what will have to say why, and the golden is what will judge the answer.

The rest: `--num-reference-samples-if-no-call` enters as *chromosomes*, twice the samples given, and only when the resources are empty; the SNP pseudocount is chosen by allele *length* rather than by the site's type, so one site can mix the two; the non-ref allele takes the larger of the two priors plus every count belonging to an allele the input did not carry; genotypes are recalled from the posteriors, so a `GT` can change and the `GQ` is recomputed from the `PP`; a hom-ref block whose only alternate is `<NON_REF>` is left alone; and the two MLEAC header checks are separate, one for the count type and one for the field type.

Family priors are measured only in their absence: no pedigree is passed, so `--skip-family-priors` is implicit. `FamilyLikelihoods` is a second algorithm and gets its own brick.

Ran twice in the pinned container and diffed: identical. The golden is `null` here and comes from this run's artefact.

Part of #641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)