### PR TITLE
Measure CalculateGenotypePosteriors' family priors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,10 @@ jobs:
             index: "48/48"
             slug: "sv-stratify-add-flow-snv-quality-calculate-genotype-posteriors"
             suites: "sv-stratify add-flow-snv-quality calculate-genotype-posteriors"
+          - group: golden-pending
+            index: "1/1"
+            slug: "family-priors"
+            suites: "family-priors"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -101,7 +101,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `BaseRecalibrator` | record-transform | oracle-backed | base-recalibrator | 1 | not measured |
 | `CRAMIssue8768Detector` | unclassified | oracle-backed | cram-issue-8768-detector | 1 | not measured |
 | `CalculateAverageCombinedAnnotations` | unclassified | oracle-backed | calculate-average-combined-annotations | 1 | not measured |
-| `CalculateGenotypePosteriors` | variant-walker | oracle-backed | calculate-genotype-posteriors | 1 | not measured |
+| `CalculateGenotypePosteriors` | variant-walker | oracle-backed | calculate-genotype-posteriors, family-priors | 2 | not measured |
 | `CalculateMixingFractions` | variant-walker | oracle-backed | calculate-mixing-fractions | 1 | not measured |
 | `CallCopyRatioSegments` | cnv-segmentation | oracle-backed | call-copy-ratio-segments | 1 | not measured |
 | `CallableLoci` | locus-walker | oracle-backed | callable-loci | 1 | not measured |

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5581,6 +5581,26 @@
           "why": "Six sites over three samples, run eleven ways and refused four: no panel, a panel, assumed reference samples with and without the panel, AC instead of MLEAC, a panel carrying no MLEAC, external counts only, discovered counts off, flat priors for indels, changed pseudocounts, and population priors skipped; then an unindexed panel, a VCF with no genotypes and the two malformed MLEAC headers. Outputs are written to out-<label>.vcf rather than <label>.vcf: the first version of this dump wrote the `panel` run's output to panel.vcf, which is the supporting panel, and the tool truncated its own input before reading it. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33009487187, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "family-priors",
+      "status": "golden-pending",
+      "title": "a trio's genotypes recomputed together",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "CalculateGenotypePosteriors"
+      ],
+      "why": "FAMILY PRIORS ONLY APPLY TO BIALLELIC SITES, apply testing variant.isBiallelic() before the family engine is called at all, so a triallelic site keeps its likelihoods whatever the pedigree says. THE NON-VIOLATION COEFFICIENT IS NOT ONE: it is 1 - 10*deNovoPrior - deNovoPrior^2, so every consistent combination is scaled DOWN by ten times the de novo prior. AT THE DEFAULT DE NOVO PRIOR A MENDELIAN VIOLATION IS OVERTURNED RATHER THAN REPORTED: two hom-ref parents and a hom-var child all become het, and raising --de-novo-prior to 0.001 leaves the violation standing instead. A TRIO NEEDS ALL THREE MEMBERS IN THE VCF, setTrios keeping a family only when exactly three of its members are present and one of them has both parents among them, so a pedigree naming only two is the same as no pedigree. AN UNCALLED PARENT BECOMES A UNIFORM THIRD and the trio is still processed as a parent/child pair, but AN UNCALLED CHILD STOPS THE WHOLE TRIO. THE JOINT TAGS ARE ONLY COMPUTED WHEN ALL THREE ARE CALLED and are -1 otherwise, and a sample in no trio carries them as missing. THE JOINT LIKELIHOOD IS TAKEN AT THE POSTERIOR'S ARGMAX rather than at its own, so JL reports the likelihood of the configuration the prior chose. AND THE POSTERIORS OVERWRITE PP, which the population half then reads back in preference to the PL, so the two halves compose in one direction only.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "FamilyPriorsDump",
+          "golden": null,
+          "why": "Six sites over a trio and one unrelated sample, run seven ways: family priors alone, two other de novo priors, both halves together, family priors skipped by argument, no pedigree at all, and a pedigree with no complete trio in the VCF. The whole input and both pedigrees are reported beside the outputs."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/FamilyPriorsDump.java
+++ b/tools/readfilter-conformance/FamilyPriorsDump.java
@@ -1,0 +1,175 @@
+/*
+ * CalculateGenotypePosteriors' family priors, taken from the reference.
+ *
+ * The other half of the tool: a trio's three genotypes recomputed together, weighting every
+ * combination by how many Mendelian violations it implies. The population half is measured by the
+ * calculate-genotype-posteriors suite; this one is about the pedigree.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - FAMILY PRIORS ONLY APPLY TO BIALLELIC SITES: apply tests `variant.isBiallelic()` before
+ *     calling the family engine at all, so a triallelic site keeps its likelihoods whatever the
+ *     pedigree says;
+ *   - THE NON-VIOLATION COEFFICIENT IS NOT ONE: it is `1 - 10*deNovoPrior - deNovoPrior^2`, so
+ *     every consistent combination is scaled DOWN by ten times the de novo prior;
+ *   - A TRIO NEEDS ALL THREE MEMBERS IN THE VCF: setTrios keeps a family only when exactly three
+ *     of its members are present AND one of them has both parents among them;
+ *   - NO PEDIGREE MEANS NO FAMILY PRIORS, and the tool says so and carries on rather than
+ *     refusing;
+ *   - AN UNCALLED PARENT BECOMES A UNIFORM THIRD, and the trio is still processed as a
+ *     parent/child pair, but AN UNCALLED CHILD STOPS THE WHOLE TRIO;
+ *   - THE JOINT TAGS ARE COMPUTED ONLY WHEN ALL THREE ARE CALLED, and are -1 otherwise;
+ *   - THE JOINT LIKELIHOOD IS TAKEN AT THE POSTERIOR'S ARGMAX, not at its own, so JL reports the
+ *     likelihood of the configuration the prior chose;
+ *   - THE POSTERIORS OVERWRITE PP, which the population half then READS BACK rather than the PL,
+ *     so the two halves compose in one direction only;
+ *   - AND --de-novo-prior MOVES BOTH SIDES OF THE WEIGHTING, the violation term and the
+ *     non-violation one.
+ *
+ * Output:
+ *
+ *     vcf\t<name>=<the whole input, escaped>
+ *     ped\t<name>=<the whole pedigree, escaped>
+ *     out\t<label>=<the whole output vcf without its header, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: FamilyPriorsDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.variantutils.CalculateGenotypePosteriors;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FamilyPriorsDump {
+
+    /**
+     * A trio and an unrelated sample.
+     *
+     * The sites are chosen so that every branch of the family engine is reached: a consistent
+     * inheritance, a Mendelian violation, an uncalled father, an uncalled child, a triallelic site
+     * the engine never sees, and a site where the child's likelihoods are flat.
+     */
+    static final String INPUT = String.join("\n",
+            "##fileformat=VCFv4.2",
+            "##contig=<ID=chr1,length=100000>",
+            "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+            "##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Quality\">",
+            "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Depth\">",
+            "##FORMAT=<ID=PL,Number=G,Type=Integer,Description=\"Likelihoods\">",
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tmom\tdad\tkid\tother",
+            // Consistent: both parents het, child het.
+            "chr1\t100\tconsistent\tA\tG\t50\t.\t.\tGT:GQ:DP:PL\t0/1:40:20:40,0,400"
+                    + "\t0/1:40:20:40,0,400\t0/1:40:20:40,0,400\t0/0:30:20:0,30,300",
+            // A violation: both parents hom-ref, child hom-var.
+            "chr1\t200\tviolation\tA\tG\t50\t.\t.\tGT:GQ:DP:PL\t0/0:40:20:0,40,400"
+                    + "\t0/0:40:20:0,40,400\t1/1:40:20:400,40,0\t0/0:30:20:0,30,300",
+            // A weak violation, where the child's own likelihoods barely prefer the violating call.
+            "chr1\t250\tweak\tA\tG\t50\t.\t.\tGT:GQ:DP:PL\t0/0:40:20:0,40,400"
+                    + "\t0/0:40:20:0,40,400\t1/1:3:20:5,3,0\t0/0:30:20:0,30,300",
+            // The father uncalled, which makes it a parent/child pair.
+            "chr1\t300\tno-father\tA\tG\t50\t.\t.\tGT:GQ:DP:PL\t0/1:40:20:40,0,400"
+                    + "\t./.:.:.:.\t0/1:40:20:40,0,400\t0/0:30:20:0,30,300",
+            // The child uncalled, which stops the trio.
+            "chr1\t400\tno-child\tA\tG\t50\t.\t.\tGT:GQ:DP:PL\t0/1:40:20:40,0,400"
+                    + "\t0/1:40:20:40,0,400\t./.:.:.:.\t0/0:30:20:0,30,300",
+            // Triallelic, which the family engine never sees.
+            "chr1\t500\ttriallelic\tA\tG,T\t50\t.\t.\tGT:GQ:DP:PL"
+                    + "\t0/1:40:20:40,0,400,40,400,400\t0/1:40:20:40,0,400,40,400,400"
+                    + "\t1/2:40:20:400,200,100,200,0,100\t0/0:30:20:0,30,300,30,300,300",
+            "");
+
+    /** mom and dad are kid's parents; `other` is its own family. */
+    static final String PED = String.join("\n",
+            "fam1\tkid\tdad\tmom\t1\t2",
+            "fam1\tdad\t0\t0\t1\t1",
+            "fam1\tmom\t0\t0\t2\t1",
+            "fam2\tother\t0\t0\t1\t1",
+            "");
+
+    /** The same pedigree with the mother missing, so no family has three members in the VCF. */
+    static final String PED_NO_TRIO = String.join("\n",
+            "fam1\tkid\tdad\t0\t1\t2",
+            "fam1\tdad\t0\t0\t1\t1",
+            "fam2\tother\t0\t0\t1\t1",
+            "");
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("family-priors-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# FamilyPriorsDump: a trio's genotypes recomputed together");
+
+        final Path input = write(dir, "input.vcf", INPUT);
+        final Path ped = write(dir, "family.ped", PED);
+        final Path pedNoTrio = write(dir, "no-trio.ped", PED_NO_TRIO);
+        System.out.printf("vcf\tinput=%s%n", ReferenceQueryDump.escape(INPUT));
+        System.out.printf("ped\tfamily=%s%n", ReferenceQueryDump.escape(PED));
+        System.out.printf("ped\tno-trio=%s%n", ReferenceQueryDump.escape(PED_NO_TRIO));
+
+        // Family priors alone, so nothing the population half does is in the way.
+        run(dir, "family-only", input, List.of("--pedigree", ped.toString(),
+                "--skip-population-priors", "true"));
+        // The de novo prior, which moves both sides of the weighting.
+        run(dir, "denovo-high", input, List.of("--pedigree", ped.toString(),
+                "--skip-population-priors", "true", "--de-novo-prior", "0.001"));
+        run(dir, "denovo-low", input, List.of("--pedigree", ped.toString(),
+                "--skip-population-priors", "true", "--de-novo-prior", "1e-9"));
+        // Both halves, in the order the tool applies them: family first, then population, which
+        // reads the PP the family half just wrote.
+        run(dir, "both-halves", input, List.of("--pedigree", ped.toString()));
+        // Family priors skipped by argument, and by having no pedigree at all.
+        run(dir, "skip-family", input, List.of("--pedigree", ped.toString(),
+                "--skip-family-priors", "true", "--skip-population-priors", "true"));
+        run(dir, "no-pedigree", input, List.of("--skip-population-priors", "true"));
+        // A pedigree with no complete trio in the VCF, which is the same as none.
+        run(dir, "no-trio", input, List.of("--pedigree", pedNoTrio.toString(),
+                "--skip-population-priors", "true"));
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path input, final List<String> extra)
+            throws Exception {
+        // Never `label + ".vcf"`: an output whose name collides with an input would be truncated
+        // before it is read. The population-prior dump learned that the hard way.
+        final Path out = dir.resolve("out-" + label + ".vcf");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-V", input.toString(), "-O", out.toString()));
+        argv.addAll(extra);
+        try {
+            new CalculateGenotypePosteriors().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            return;
+        }
+        final StringBuilder body = new StringBuilder();
+        for (final String line : Files.readString(out).split("\n", -1)) {
+            if (!line.startsWith("##") && !line.isEmpty()) {
+                body.append(line).append("\n");
+            }
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(body.toString(), dir)));
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
The other half of the tool, measured on its own: a trio's three genotypes recomputed together, weighting every combination by how many Mendelian violations it implies. Six sites over a trio and one unrelated sample, run seven ways.

**At the default de novo prior a Mendelian violation is overturned, not reported.** Two hom-ref parents and a hom-var child all come out **het**, with the GQ dropping from 40 to 3:

```
violation  0/1:20:3:0:1:0,40,400:3,0,360 | 0/1:20:3:0:1:400,40,0:323,0,3 | 0/1:20:3:0:1:0,40,400:3,0,360
```

Raising `--de-novo-prior` to 0.001 leaves the violation standing instead, parents `0/0` and child `1/1` with a GQ of 10. The same argument moves both sides of the weighting.

**The non-violation coefficient is not one.** It is `1 - 10*deNovoPrior - deNovoPrior²`, so every *consistent* combination is scaled down by ten times the de novo prior. Nothing in the tool's documentation says so.

**An uncalled parent is a uniform third and the pair is still processed; an uncalled child stops the trio.** At `no-father` the mother and child are recomputed and their joint tags come out `-1`; at `no-child` nothing is touched and there are no joint tags at all.

The rest: family priors only apply to biallelic sites, so the triallelic one keeps its likelihoods whatever the pedigree says; a trio needs all three members in the VCF, so a pedigree naming only two is the same as no pedigree; the joint likelihood is taken at the *posterior's* argmax rather than its own; and the family posteriors overwrite `PP`, which the population half then reads back in preference to `PL`, so the two halves compose in one direction only.

Outputs go to `out-<label>.vcf` from the start: [#873](https://github.com/IPNP-BIPN/gatk-rs/pull/873) is why.

Ran twice in the pinned container and diffed: identical. The golden is `null` here and comes from this run's artefact.

Part of #641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)