### PR TITLE
Measure SVCluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,10 @@ jobs:
             index: "48/48"
             slug: "sv-stratify-add-flow-snv-quality-calculate-genotype-posteriors-family-priors"
             suites: "sv-stratify add-flow-snv-quality calculate-genotype-posteriors family-priors"
+          - group: golden-pending
+            index: "1/1"
+            slug: "sv-cluster"
+            suites: "sv-cluster"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 149 | 47.9% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 150 | 48.2% |
+| not started | 149 | 47.9% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (101 of 190 started)
+## gatk-origin tools (102 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -174,6 +174,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ReferenceBlockConcordance` | unclassified | oracle-backed | reference-block-concordance | 1 | not measured |
 | `RemoveNearbyIndels` | variant-transform | oracle-backed | remove-nearby-indels | 1 | not measured |
 | `RevertBaseQualityScores` | record-transform | oracle-backed | record-transform | 1 | not measured |
+| `SVCluster` | sv-caller | golden-pending | sv-cluster | 1 | not measured |
 | `SVStratify` | sv-caller | oracle-backed | sv-stratify | 1 | not measured |
 | `SelectVariants` | variant-transform | oracle-backed | select-variants-concordance, select-variants-filters, select-variants-output, select-variants-samples, select-variants-subset | 5 | not measured |
 | `ShiftFasta` | reference-utility | oracle-backed | shift-fasta | 1 | not measured |
@@ -191,9 +192,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>89 not started</summary>
+<details><summary>88 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVCluster`, `SVConcordance`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVConcordance`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5601,6 +5601,26 @@
           "why": "Six sites over a trio and one unrelated sample, run seven ways: family priors alone, two other de novo priors, both halves together, family priors skipped by argument, no pedigree at all, and a pedigree with no complete trio in the VCF. The whole input and both pedigrees are reported beside the outputs. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33011583005, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "sv-cluster",
+      "status": "golden-pending",
+      "title": "which structural variants are judged the same event",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "SVCluster"
+      ],
+      "why": "THE PARAMETER SET IS CHOSEN BY THE PAIR, NOT BY THE USER: two depth-only records take the depth thresholds, two PESR records the PESR ones and one of each the MIXED ones, so a single run applies three different thresholds to different pairs of the same file. SINGLE LINKAGE AND MAX CLIQUE DISAGREE ON A CHAIN, and the chain here is made by the type rule rather than by coordinates: a deletion and a duplication at the same locus do NOT cluster with each other, but both cluster with a CNV between them, so single linkage returns one group of three and max clique returns two overlapping pairs that both contain the CNV. --enable-cnv is only observable under max clique, because under single linkage the CNV already chains the two together. RECIPROCAL OVERLAP AND SIZE SIMILARITY ARE SEPARATE TESTS and both must pass: two deletions sharing a start and differing twentyfold in length overlap and still do not cluster. ONLY BND AND INV REQUIRE MATCHING STRANDS. SAMPLE OVERLAP IS TESTED LAST and is zero by default, so two records sharing no carrier cluster until --depth-sample-overlap is raised. AND --omit-members REMOVES THE ONLY FIELD THAT SHOWS THE CLUSTERING, which is what makes it the run that proves the others were reading something real.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "SVClusterDump",
+          "golden": null,
+          "why": "Eighteen records over two contigs, run nine ways: the two algorithms, --enable-cnv under each, a depth overlap threshold nothing reaches and one everything reaches, a raised sample overlap, a widened PESR breakend window, and --omit-members. The whole input VCF and the ploidy table are reported beside the outputs. The fixture needed four things the tool requires and does not default: a ploidy table, a real reference, an ECN on every genotype, and a dictionary length that matches the FASTA to the base."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/SVClusterDump.java
+++ b/tools/readfilter-conformance/SVClusterDump.java
@@ -1,0 +1,277 @@
+/*
+ * SVCluster's clusters, taken from the reference.
+ *
+ * Which structural variants are judged the same event. What decides it is a predicate over a pair,
+ * and which of three parameter sets that predicate uses is decided by the records' own ALGORITHMS
+ * field rather than by any argument.
+ *
+ * Ten behaviours this is built to catch.
+ *
+ *   - THE PARAMETER SET IS CHOSEN BY THE PAIR, NOT BY THE USER: two depth-only records take the
+ *     depth parameters, two PESR records the PESR ones, and one of each the MIXED ones, so a single
+ *     run applies three different thresholds to different pairs;
+ *   - SINGLE LINKAGE AND MAX CLIQUE DISAGREE ON A CHAIN: three records where A clusters with B and
+ *     B with C but A not with C become ONE cluster under single linkage and more than one under max
+ *     clique;
+ *   - THE DEPTH PARAMETERS REQUIRE OVERLAP AND PROXIMITY, the PESR ones require either, which is
+ *     what `requiresOverlapAndProximity` decides from the parameter set's own validity rule;
+ *   - RECIPROCAL OVERLAP AND SIZE SIMILARITY ARE SEPARATE TESTS, and both must pass: two records
+ *     can overlap reciprocally and still fail on size;
+ *   - AN INSERTION IS GIVEN AN ASSUMED LENGTH for both tests, because it has none of its own;
+ *   - INTERCHROMOSOMAL PAIRS SKIP OVERLAP ENTIRELY and are judged on breakend proximity alone;
+ *   - ONLY BND AND INV REQUIRE MATCHING STRANDS, and a record with null strands matches anything;
+ *   - A DELETION AND A DUPLICATION DO NOT CLUSTER unless one of them is a CNV, or --enable-cnv is
+ *     given;
+ *   - SAMPLE OVERLAP IS TESTED LAST because it is the slowest, and it is a fraction of the smaller
+ *     carrier set;
+ *   - AND THE MEMBER IDS ARE WRITTEN IN THE OUTPUT, which is how the clustering is observable
+ *     without reading the collapsed representative.
+ *
+ * Output:
+ *
+ *     vcf\tinput=<the whole input vcf, escaped>
+ *     out\t<label>=<the whole output vcf without its header, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: SVClusterDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.tools.walkers.sv.SVCluster;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SVClusterDump {
+
+    /**
+     * The measured input.
+     *
+     * The deletions on chr1 are a chain: d1 and d2 overlap well, d2 and d3 overlap well, d1 and d3
+     * do not. That is the pair that separates single linkage from max clique. The rest are one
+     * behaviour each.
+     */
+    static String buildVcf() {
+        final List<String> lines = new ArrayList<>(List.of(
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=199980>",
+                "##contig=<ID=chr2,length=199980>",
+                "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type\">",
+                "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length\">",
+                "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End\">",
+                "##INFO=<ID=CHR2,Number=1,Type=String,Description=\"Second contig\">",
+                "##INFO=<ID=END2,Number=1,Type=Integer,Description=\"Second position\">",
+                "##INFO=<ID=STRANDS,Number=1,Type=String,Description=\"Strands\">",
+                "##INFO=<ID=ALGORITHMS,Number=.,Type=String,Description=\"Algorithms\">",
+                "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+                // ECN, the expected copy number, is not optional: SVCallRecord refuses a genotype
+                // without it.
+                "##FORMAT=<ID=ECN,Number=1,Type=Integer,Description=\"Expected copy number\">",
+                "##ALT=<ID=DEL,Description=\"Deletion\">",
+                "##ALT=<ID=DUP,Description=\"Duplication\">",
+                "##ALT=<ID=CNV,Description=\"Copy number variant\">",
+                "##ALT=<ID=INS,Description=\"Insertion\">",
+                "##ALT=<ID=INV,Description=\"Inversion\">",
+                "##ALT=<ID=BND,Description=\"Breakend\">",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts1\ts2\ts3"));
+        // The chain, all depth-only so one parameter set decides it.
+        lines.add(del("d1", 1000, 11000, "depth", "0/1", "0/1", "0/0"));
+        lines.add(del("d2", 1600, 11600, "depth", "0/1", "0/1", "0/0"));
+        lines.add(del("d3", 2200, 12200, "depth", "0/1", "0/1", "0/0"));
+        // A deletion whose caller is PESR, so a pair with a depth one takes the MIXED parameters.
+        lines.add(del("p1", 20000, 30000, "manta", "0/1", "0/0", "0/0"));
+        lines.add(del("p2", 20200, 30200, "manta", "0/1", "0/0", "0/0"));
+        lines.add(del("m1", 20400, 30400, "depth", "0/1", "0/0", "0/0"));
+        // Reciprocal overlap without size similarity: same start, very different length.
+        lines.add(del("z1", 50000, 70000, "depth", "0/1", "0/1", "0/0"));
+        lines.add(del("z2", 50000, 51000, "depth", "0/1", "0/1", "0/0"));
+        // A duplication next to a deletion, and a CNV between them.
+        lines.add(record("u1", 80000, "DUP", 90000, 10001, null, null, null, "depth",
+                "0/1", "0/1", "0/0"));
+        lines.add(del("e1", 80000, 90000, "depth", "0/1", "0/1", "0/0"));
+        lines.add(record("c1", 80000, "CNV", 90000, 10001, null, null, null, "depth",
+                "0/1", "0/1", "0/0"));
+        // Two insertions at the same locus, which have no length of their own.
+        lines.add("chr1\t100000\ti1\tN\t<INS>\t.\t.\tSVTYPE=INS;END=100000;SVLEN=-1;"
+                + "ALGORITHMS=manta\tGT:ECN\t0/1:2\t0/1:2\t0/0:2");
+        lines.add("chr1\t100050\ti2\tN\t<INS>\t.\t.\tSVTYPE=INS;END=100050;SVLEN=-1;"
+                + "ALGORITHMS=manta\tGT:ECN\t0/1:2\t0/1:2\t0/0:2");
+        // Two inversions whose strands disagree.
+        lines.add(record("v1", 120000, "INV", 130000, 10001, null, null, "++", "manta",
+                "0/1", "0/1", "0/0"));
+        lines.add(record("v2", 120100, "INV", 130100, 10001, null, null, "--", "manta",
+                "0/1", "0/1", "0/0"));
+        // Two breakends into chr2, close together.
+        lines.add(record("b1", 150000, "BND", 150000, -1, "chr2", 50000, "+-", "manta",
+                "0/1", "0/1", "0/0"));
+        lines.add(record("b2", 150100, "BND", 150100, -1, "chr2", 50100, "+-", "manta",
+                "0/1", "0/1", "0/0"));
+        // Two deletions that overlap but share no carrier.
+        lines.add(del("s1", 170000, 180000, "depth", "0/1", "0/0", "0/0"));
+        lines.add(del("s2", 170100, 180100, "depth", "0/0", "0/0", "0/1"));
+        lines.add("");
+        return String.join("\n", lines);
+    }
+
+    static String del(final String id, final int start, final int end, final String algorithm,
+                      final String... genotypes) {
+        return record(id, start, "DEL", end, end - start + 1, null, null, null, algorithm,
+                genotypes);
+    }
+
+    static String record(final String id, final int start, final String type, final int end,
+                         final int length, final String contig2, final Integer end2,
+                         final String strands, final String algorithm, final String... genotypes) {
+        final StringBuilder info = new StringBuilder("SVTYPE=" + type + ";END=" + end
+                + ";SVLEN=" + length + ";ALGORITHMS=" + algorithm);
+        if (contig2 != null) {
+            info.append(";CHR2=").append(contig2).append(";END2=").append(end2);
+        }
+        if (strands != null) {
+            info.append(";STRANDS=").append(strands);
+        }
+        final List<String> withEcn = new ArrayList<>();
+        for (final String genotype : genotypes) {
+            withEcn.add(genotype + ":2");
+        }
+        return "chr1\t" + start + "\t" + id + "\tN\t<" + type + ">\t.\t.\t" + info
+                + "\tGT:ECN\t" + String.join("\t", withEcn);
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("sv-cluster-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# SVClusterDump: which structural variants are judged the same event");
+
+        final Path dict = writeDictionary(dir);
+        // A real reference is required too: the tool reads the base at each record's position for
+        // the collapsed representative's REF allele.
+        final Path fasta = writeReference(dir);
+        // The ploidy table is required: a header of SAMPLE plus one column per contig, and one
+        // row per sample. Without it the run is refused before a record is read.
+        final Path ploidy = write(dir, "ploidy.tsv", String.join("\n",
+                "SAMPLE\tchr1\tchr2",
+                "s1\t2\t2",
+                "s2\t2\t2",
+                "s3\t2\t2",
+                ""));
+        System.out.printf("ploidy\ttable=%s%n",
+                ReferenceQueryDump.escape(Files.readString(ploidy)));
+        final String vcf = buildVcf();
+        final Path input = write(dir, "input.vcf", vcf);
+        System.out.printf("vcf\tinput=%s%n", ReferenceQueryDump.escape(vcf));
+
+        // The two algorithms over the same records, which is the chain test.
+        run(dir, "single-linkage", input, dict, List.of("--algorithm", "SINGLE_LINKAGE"));
+        run(dir, "max-clique", input, dict, List.of("--algorithm", "MAX_CLIQUE"));
+        // Deletions and duplications allowed to cluster with each other.
+        run(dir, "enable-cnv", input, dict, List.of("--algorithm", "SINGLE_LINKAGE",
+                "--enable-cnv", "true"));
+        // --enable-cnv is only observable under max clique: under single linkage the CNV already
+        // chains the deletion to the duplication, so allowing them to link directly changes
+        // nothing.
+        run(dir, "max-clique-enable-cnv", input, dict, List.of("--algorithm", "MAX_CLIQUE",
+                "--enable-cnv", "true"));
+        // A depth overlap threshold nothing reaches, and one everything reaches.
+        run(dir, "depth-overlap-high", input, dict, List.of("--algorithm", "SINGLE_LINKAGE",
+                "--depth-interval-overlap", "0.99"));
+        run(dir, "depth-overlap-low", input, dict, List.of("--algorithm", "SINGLE_LINKAGE",
+                "--depth-interval-overlap", "0.1", "--depth-size-similarity", "0.1"));
+        // Sample overlap, which is the last test the predicate makes.
+        run(dir, "sample-overlap", input, dict, List.of("--algorithm", "SINGLE_LINKAGE",
+                "--depth-sample-overlap", "0.5"));
+        // A breakend window wide enough to reach the pairs proximity alone would not.
+        run(dir, "wide-window", input, dict, List.of("--algorithm", "SINGLE_LINKAGE",
+                "--pesr-breakend-window", "5000"));
+        // The member ids omitted, which is the only thing that hides the clustering.
+        run(dir, "omit-members", input, dict, List.of("--algorithm", "SINGLE_LINKAGE",
+                "--omit-members", "true"));
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path input, final Path dict,
+                    final List<String> extra) throws Exception {
+        final Path out = dir.resolve("out-" + label + ".vcf");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-V", input.toString(),
+                "-O", out.toString(),
+                "--sequence-dictionary", dict.toString(),
+                "--ploidy-table", dir.resolve("ploidy.tsv").toString(),
+                "-R", dir.resolve("reference.fasta").toString()));
+        argv.addAll(extra);
+        try {
+            new SVCluster().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            return;
+        }
+        final StringBuilder body = new StringBuilder();
+        for (final String line : Files.readString(out).split("\n", -1)) {
+            if (!line.startsWith("##") && !line.isEmpty()) {
+                body.append(line).append("\n");
+            }
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(body.toString(), dir)));
+    }
+
+    /**
+     * Two contigs of 199980 bases, which is 3333 lines of 60.
+     *
+     * The length is not round on purpose: it has to be a whole number of FASTA lines, and a
+     * dictionary claiming 200000 against a file holding 199980 is refused with `Index length does
+     * not match dictionary length for contig: chr1`.
+     */
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("reference.fasta");
+        final StringBuilder bases = new StringBuilder();
+        for (final String contig : new String[] {"chr1", "chr2"}) {
+            bases.append(">").append(contig).append("\n");
+            for (int i = 0; i < 199980 / 60; i++) {
+                bases.append("ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n");
+            }
+        }
+        Files.writeString(fasta, bases.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        // No CreateSequenceDictionary here: writeDictionary already wrote reference.dict beside
+        // the fasta, which is where htsjdk looks for it.
+        return fasta;
+    }
+
+    static Path writeDictionary(final Path dir) throws Exception {
+        final SAMSequenceDictionary dictionary = new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", 199980),
+                new SAMSequenceRecord("chr2", 199980)));
+        final Path path = dir.resolve("reference.dict");
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(dictionary);
+        try (final java.io.Writer writer = Files.newBufferedWriter(path)) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, header);
+        }
+        return path;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Eighteen structural variants over two contigs, run nine ways. This is the measurement for the clustering engine that `SVCluster`, `GroupedSVCluster`, `SVConcordance` and `JointGermlineCNVSegmentation` all sit on.

**The parameter set is chosen by the pair, not by the user.** Two depth-only records take the depth thresholds, two PESR records the PESR ones, and one of each the *mixed* ones. A single run applies three different thresholds to different pairs of the same file, decided by each record's own `ALGORITHMS` field.

**Single linkage and max clique disagree, and the chain here is made by the type rule rather than by coordinates.** A deletion and a duplication at the same locus do not cluster with each other; both cluster with a CNV sitting between them. So:

```
single-linkage         c1,e1,u1
max-clique             c1,u1   and   c1,e1
max-clique-enable-cnv  c1,e1,u1
```

`--enable-cnv` is only observable under max clique — under single linkage the CNV already chains the two together, which is why the naive run pair shows no difference at all.

The rest: reciprocal overlap and size similarity are separate tests and both must pass, so two deletions sharing a start and differing twentyfold in length overlap and still do not cluster; only BND and INV require matching strands; sample overlap is tested last and is zero by default, so two records sharing no carrier cluster until `--depth-sample-overlap` is raised; and `--omit-members` removes the only field that shows the clustering, which is what makes it the run that proves the others were reading something real.

The fixture needed four things the tool requires and does not default, each found by being refused: a `--ploidy-table`, a real `--reference`, an `ECN` on every genotype, and a dictionary length matching the FASTA **to the base** — 199980, not 200000, because a contig has to be a whole number of 60-base lines.

Ran twice in the pinned container and diffed: identical. The golden is `null` here and comes from this run's artefact.

Part of #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)