### PR TITLE
Ignore the completion ledger and its hook state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ tools/conformance/pending/
 
 # The editor workspace file, which is one developer's layout and not the repository's.
 *.code-workspace
+
+# unlazy: the completion ledger, its approvals and the stop hook's per-session state. The ledger
+# is a working artefact of one session, not a repository fact; what it proves lands in the commit
+# history instead.
+.unlazy/
+.unlazy-hook-state.json
+.claude/settings.local.json


### PR DESCRIPTION
The unlazy ledger, its approvals and the stop hook per-session state are working artefacts of one session, not repository facts. What a ledger proves lands in the commit history instead.

Three paths: `.unlazy/`, `.unlazy-hook-state.json`, `.claude/settings.local.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)