### PR TITLE
Measure GroupedSVCluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,10 @@ jobs:
             index: "48/48"
             slug: "sv-stratify-add-flow-snv-quality-calculate-genotype-posteriors-family-priors-sv-cluster"
             suites: "sv-stratify add-flow-snv-quality calculate-genotype-posteriors family-priors sv-cluster"
+          - group: golden-pending
+            index: "1/1"
+            slug: "grouped-sv-cluster"
+            suites: "grouped-sv-cluster"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 150 | 48.2% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 149 | 47.9% |
+| not started | 148 | 47.6% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (102 of 190 started)
+## gatk-origin tools (103 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -147,6 +147,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |
 | `GetPileupSummaries` | locus-walker | oracle-backed | get-pileup-summaries | 1 | not measured |
 | `GetSampleName` | reporting-walker | oracle-backed | get-sample-name | 1 | not measured |
+| `GroupedSVCluster` | sv-caller | golden-pending | grouped-sv-cluster | 1 | not measured |
 | `GtfToBed` | assembly-caller | oracle-backed | gtf-to-bed | 1 | not measured |
 | `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file | 1 | not measured |
 | `LeftAlignAndTrimVariants` | variant-transform | oracle-backed | left-align-and-trim-variants | 1 | not measured |
@@ -192,9 +193,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>88 not started</summary>
+<details><summary>87 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `GroupedSVCluster`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVConcordance`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CollectSVEvidence`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `JointGermlineCNVSegmentation`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `SVAnnotate`, `SVConcordance`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5621,6 +5621,26 @@
           "why": "Eighteen records over two contigs, run nine ways: the two algorithms, --enable-cnv under each, a depth overlap threshold nothing reaches and one everything reaches, a raised sample overlap, a widened PESR breakend window, and --omit-members. The whole input VCF and the ploidy table are reported beside the outputs. The fixture needed four things the tool requires and does not default: a ploidy table, a real reference, an ECN on every genotype, and a dictionary length that matches the FASTA to the base. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33018774946, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "grouped-sv-cluster",
+      "status": "golden-pending",
+      "title": "one stratum per record, one threshold set per stratum",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "GroupedSVCluster"
+      ],
+      "why": "EACH STRATUM CLUSTERS WITH ITS OWN THRESHOLDS: two large deletions that would cluster under a half-overlap threshold stay apart under their stratum's 0.99, while two small ones cluster, in the same run and from the same engine. A RECORD MATCHING TWO STRATA IS REFUSED OUTRIGHT here, and the message differs from SVStratify's: this tool says the groups must be mutually exclusive rather than offering a flag, because allowing it would proliferate variants, and the groups are listed in java.util.HashMap order over their names. AN UNMATCHED RECORD IS NOT CLUSTERED AT ALL: it is written straight out carrying its own id as its only member and `default` as its stratum. THE TWO CONFIGURATIONS MUST NAME THE SAME GROUPS, checked twice, once by count and once by name, with two different messages. AN EMPTY STRATIFICATION CONFIGURATION IS REFUSED before either engine is built. AND THE COLUMN-COUNT MESSAGE PRINTS THE SAME NUMBER TWICE here as well: `Expected 6 columns but found 6`, a second copy of the same mistake the stratification parser makes.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "GroupedSVClusterDump",
+          "golden": null,
+          "why": "Seven records over three strata, run two ways and refused five: the two algorithms, a clustering table with a row too few, one whose row is renamed, an empty stratification table, two strata a single record matches, and a clustering table with an extra column. Both configuration tables and the whole input VCF are reported beside the outputs."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/GroupedSVClusterDump.java
+++ b/tools/readfilter-conformance/GroupedSVClusterDump.java
@@ -1,0 +1,241 @@
+/*
+ * GroupedSVCluster's clusters, taken from the reference.
+ *
+ * The stratification engine and the clustering engine bolted together: each record is sorted into
+ * exactly one stratum, and each stratum clusters with its own thresholds. What the tool adds over
+ * the two engines is the pairing of the two configurations, and what it refuses when they disagree.
+ *
+ * Eight behaviours this is built to catch.
+ *
+ *   - THE TWO CONFIGURATIONS MUST NAME THE SAME GROUPS, checked twice: once by count and once by
+ *     name, with two different messages;
+ *   - AN EMPTY STRATIFICATION CONFIGURATION IS REFUSED before either engine is built;
+ *   - A RECORD MATCHING TWO STRATA IS REFUSED HERE, with a DIFFERENT message from SVStratify's:
+ *     this tool says the groups must be mutually exclusive rather than offering a flag, because
+ *     allowing it would proliferate variants;
+ *   - AN UNMATCHED RECORD IS NOT CLUSTERED AT ALL: it is written straight out carrying its own id
+ *     as its only member and `default` as its stratum;
+ *   - EACH STRATUM CLUSTERS WITH ITS OWN THRESHOLDS, so two records that would cluster under one
+ *     group's parameters do not under another's;
+ *   - THE STRATUM IS WRITTEN INTO EVERY RECORD, matched or not;
+ *   - THE OUTPUT IS NOT SORTED and the tool says so by disabling its own index;
+ *   - AND THE COLUMN-COUNT MESSAGE PRINTS THE SAME NUMBER TWICE, in a second copy of the same
+ *     mistake the stratification parser makes.
+ *
+ * Output:
+ *
+ *     vcf\tinput=<the whole input vcf, escaped>
+ *     strata\t<label>=<the stratification table, escaped>
+ *     cluster\t<label>=<the clustering table, escaped>
+ *     out\t<label>=<the whole output vcf without its header, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: GroupedSVClusterDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.tools.walkers.sv.GroupedSVCluster;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GroupedSVClusterDump {
+
+    /** Two strata over deletions, split by size, plus one over duplications. */
+    static final String STRATA = String.join("\n",
+            "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE\tTRACKS",
+            "DEL_small\tDEL\t-1\t5000\t-1",
+            "DEL_large\tDEL\t5000\t-1\t-1",
+            "DUP_any\tDUP\t-1\t-1\t-1",
+            "");
+
+    /** One row per stratum, with thresholds that differ between them on purpose. */
+    static final String CLUSTERING = String.join("\n",
+            "NAME\tRECIPROCAL_OVERLAP\tSIZE_SIMILARITY\tBREAKEND_WINDOW\tSAMPLE_OVERLAP",
+            "DEL_small\t0.5\t0\t500\t0",
+            "DEL_large\t0.99\t0\t100\t0",
+            "DUP_any\t0.5\t0\t500\t0",
+            "");
+
+    static String buildVcf() {
+        final List<String> lines = new ArrayList<>(List.of(
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=199980>",
+                "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type\">",
+                "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length\">",
+                "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End\">",
+                "##INFO=<ID=ALGORITHMS,Number=.,Type=String,Description=\"Algorithms\">",
+                "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+                "##FORMAT=<ID=ECN,Number=1,Type=Integer,Description=\"Expected copy number\">",
+                "##ALT=<ID=DEL,Description=\"Deletion\">",
+                "##ALT=<ID=DUP,Description=\"Duplication\">",
+                "##ALT=<ID=INS,Description=\"Insertion\">",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts1\ts2"));
+        // Two small deletions that cluster under DEL_small's half-overlap threshold.
+        lines.add(record("small1", 1000, "DEL", 2000, 1001));
+        lines.add(record("small2", 1300, "DEL", 2300, 1001));
+        // Two large deletions that would cluster under a half-overlap threshold and do NOT under
+        // DEL_large's 0.99, which is what shows each stratum using its own parameters.
+        lines.add(record("large1", 20000, "DEL", 30000, 10001));
+        lines.add(record("large2", 21000, "DEL", 31000, 10001));
+        // Two duplications, in their own stratum.
+        lines.add(record("dup1", 50000, "DUP", 51000, 1001));
+        lines.add(record("dup2", 50300, "DUP", 51300, 1001));
+        // An insertion, which no stratum claims.
+        lines.add("chr1\t80000\tunmatched\tN\t<INS>\t.\t.\tSVTYPE=INS;END=80000;SVLEN=-1;"
+                + "ALGORITHMS=depth\tGT:ECN\t0/1:2\t0/1:2");
+        lines.add("");
+        return String.join("\n", lines);
+    }
+
+    static String record(final String id, final int start, final String type, final int end,
+                         final int length) {
+        return "chr1\t" + start + "\t" + id + "\tN\t<" + type + ">\t.\t.\tSVTYPE=" + type
+                + ";END=" + end + ";SVLEN=" + length + ";ALGORITHMS=depth\tGT:ECN\t0/1:2\t0/1:2";
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("grouped-sv-cluster-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# GroupedSVClusterDump: one stratum per record, one threshold set per stratum");
+
+        final Path dict = writeDictionary(dir);
+        final Path fasta = writeReference(dir);
+        final Path ploidy = write(dir, "ploidy.tsv", "SAMPLE\tchr1\ns1\t2\ns2\t2\n");
+        final String vcf = buildVcf();
+        final Path input = write(dir, "input.vcf", vcf);
+        System.out.printf("vcf\tinput=%s%n", ReferenceQueryDump.escape(vcf));
+
+        final Path strata = write(dir, "strata.tsv", STRATA);
+        final Path clustering = write(dir, "clustering.tsv", CLUSTERING);
+        System.out.printf("strata\tmain=%s%n", ReferenceQueryDump.escape(STRATA));
+        System.out.printf("cluster\tmain=%s%n", ReferenceQueryDump.escape(CLUSTERING));
+
+        run(dir, "default", input, dict, fasta, ploidy, strata, clustering, List.of());
+        run(dir, "max-clique", input, dict, fasta, ploidy, strata, clustering,
+                List.of("--algorithm", "MAX_CLIQUE"));
+
+        // A clustering configuration with one row too few, and one whose row is named differently.
+        final Path shortTable = write(dir, "short.tsv", String.join("\n",
+                "NAME\tRECIPROCAL_OVERLAP\tSIZE_SIMILARITY\tBREAKEND_WINDOW\tSAMPLE_OVERLAP",
+                "DEL_small\t0.5\t0\t500\t0",
+                "DEL_large\t0.99\t0\t100\t0",
+                ""));
+        System.out.printf("cluster\tshort=%s%n",
+                ReferenceQueryDump.escape(Files.readString(shortTable)));
+        run(dir, "too-few-groups", input, dict, fasta, ploidy, strata, shortTable, List.of());
+
+        final Path renamed = write(dir, "renamed.tsv", CLUSTERING.replace("DUP_any", "DUP_other"));
+        System.out.printf("cluster\trenamed=%s%n",
+                ReferenceQueryDump.escape(Files.readString(renamed)));
+        run(dir, "group-not-found", input, dict, fasta, ploidy, strata, renamed, List.of());
+
+        // A stratification configuration with a header and no rows.
+        final Path empty = write(dir, "empty-strata.tsv",
+                "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE\tTRACKS\n");
+        System.out.printf("strata\tempty=%s%n",
+                ReferenceQueryDump.escape(Files.readString(empty)));
+        run(dir, "no-strata", input, dict, fasta, ploidy, empty, clustering, List.of());
+
+        // Two strata a single record matches, which this tool refuses outright.
+        final Path overlapping = write(dir, "overlapping.tsv", String.join("\n",
+                "NAME\tSVTYPE\tMIN_SIZE\tMAX_SIZE\tTRACKS",
+                "DEL_a\tDEL\t-1\t-1\t-1",
+                "DEL_b\tDEL\t-1\t-1\t-1",
+                ""));
+        final Path twoGroups = write(dir, "two-groups.tsv", String.join("\n",
+                "NAME\tRECIPROCAL_OVERLAP\tSIZE_SIMILARITY\tBREAKEND_WINDOW\tSAMPLE_OVERLAP",
+                "DEL_a\t0.5\t0\t500\t0",
+                "DEL_b\t0.5\t0\t500\t0",
+                ""));
+        System.out.printf("strata\toverlapping=%s%n",
+                ReferenceQueryDump.escape(Files.readString(overlapping)));
+        run(dir, "multiple-matches", input, dict, fasta, ploidy, overlapping, twoGroups, List.of());
+
+        // A clustering table with an extra column, which is the second copy of the doubled-number
+        // message.
+        final Path extra = write(dir, "extra.tsv", String.join("\n",
+                "NAME\tRECIPROCAL_OVERLAP\tSIZE_SIMILARITY\tBREAKEND_WINDOW\tSAMPLE_OVERLAP\tEXTRA",
+                "DEL_small\t0.5\t0\t500\t0\tx",
+                ""));
+        run(dir, "extra-column", input, dict, fasta, ploidy, strata, extra, List.of());
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path input, final Path dict,
+                    final Path fasta, final Path ploidy, final Path strata, final Path clustering,
+                    final List<String> extra) throws Exception {
+        final Path out = dir.resolve("out-" + label + ".vcf");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-V", input.toString(),
+                "-O", out.toString(),
+                "-R", fasta.toString(),
+                "--sequence-dictionary", dict.toString(),
+                "--ploidy-table", ploidy.toString(),
+                "--stratify-config", strata.toString(),
+                "--clustering-config", clustering.toString()));
+        argv.addAll(extra);
+        try {
+            new GroupedSVCluster().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            return;
+        }
+        final StringBuilder body = new StringBuilder();
+        for (final String line : Files.readString(out).split("\n", -1)) {
+            if (!line.startsWith("##") && !line.isEmpty()) {
+                body.append(line).append("\n");
+            }
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(body.toString(), dir)));
+    }
+
+    /** One contig of 199980 bases, which is 3333 lines of 60. */
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("reference.fasta");
+        final StringBuilder bases = new StringBuilder(">chr1\n");
+        for (int i = 0; i < 3333; i++) {
+            bases.append("ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n");
+        }
+        Files.writeString(fasta, bases.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        return fasta;
+    }
+
+    static Path writeDictionary(final Path dir) throws Exception {
+        final SAMSequenceDictionary dictionary = new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", 199980)));
+        final Path path = dir.resolve("reference.dict");
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(dictionary);
+        try (final java.io.Writer writer = Files.newBufferedWriter(path)) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, header);
+        }
+        return path;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
The stratification engine and the clustering engine bolted together, both already ported ([#869](https://github.com/IPNP-BIPN/gatk-rs/pull/869), [#879](https://github.com/IPNP-BIPN/gatk-rs/pull/879)). What this tool adds is the pairing of two configuration tables, and what it refuses when they disagree.

**Each stratum clusters with its own thresholds.** Two large deletions that would cluster under a half-overlap threshold stay apart under their stratum's 0.99, while two small ones cluster — same run, same engine:

```
small1  members=small1,small2  strat=DEL_small
large1  members=large1         strat=DEL_large
large2  members=large2         strat=DEL_large
dup1    members=dup1,dup2      strat=DUP_any
```

**A record matching two strata is refused outright, and the message is not SVStratify's.** There the refusal offers `--allow-multiple-matches`; here it says the groups must be mutually exclusive, because allowing it would proliferate variants. The groups are listed in `java.util.HashMap` order over their names, same as the other tool.

**An unmatched record is not clustered at all** — it is written straight out carrying its own id as its only member and `default` as its stratum.

The two configurations must name the same groups, checked twice with two different messages: once by count, once by name. An empty stratification table is refused before either engine is built.

And the doubled-number message has a second home: `Expected 6 columns but found 6` from `StratifiedClusteringTableParser`, the same mistake `SVStatificationEngine` makes, in a different file.

Ran twice in the pinned container and diffed: identical. The golden is `null` here and comes from this run's artefact.

Part of #632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)