### PR TITLE
Report the reads' bases in CollectSVEvidenceDump

### DIFF
--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5718,7 +5718,7 @@
         {
           "dump": "CollectSVEvidenceDump",
           "golden": null,
-          "why": "One coordinate-sorted BAM of twenty-two reads over two contigs, a VCF of six candidate site-depth loci of which three qualify, and three depth intervals of which one is reached by nothing, run five ways and refused seven: all four outputs at once, a raised mapping-quality floor, a lowered base-quality floor, the discordant and split writers each on their own, then no output at all, an unpaired read, a wrong file name for each of the four writers, and an empty intervals file. The reads are reported as a line each, and both reference files whole, beside the outputs."
+          "why": "One coordinate-sorted BAM of twenty-two reads over two contigs, a VCF of six candidate site-depth loci of which three qualify, and three depth intervals of which one is reached by nothing, run five ways and refused seven: all four outputs at once, a raised mapping-quality floor, a lowered base-quality floor, the discordant and split writers each on their own, then no output at all, an unpaired read, a wrong file name for each of the four writers, and an empty intervals file. The reads are reported as a line each, bases and base qualities included so the site depths can be recomputed from the golden rather than from the dump's source, and both reference files whole, beside the outputs."
         }
       ]
     }

--- a/tools/readfilter-conformance/CollectSVEvidenceDump.java
+++ b/tools/readfilter-conformance/CollectSVEvidenceDump.java
@@ -206,10 +206,22 @@ public class CollectSVEvidenceDump {
         return records;
     }
 
-    /** The reads as text, so the golden says what was fed in. */
+    /**
+     * The reads as text, so the golden says what was fed in.
+     *
+     * The BASES and the BASE QUALITIES are reported too: without them the site-depth counts cannot
+     * be recomputed from the golden, only from the source of this file.
+     */
     static String describe(final List<SAMRecord> records) {
         final StringBuilder text = new StringBuilder();
         for (final SAMRecord record : records) {
+            final StringBuilder qualities = new StringBuilder();
+            for (final byte quality : record.getBaseQualities()) {
+                if (qualities.length() > 0) {
+                    qualities.append(',');
+                }
+                qualities.append(quality);
+            }
             text.append(record.getReadName()).append('\t')
                     .append(record.getFlags()).append('\t')
                     .append(record.getReferenceName()).append('\t')
@@ -219,6 +231,9 @@ public class CollectSVEvidenceDump {
                     .append(record.getReadPairedFlag() ? record.getMateReferenceName() : ".")
                     .append('\t')
                     .append(record.getReadPairedFlag() ? record.getMateAlignmentStart() : 0)
+                    .append('\t')
+                    .append(record.getReadString()).append('\t')
+                    .append(qualities)
                     .append('\n');
         }
         return text.toString();


### PR DESCRIPTION
The read table carried name, flags, contig, start, mapping quality, cigar and
mate position, which is enough to recompute the discordant pairs, the split
reads and the interval depths. It is not enough for the site depths: those are
counts of BASES that passed a base-quality floor, and the golden carried
neither the bases nor the qualities.

Recomputing them would have meant reading the dump's own source rather than
the golden, which is not a comparison. The table now reports the read string
and the per-base qualities as well.

No behaviour is measured differently. Only the input description grows, so the
four evidence outputs and the seven refusals are unchanged from run
33027732942.

Run twice in the pinned container with identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)