### PR TITLE
Measure FilterAlignmentArtifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,10 @@ jobs:
             index: "49/49"
             slug: "grouped-sv-cluster-sv-concordance-sv-annotate-joint-germline-cnv-segmentation-collect-sv-evidence"
             suites: "grouped-sv-cluster sv-concordance sv-annotate joint-germline-cnv-segmentation collect-sv-evidence"
+          - group: golden-pending
+            index: "1/1"
+            slug: "filter-alignment-artifacts"
+            suites: "filter-alignment-artifacts"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 155 | 49.8% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 144 | 46.3% |
+| not started | 143 | 46.0% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (107 of 190 started)
+## gatk-origin tools (108 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -132,6 +132,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ExampleMultiFeatureWalker` | unclassified | oracle-backed | multi-feature-walker | 1 | not measured |
 | `FastaAlternateReferenceMaker` | reference-utility | oracle-backed | fasta-alternate-reference-maker | 1 | not measured |
 | `FastaReferenceMaker` | reference-utility | oracle-backed | fasta-reference-maker | 1 | not measured |
+| `FilterAlignmentArtifacts` | variant-transform | golden-pending | filter-alignment-artifacts | 1 | not measured |
 | `FilterFuncotations` | variant-walker | oracle-backed | filter-funcotations | 1 | not measured |
 | `FilterIntervals` | cnv-segmentation | oracle-backed | filter-intervals | 1 | not measured |
 | `FilterMutectCalls` | variant-transform | oracle-backed | filter-mutect-calls | 1 | not measured |
@@ -197,9 +198,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>83 not started</summary>
+<details><summary>82 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FilterAlignmentArtifacts`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5721,6 +5721,26 @@
           "why": "One coordinate-sorted BAM of twenty-two reads over two contigs, a VCF of six candidate site-depth loci of which three qualify, and three depth intervals of which one is reached by nothing, run five ways and refused seven: all four outputs at once, a raised mapping-quality floor, a lowered base-quality floor, the discordant and split writers each on their own, then no output at all, an unpaired read, a wrong file name for each of the four writers, and an empty intervals file. The reads are reported as a line each, bases and base qualities included so the site depths can be recomputed from the golden rather than from the dump's source, and both reference files whole, beside the outputs. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33028127949, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "filter-alignment-artifacts",
+      "status": "golden-pending",
+      "title": "which reads support a variant, and which realignments are the same one",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "FilterAlignmentArtifacts"
+      ],
+      "why": "A READ SUPPORTS A SNP BY ITS BASES, compared from the offset the reference coordinate maps to, and a variant position that falls inside a DELETION never supports a SNP. AN INDEL IS MATCHED BY CIGAR OPERATOR INSTEAD, because indel representation is not unique: a deletion by a D or an S, an insertion by an I or an S. THE WALK COMPARES A RUNNING SUM OF ELEMENT LENGTHS against the variant's offset, so at a tolerance of 0 the sum has to land on it EXACTLY: a leading 6M steps from 0 straight over an offset of 5 and the read supports nothing. AN INSERTION IS THEREFORE NEVER SUPPORTED BY AN I AT TOLERANCE 0, whatever the cigar, because the read index for the variant position lands PAST the inserted bases and the sum is short of it by the insertion's own length; only a soft clip supports an insertion exactly. AND THE TOLERANCE LOOP STOPS ADVANCING THE SUM once an element is within tolerance, so a wide enough tolerance freezes it at 0 and scans the whole cigar for a supporting operator however far away it really is: the same read that supports nothing at 0 supports the deletion at 5. ON THE JOINT SIDE, one unitig makes every alignment its own joint alignment and no unitigs make none; TWO UNITIGS JOIN ONLY ON THE SAME STRAND and only within half the maximum fragment length on each side; the BEST-SCORING alignment of each unitig is the one kept; a locus only some of the unitigs reach is dropped; AND THE RESULT COMES OUT OF A HashSet OF LISTS whose elements define no equals, so its order is identity-hash order and is not reproducible, which is why the report sorts it.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "FilterAlignmentArtifactsDump",
+          "golden": null,
+          "why": "Fifteen read-and-variant pairs through `supportsVariant` and thirteen sets of constructed alignments through `findJointAlignments`, both of them public and both decidable without an aligner. The realignment itself is not measured here: it is BWA's, and the assembly that produces the unitigs is the Mutect2 assembler's. What is measured is the two rules the tool owns."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/FilterAlignmentArtifactsDump.java
+++ b/tools/readfilter-conformance/FilterAlignmentArtifactsDump.java
@@ -1,0 +1,243 @@
+/*
+ * FilterAlignmentArtifacts' two decidable rules, taken from the reference.
+ *
+ * Whether a variant is an artefact of alignment: the reads supporting it are reassembled into
+ * unitigs, the unitigs are realigned, and if they map somewhere else just as well the variant is
+ * filtered. Two of the three steps are decidable without an aligner, and those are what this
+ * measures: which reads are taken to SUPPORT the variant, and which realignments are taken to be
+ * the SAME joint alignment.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - A READ SUPPORTS A SNP BY ITS BASES, compared from the offset the reference coordinate maps
+ *     to, and a variant position that falls inside a DELETION never supports a SNP;
+ *   - A READ THAT DOES NOT REACH THE POSITION SUPPORTS NOTHING;
+ *   - AN INDEL IS MATCHED BY CIGAR OPERATOR RATHER THAN BY BASES, because indel representation is
+ *     not unique: a deletion is supported by a D or an S, an insertion by an I or an S;
+ *   - THE TOLERANCE LOOP STOPS ADVANCING once an element is within tolerance, so every element
+ *     after the first match is also treated as being at the variant, whatever its length;
+ *   - --indel-start-tolerance WIDENS THAT WINDOW;
+ *   - ONE UNITIG MAKES EVERY ALIGNMENT ITS OWN JOINT ALIGNMENT, and no unitigs make none;
+ *   - TWO UNITIGS JOIN ONLY ON THE SAME STRAND, and only within half the maximum fragment length
+ *     on each side;
+ *   - THE BEST-SCORING ALIGNMENT OF EACH UNITIG IS THE ONE KEPT for a joint alignment;
+ *   - AND THE RESULT COMES OUT OF A HashSet OF LISTS whose elements define no equals, so its order
+ *     is identity-hash order and is not reproducible: the report below sorts it.
+ *
+ * Output:
+ *
+ *     support\t<label>=<true|false>
+ *     joint\t<label>=<one line per joint alignment: refId:refStart-refEnd/score/mismatches, sorted>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: FilterAlignmentArtifactsDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import org.broadinstitute.hellbender.utils.bwa.BwaMemAlignment;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.broadinstitute.hellbender.tools.walkers.realignmentfilter.RealignmentEngine;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FilterAlignmentArtifactsDump {
+
+    static final int CONTIG_LENGTH = 199980;
+
+    static SAMFileHeader header() {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", CONTIG_LENGTH),
+                new SAMSequenceRecord("chr2", CONTIG_LENGTH))));
+        return header;
+    }
+
+    static GATKRead read(final SAMFileHeader header, final String name, final int start,
+                         final String cigar, final String bases) {
+        final SAMRecord record = new SAMRecord(header);
+        record.setReadName(name);
+        record.setReferenceName("chr1");
+        record.setAlignmentStart(start);
+        record.setCigarString(cigar);
+        record.setMappingQuality(60);
+        record.setReadBases(bases.getBytes());
+        final byte[] qualities = new byte[bases.length()];
+        Arrays.fill(qualities, (byte) 30);
+        record.setBaseQualities(qualities);
+        return new SAMRecordToGATKReadAdapter(record);
+    }
+
+    static VariantContext variant(final int start, final String reference, final String alternate) {
+        final Allele ref = Allele.create(reference, true);
+        final Allele alt = Allele.create(alternate, false);
+        return new VariantContextBuilder("dump", "chr1", start,
+                start + reference.length() - 1, List.of(ref, alt)).make();
+    }
+
+    static void support(final String label, final GATKRead read, final VariantContext variant,
+                        final int tolerance) {
+        System.out.printf("support\t%s=%s%n", label,
+                RealignmentEngine.supportsVariant(read, variant, tolerance));
+    }
+
+    /** One alignment, with only the fields the joint rule reads. */
+    static BwaMemAlignment alignment(final int refId, final int refStart, final int refEnd,
+                                     final int score, final int mismatches, final boolean reverse) {
+        return new BwaMemAlignment(reverse ? 16 : 0, refId, refStart, refEnd, 0, refEnd - refStart,
+                60, mismatches, score, 0, null, null, null, -1, -1, 0);
+    }
+
+    static String describe(final BwaMemAlignment alignment) {
+        return alignment.getRefId() + ":" + alignment.getRefStart() + "-" + alignment.getRefEnd()
+                + "/" + alignment.getAlignerScore() + "/" + alignment.getNMismatches()
+                + ((alignment.getSamFlag() & 16) != 0 ? "/-" : "/+");
+    }
+
+    static void joint(final String label, final List<List<BwaMemAlignment>> unitigs,
+                      final int maxFragmentLength) {
+        // The reference returns a HashSet's iteration order over lists whose elements define no
+        // equals, which is identity-hash order and not reproducible: sorted here so the golden is.
+        final List<String> lines = new ArrayList<>();
+        for (final List<BwaMemAlignment> group :
+                RealignmentEngine.findJointAlignments(copy(unitigs), maxFragmentLength)) {
+            final List<String> parts = new ArrayList<>();
+            for (final BwaMemAlignment alignment : group) {
+                parts.add(describe(alignment));
+            }
+            java.util.Collections.sort(parts);
+            lines.add(String.join(",", parts));
+        }
+        java.util.Collections.sort(lines);
+        System.out.printf("joint\t%s=%s%n", label, String.join(";", lines));
+    }
+
+    /** findJointAlignments SORTS its argument in place, so each call gets its own copy. */
+    static List<List<BwaMemAlignment>> copy(final List<List<BwaMemAlignment>> unitigs) {
+        final List<List<BwaMemAlignment>> out = new ArrayList<>();
+        for (final List<BwaMemAlignment> unitig : unitigs) {
+            out.add(new ArrayList<>(unitig));
+        }
+        return out;
+    }
+
+    public static void main(final String[] args) {
+        System.out.println("# FilterAlignmentArtifactsDump: which reads support a variant, and "
+                + "which realignments are the same one");
+
+        final SAMFileHeader header = header();
+
+        // A SNP at 1005, on a read whose base there is the alternate.
+        final VariantContext snp = variant(1005, "A", "C");
+        support("snp-matching", read(header, "r", 1000, "20M", "ACGTACGTACGTACGTACGT"), snp, 0);
+        // The same read against a SNP whose alternate it does not carry.
+        support("snp-not-matching", read(header, "r", 1000, "20M", "ACGTACGTACGTACGTACGT"),
+                variant(1005, "A", "G"), 0);
+        // A read that stops before the variant.
+        support("snp-not-covered", read(header, "r", 1000, "3M", "ACG"), snp, 0);
+        // A read whose alignment DELETES the variant position, which never supports a SNP.
+        support("snp-in-deletion", read(header, "r", 1000, "3M5D12M", "ACGTACGTACGTACG"), snp, 0);
+
+        // An indel is matched by CIGAR OPERATOR rather than by bases. The walk compares a running
+        // sum of element lengths against the variant's offset in the read, which is 5 here, so at
+        // a tolerance of 0 the sum has to land on 5 EXACTLY.
+        final VariantContext deletion = variant(1005, "ACGTA", "A");
+        final VariantContext insertion = variant(1005, "A", "ACGTA");
+        support("del-exact-deletion", read(header, "r", 1000, "5M4D15M",
+                "ACGTACGTACGTACGTACGT"), deletion, 0);
+        // A soft clip stands in for a deletion as well as for an insertion.
+        support("del-exact-clip", read(header, "r", 1000, "5M15S",
+                "ACGTACGTACGTACGTACGT"), deletion, 0);
+        support("ins-exact-clip", read(header, "r", 1000, "5M15S",
+                "ACGTACGTACGTACGTACGT"), insertion, 0);
+        // An I operator cannot be reached at tolerance 0 at all: the read index for the variant
+        // position lands PAST the inserted bases, so the running sum is always short of it by the
+        // insertion's own length. Only the soft clip above supports an insertion exactly.
+        support("ins-exact-insertion", read(header, "r", 1000, "5M4I15M",
+                "ACGTACGTACGTACGTACGTACGT"), insertion, 0);
+        // With the tolerance wide enough for the first element to qualify, the sum freezes at 0
+        // and the I is reached after all.
+        support("ins-tolerant-insertion", read(header, "r", 1000, "5M4I15M",
+                "ACGTACGTACGTACGTACGTACGT"), insertion, 100);
+        // A deletion's operator does not support an insertion, or the other way round.
+        support("ins-exact-deletion", read(header, "r", 1000, "5M4D15M",
+                "ACGTACGTACGTACGTACGT"), insertion, 0);
+        support("del-exact-insertion", read(header, "r", 1000, "5M4I15M",
+                "ACGTACGTACGTACGTACGTACGT"), deletion, 0);
+        // A sum that steps OVER the offset never lands on it: 6M takes it from 0 to 6.
+        support("del-stepped-over", read(header, "r", 1000, "6M4D14M",
+                "ACGTACGTACGTACGTACGT"), deletion, 0);
+
+        // The tolerance, and the quirk in the loop it exposes: `readPosition` is advanced ONLY in
+        // the else branch, so as soon as one element is within tolerance the sum freezes and every
+        // element after it is treated as being at the variant too. At a tolerance of 5 the very
+        // first element already qualifies, the sum never moves off 0, and the whole cigar is
+        // scanned for a supporting operator however far away it really is.
+        final GATKRead far = read(header, "r", 1000, "12M4D8M", "ACGTACGTACGTACGTACGT");
+        support("tolerance-0", far, deletion, 0);
+        support("tolerance-5", far, deletion, 5);
+        support("tolerance-100", far, deletion, 100);
+        // The same read against an insertion, which its D cannot support at any tolerance.
+        support("tolerance-100-insertion", far, insertion, 100);
+
+        // Joint alignments. No unitigs at all.
+        joint("no-unitigs", List.of(), 1000);
+        // One unitig: every alignment becomes its own joint alignment.
+        joint("one-unitig", List.of(List.of(
+                alignment(0, 1000, 1100, 100, 0, false),
+                alignment(0, 5000, 5100, 90, 2, false),
+                alignment(1, 1000, 1100, 80, 4, false))), 1000);
+        // Two unitigs that overlap on the same strand.
+        joint("two-same-strand", List.of(
+                List.of(alignment(0, 1000, 1100, 100, 0, false)),
+                List.of(alignment(0, 1050, 1150, 95, 1, false))), 1000);
+        // The same pair on opposite strands, which never joins.
+        joint("two-opposite-strands", List.of(
+                List.of(alignment(0, 1000, 1100, 100, 0, false)),
+                List.of(alignment(0, 1050, 1150, 95, 1, true))), 1000);
+        // Far apart, so the padding decides it: half the maximum fragment length on each side.
+        joint("far-apart-narrow", List.of(
+                List.of(alignment(0, 1000, 1100, 100, 0, false)),
+                List.of(alignment(0, 3000, 3100, 95, 1, false))), 1000);
+        joint("far-apart-wide", List.of(
+                List.of(alignment(0, 1000, 1100, 100, 0, false)),
+                List.of(alignment(0, 3000, 3100, 95, 1, false))), 100000);
+        // Two candidates for the second unitig at one locus: the higher score is kept.
+        joint("best-score-kept", List.of(
+                List.of(alignment(0, 1000, 1100, 100, 0, false)),
+                List.of(alignment(0, 1050, 1150, 95, 1, false),
+                        alignment(0, 1060, 1160, 120, 3, false))), 1000);
+        // Two separate loci, each of which joins: two joint alignments.
+        joint("two-loci", List.of(
+                List.of(alignment(0, 1000, 1100, 100, 0, false),
+                        alignment(0, 50000, 50100, 98, 1, false)),
+                List.of(alignment(0, 1050, 1150, 95, 1, false),
+                        alignment(0, 50050, 50150, 93, 2, false))), 1000);
+        // A locus only one of the two unitigs reaches, which is dropped.
+        joint("one-sided", List.of(
+                List.of(alignment(0, 1000, 1100, 100, 0, false),
+                        alignment(0, 90000, 90100, 99, 0, false)),
+                List.of(alignment(0, 1050, 1150, 95, 1, false))), 1000);
+        // On different contigs, which never overlap.
+        joint("different-contigs", List.of(
+                List.of(alignment(0, 1000, 1100, 100, 0, false)),
+                List.of(alignment(1, 1000, 1100, 95, 1, false))), 1000);
+        // Three unitigs, which must ALL overlap.
+        joint("three-unitigs", List.of(
+                List.of(alignment(0, 1000, 1100, 100, 0, false)),
+                List.of(alignment(0, 1050, 1150, 95, 1, false)),
+                List.of(alignment(0, 1080, 1180, 90, 2, false))), 1000);
+        joint("three-unitigs-one-missing", List.of(
+                List.of(alignment(0, 1000, 1100, 100, 0, false)),
+                List.of(alignment(0, 1050, 1150, 95, 1, false)),
+                List.of(alignment(0, 90000, 90100, 90, 2, false))), 1000);
+    }
+}


### PR DESCRIPTION
The tool has three steps: reassemble the reads supporting a variant into
unitigs, realign the unitigs, and filter the variant if they map somewhere
else just as well. The middle step is BWA's and the first is the Mutect2
assembler's. The two rules the tool owns are decidable without either, and
both are public, so both are measured directly: fifteen read-and-variant pairs
through supportsVariant and thirteen sets of constructed alignments through
findJointAlignments. No golden yet: this is the measurement half of the brick.

supportsVariant matches a SNP by bases and an indel by cigar operator, because
indel representation is not unique. The walk compares a running sum of element
lengths against the variant's offset in the read, so at a tolerance of 0 the
sum has to land on it exactly: a leading 6M steps from 0 straight over an
offset of 5, and that read supports nothing.

Two consequences the fixture had to be rebuilt to show:

  - an insertion is never supported by an I operator at a tolerance of 0,
    whatever the cigar. The read index for the variant position lands past the
    inserted bases, so the running sum is always short of it by the
    insertion's own length. Only a soft clip supports an insertion exactly,
    and `ins-exact-clip` is the run that shows it. The first fixture had every
    indel case coming back false and no positive control at all;
  - the tolerance loop advances the sum ONLY in its else branch, so as soon as
    one element is within tolerance the sum freezes at that value and every
    element after it is treated as being at the variant. At a tolerance of 5
    the very first element already qualifies, the sum never moves off 0, and
    the whole cigar is scanned however far away the indel really is. The same
    read supports nothing at 0 and the deletion at 5.

findJointAlignments joins two unitigs only on the same strand and only within
half the maximum fragment length on each side, keeps the best-scoring
alignment of each unitig, and drops a locus only some of the unitigs reach.
Its result comes out of a HashSet of Lists whose elements define no equals, so
its order is identity-hash order and is not reproducible: the report sorts
both the groups and the alignments inside them, and says so.

Run twice in the pinned container with identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)