### PR TITLE
Measure LearnReadOrientationModel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,10 @@ jobs:
             index: "50/50"
             slug: "filter-alignment-artifacts"
             suites: "filter-alignment-artifacts"
+          - group: golden-pending
+            index: "1/1"
+            slug: "learn-read-orientation-model"
+            suites: "learn-read-orientation-model"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 156 | 50.2% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 143 | 46.0% |
+| not started | 142 | 45.7% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (108 of 190 started)
+## gatk-origin tools (109 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -153,6 +153,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GtfToBed` | assembly-caller | oracle-backed | gtf-to-bed | 1 | not measured |
 | `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file | 1 | not measured |
 | `JointGermlineCNVSegmentation` | sv-caller | oracle-backed | joint-germline-cnv-segmentation | 1 | not measured |
+| `LearnReadOrientationModel` | assembly-caller | golden-pending | learn-read-orientation-model | 1 | not measured |
 | `LeftAlignAndTrimVariants` | variant-transform | oracle-backed | left-align-and-trim-variants | 1 | not measured |
 | `LeftAlignIndels` | record-transform | oracle-backed | left-align-indels-tool | 1 | not measured |
 | `MTLowHeteroplasmyFilterTool` | unclassified | oracle-backed | mt-low-heteroplasmy | 1 | not measured |
@@ -198,9 +199,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>82 not started</summary>
+<details><summary>81 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LearnReadOrientationModel`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5741,6 +5741,26 @@
           "why": "Fifteen read-and-variant pairs through `supportsVariant` and thirteen sets of constructed alignments through `findJointAlignments`, both of them public and both decidable without an aligner. The realignment itself is not measured here: it is BWA's, and the assembly that produces the unitigs is the Mutect2 assembler's. What is measured is the two rules the tool owns. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33029059438, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "learn-read-orientation-model",
+      "status": "golden-pending",
+      "title": "which of twelve states a site is in",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "LearnReadOrientationModel"
+      ],
+      "why": "THE FLAT PRIOR IS NOT FLAT OVER TWELVE STATES: the two artefact states whose alternate base IS the reference base are given zero and the remaining ten share the mass at a tenth each, so the prior depends on the reference base and no state ever gets a twelfth. A REF-TO-REF ARTEFACT IS IMPOSSIBLE and takes zero responsibility however the counts fall, AND SO IS ANY ARTEFACT STATE WHOSE BASE IS NOT THE OBSERVED ALTERNATE, so at most TWO of the eight artefact states can be non-zero for one site: F1R2 and F2R1 of the observed base. WHICH OF THE TWO TAKES THE MASS IS DECIDED BY THE F1R2 COUNT ALONE: the same five alternate reads out of fifty give 0.97 to F1R2_C when all five are F1R2 and the same 0.97 to F2R1_C when none of them are, and give neither of them anything when they are split evenly. `givenNotHomRef` ZEROES HOM_REF AFTER the posteriors are computed, so what is left is RENORMALISED rather than rescaled: the two artefact states go from 0.117 each to 0.484 each. A STATE WITH A ZERO PRIOR STAYS AT ZERO, which is what makes the flat prior's zeros stick through every iteration, and a prior concentrated on ONE state returns that state at 1.0 whatever the counts say. DEPTH AND ALTERNATE DEPTH MOVE THE ANSWER SEPARATELY: the same tenth alternate fraction at ten times the depth goes from 0.97 to 0.99999979. AND TWO OF THE CONSTRUCTOR'S THREE REFUSALS ARE NOT ITS OWN: a context of the wrong length and a non-canonical kmer are validated, but an EMPTY alt design matrix passes both and then builds a matrix with zero rows, which Apache Commons refuses with `0 is smaller than, or equal to, the minimum (0)`.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "LearnReadOrientationModelDump",
+          "golden": null,
+          "why": "Four flat priors, fourteen responsibility vectors and three refusals, all through the two public statics the EM is built from and the engine's own constructor. The EM loop itself is not measured here: it needs a counts file, which is CollectF1R2Counts's output and has its own suite. Every number is printed to ten decimal places, so a change of one part in a million shows."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/LearnReadOrientationModelDump.java
+++ b/tools/readfilter-conformance/LearnReadOrientationModelDump.java
@@ -1,0 +1,182 @@
+/*
+ * LearnReadOrientationModel's mixture model, taken from the reference.
+ *
+ * Which of twelve states a site is in: eight orientation artefacts, one per alternate base per
+ * read orientation, and four real states. The tool fits the prior over those states by EM. What is
+ * decidable without the counts file is the two functions the fit is built from: the flat prior it
+ * starts from, and the responsibilities one site gets given a prior.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - THE FLAT PRIOR IS NOT FLAT OVER TWELVE STATES: the two artefact states whose alternate base
+ *     IS the reference base are given zero, and the remaining ten share the mass, so the value
+ *     depends on the reference base;
+ *   - A REF-TO-REF ARTEFACT IS IMPOSSIBLE, and is given zero responsibility however the counts
+ *     fall;
+ *   - AN ARTEFACT STATE WHOSE BASE IS NOT THE OBSERVED ALTERNATE IS ALSO IMPOSSIBLE, so only two
+ *     of the eight artefact states can ever be non-zero for one site;
+ *   - THE TWO SURVIVING ARTEFACT STATES ARE F1R2 AND F2R1 OF THE OBSERVED BASE, and which of them
+ *     takes the mass is decided by the F1R2 count alone;
+ *   - `givenNotHomRef` ZEROES HOM_REF AFTER the posteriors are computed, so the remaining states
+ *     are renormalised rather than rescaled;
+ *   - THE RESPONSIBILITIES ARE NORMALISED FROM LOG SPACE, so they sum to one whatever the prior;
+ *   - A STATE WITH A ZERO PRIOR STAYS AT ZERO, which is what makes the flat prior's zeros stick
+ *     through every iteration;
+ *   - DEPTH AND ALT DEPTH MOVE THE ANSWER SEPARATELY: the same alt fraction at a greater depth is
+ *     more certain;
+ *   - AND THE STATES HAVE A FIXED ORDER, the eight artefacts first and the four real states after,
+ *     which is the order every prior array is indexed in.
+ *
+ * Output:
+ *
+ *     order\tstates=<the twelve state names, comma separated>
+ *     flat\t<base>=<the twelve prior entries>
+ *     resp\t<label>=<the twelve responsibilities>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: LearnReadOrientationModelDump
+ */
+
+import htsjdk.samtools.util.Histogram;
+import org.broadinstitute.hellbender.tools.walkers.readorientation.ArtifactState;
+import org.broadinstitute.hellbender.tools.walkers.readorientation.LearnReadOrientationModelEngine;
+import org.broadinstitute.hellbender.utils.Nucleotide;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LearnReadOrientationModelDump {
+
+    /** Every double printed the same way, so a change of one part in a million shows. */
+    static String format(final double[] values) {
+        final List<String> parts = new ArrayList<>();
+        for (final double value : values) {
+            parts.add(String.format("%.10f", value));
+        }
+        return String.join(",", parts);
+    }
+
+    static void flat(final Nucleotide base) {
+        System.out.printf("flat\t%s=%s%n", base,
+                format(LearnReadOrientationModelEngine.getFlatPrior(base)));
+    }
+
+    static void responsibilities(final String label, final Nucleotide reference,
+                                 final Nucleotide alternate, final int altDepth,
+                                 final int f1r2AltCount, final int depth, final double[] prior,
+                                 final boolean givenNotHomRef) {
+        try {
+            System.out.printf("resp\t%s=%s%n", label,
+                    format(LearnReadOrientationModelEngine.computeResponsibilities(reference,
+                            alternate, altDepth, f1r2AltCount, depth, prior, givenNotHomRef)));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(cause.getMessage())));
+        }
+    }
+
+    public static void main(final String[] args) {
+        System.out.println("# LearnReadOrientationModelDump: which of twelve states a site is in");
+
+        final List<String> names = new ArrayList<>();
+        for (final ArtifactState state : ArtifactState.values()) {
+            names.add(state.name());
+        }
+        System.out.printf("order\tstates=%s%n", String.join(",", names));
+
+        // The flat prior, which is not flat: the two states whose alternate IS the reference get
+        // zero and the other ten share the mass.
+        for (final Nucleotide base : new Nucleotide[] {Nucleotide.A, Nucleotide.C, Nucleotide.G,
+                Nucleotide.T}) {
+            flat(base);
+        }
+
+        final double[] flatA = LearnReadOrientationModelEngine.getFlatPrior(Nucleotide.A);
+        final double[] flatC = LearnReadOrientationModelEngine.getFlatPrior(Nucleotide.C);
+
+        // A site with no alternate read at all: hom ref should take almost everything.
+        responsibilities("no-alt", Nucleotide.A, Nucleotide.C, 0, 0, 50, flatA, false);
+        // The same site with hom ref forbidden, which renormalises over what is left.
+        responsibilities("no-alt-not-hom-ref", Nucleotide.A, Nucleotide.C, 0, 0, 50, flatA, true);
+        // A low alt fraction entirely on one orientation, which is what an artefact looks like.
+        responsibilities("artifact-f1r2", Nucleotide.A, Nucleotide.C, 5, 5, 50, flatA, false);
+        // The same counts on the other orientation.
+        responsibilities("artifact-f2r1", Nucleotide.A, Nucleotide.C, 5, 0, 50, flatA, false);
+        // The same alt fraction split evenly, which is not an artefact.
+        responsibilities("balanced", Nucleotide.A, Nucleotide.C, 6, 3, 50, flatA, false);
+        // A half alt fraction, which is a germline het.
+        responsibilities("het", Nucleotide.A, Nucleotide.C, 25, 12, 50, flatA, false);
+        // Every read alternate, which is hom var.
+        responsibilities("hom-var", Nucleotide.A, Nucleotide.C, 50, 25, 50, flatA, false);
+        // The same alt fraction at ten times the depth, which is more certain.
+        responsibilities("artifact-deep", Nucleotide.A, Nucleotide.C, 50, 50, 500, flatA, false);
+        // A different observed alternate, which moves the mass to a different pair of states.
+        responsibilities("artifact-g", Nucleotide.A, Nucleotide.G, 5, 5, 50, flatA, false);
+        // The reference base as the alternate, which is the ref-to-ref case.
+        responsibilities("alt-is-ref", Nucleotide.A, Nucleotide.A, 5, 5, 50, flatA, false);
+        // A different reference base, which zeroes a different pair of states.
+        responsibilities("ref-c", Nucleotide.C, Nucleotide.A, 5, 5, 50, flatC, false);
+        // A prior that already rules out both surviving artefact states.
+        final double[] noArtifacts = flatA.clone();
+        noArtifacts[ArtifactState.F1R2_C.ordinal()] = 0;
+        noArtifacts[ArtifactState.F2R1_C.ordinal()] = 0;
+        responsibilities("prior-without-artifacts", Nucleotide.A, Nucleotide.C, 5, 5, 50,
+                noArtifacts, false);
+        // A prior concentrated entirely on one artefact state.
+        final double[] onlyF1R2 = new double[ArtifactState.values().length];
+        onlyF1R2[ArtifactState.F1R2_C.ordinal()] = 1.0;
+        responsibilities("prior-only-f1r2", Nucleotide.A, Nucleotide.C, 5, 5, 50, onlyF1R2, false);
+        // And the same prior with the observation pointing the other way.
+        responsibilities("prior-only-f1r2-wrong-way", Nucleotide.A, Nucleotide.C, 5, 0, 50,
+                onlyF1R2, false);
+
+        // A histogram whose label is not a canonical kmer, which the engine refuses.
+        try {
+            final Histogram<Integer> histogram = new Histogram<>("depth", "ACGT");
+            new LearnReadOrientationModelEngine(histogram, List.of(), List.of(), 1e-4, 20, 100,
+                    null);
+            System.out.println("error\tbad-context\tNONE:no exception");
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\tbad-context\t%s:%s%n", cause.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(cause.getMessage())));
+        }
+        // A canonical label with NO alt sites, which passes both validations and then builds a
+        // matrix with zero rows.
+        try {
+            final Histogram<Integer> histogram = new Histogram<>("depth", "TCA");
+            new LearnReadOrientationModelEngine(histogram, List.of(), List.of(), 1e-4, 20, 100,
+                    null);
+            System.out.println("error\tempty-design-matrix\tNONE:no exception");
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\tempty-design-matrix\t%s:%s%n", cause.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(cause.getMessage())));
+        }
+        // A label of the right length whose middle base is not canonical, which IS refused by the
+        // validation the empty matrix never reaches.
+        try {
+            final Histogram<Integer> histogram = new Histogram<>("depth", "AGT");
+            new LearnReadOrientationModelEngine(histogram, List.of(), List.of(), 1e-4, 20, 100,
+                    null);
+            System.out.println("error\tnon-canonical\tNONE:no exception");
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\tnon-canonical\t%s:%s%n", cause.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(cause.getMessage())));
+        }
+    }
+}


### PR DESCRIPTION
Four flat priors, fourteen responsibility vectors and three refusals, through
the two public statics the EM is built from and the engine's own constructor.
No golden yet: this is the measurement half of the brick.

The EM loop itself is not measured. It needs a counts file, which is
CollectF1R2Counts's output and has its own suite; what the two statics carry
is the model.

The flat prior is not flat over twelve states. The two artefact states whose
alternate base IS the reference base are given zero and the remaining ten
share the mass at a tenth each, so no state ever gets a twelfth and the prior
depends on the reference base.

At most two of the eight artefact states can be non-zero for one site: F1R2
and F2R1 of the observed alternate. Which of the two takes the mass is decided
by the F1R2 count alone. The same five alternate reads out of fifty give 0.97
to F1R2_C when all five are F1R2, the same 0.97 to F2R1_C when none of them
are, and give neither of them anything when they are split evenly.

givenNotHomRef zeroes HOM_REF after the posteriors are computed, so what is
left is renormalised rather than rescaled: the two artefact states go from
0.117 each to 0.484 each.

A state with a zero prior stays at zero, which is what makes the flat prior's
zeros stick through every iteration, and a prior concentrated on one state
returns that state at 1.0 whatever the counts say. The fixture runs the same
degenerate prior with the observation pointing both ways to show it.

Two of the constructor's three refusals are not its own, which the first run
found rather than confirmed. A context of the wrong length and a non-canonical
kmer are both validated and refused with their own messages. An EMPTY alt
design matrix passes both validations and then builds a matrix with zero rows,
which Apache Commons refuses with "0 is smaller than, or equal to, the minimum
(0)". The case that was written as the non-canonical one was in fact canonical
and hit that instead, so it is now labelled for what it measures and a real
non-canonical case sits beside it.

Every number is printed to ten decimal places, so a change of one part in a
million shows. Run twice in the pinned container with identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)