### PR TITLE
Measure CreateSomaticPanelOfNormals and the Brent optimiser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,10 @@ jobs:
             index: "50/50"
             slug: "filter-alignment-artifacts-learn-read-orientation-model"
             suites: "filter-alignment-artifacts learn-read-orientation-model"
+          - group: golden-pending
+            index: "1/1"
+            slug: "brent-optimizer-create-somatic-panel-of-normals"
+            suites: "brent-optimizer create-somatic-panel-of-normals"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 157 | 50.5% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 142 | 45.7% |
+| not started | 141 | 45.3% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (109 of 190 started)
+## gatk-origin tools (110 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -125,6 +125,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
 | `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
 | `CountVariants` | variant-walker | oracle-backed | count-variants | 1 | not measured |
+| `CreateSomaticPanelOfNormals` | variant-transform | golden-pending | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |
 | `DenoiseReadCounts` | cnv-segmentation | oracle-backed | denoise-read-counts | 1 | not measured |
 | `DownsampleByDuplicateSet` | unclassified | oracle-backed | downsample-by-duplicate-set | 1 | not measured |
 | `DumpTabixIndex` | reporting-walker | oracle-backed | dump-tabix-index | 1 | not measured |
@@ -199,9 +200,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>81 not started</summary>
+<details><summary>80 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `CreateSomaticPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5761,6 +5761,46 @@
           "why": "Four flat priors, fourteen responsibility vectors and three refusals, all through the two public statics the EM is built from and the engine's own constructor. The EM loop itself is not measured here: it needs a counts file, which is CollectF1R2Counts's output and has its own suite. Every number is printed to ten decimal places, so a change of one part in a million shows. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33029944133, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "brent-optimizer",
+      "status": "golden-pending",
+      "title": "where the univariate maximiser stops",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "CreateSomaticPanelOfNormals"
+      ],
+      "why": "A FUNCTION THAT IS EXACTLY A PARABOLA IS SOLVED IN ONE STEP by the parabolic interpolation, so the tolerances never reach it: the same vertex comes back at 1e-12 and at 0.1, from a guess on either side of it, from a guess sitting on it and from a guess at either end of the interval. THE TOLERANCES ARE ONLY VISIBLE ON A FUNCTION THE INTERPOLATION CANNOT FIT, and there they are not cosmetic: the same function peaking at 7 is answered 6.925 at the panel's own settings, 7.000 at 1e-12 and 15.444 at 0.5, which is not a maximum at all. THE SEARCH IS LOCAL, so a function with several maxima returns whichever one the guess is nearest: sine over nought to twenty answers 7.854 from a guess of 1 and 14.141 from a guess of 14. IT RETURNS THE POINT IT LAST EVALUATED, so a symmetric function answers with a NEGATIVE zero. AND THREE THINGS ARE REFUSED RATHER THAN CLAMPED: an evaluation budget too small to converge, a guess outside the interval, and an interval whose ends are the wrong way round, each with its own Apache Commons exception.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "BrentOptimizerDump",
+          "golden": null,
+          "why": "Fifteen calls of `OptimizationUtils.max`, the public entry point the panel of normals fits its beta shape through, over four functions and every combination of tolerance, guess and budget that changes the answer. Every point and value is printed to fourteen decimal places. This is a suite for an ENGINE primitive rather than for a tool: it is here because the panel's BETA field cannot be reproduced without it."
+        }
+      ]
+    },
+    {
+      "id": "create-somatic-panel-of-normals",
+      "status": "golden-pending",
+      "title": "which sites recur across normals often enough to be artefacts",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "CreateSomaticPanelOfNormals"
+      ],
+      "why": "A SITE WITH NO ALTERNATE ALLELE IS SKIPPED, and so is one whose only alternate is the spanning deletion. THE GERMLINE TEST IS SKIPPED ENTIRELY FOR A MULTIALLELIC SITE: every genotype counts whatever its counts say, which the source marks as a TODO rather than a rule, and the fixture shows a half-fraction multiallelic site surviving a germline frequency that removes the biallelic one beside it. WITH NO GERMLINE RESOURCE EVERY ALTERNATE COUNTS, because a frequency of zero is below the negligible threshold and the germline probability is returned as exactly zero: NO THRESHOLD CAN DROP A SITE THE RESOURCE DOES NOT MENTION, which is why --max-germline-probability 0.0001 changes nothing beyond what the resource itself removed. A HIGH GERMLINE FREQUENCY REMOVES A HET-LOOKING GENOTYPE AND LEAVES A LOW-FRACTION ONE at the same frequency, which is the whole point of the resource: the site at a tenth alternate fraction survives an AF of 0.4 and the one at a half does not. --min-sample-count IS COMPARED AGAINST THE SURVIVORS. FRACTION IS OVER ALL SAMPLES IN THE HEADER rather than over the survivors, so adding a fourth sample that carries nothing takes it from 0.667 to 0.500 without moving the BETA. A GENOTYPE WITHOUT AD COUNTS FOR THE SITE AND CONTRIBUTES NOTHING TO THE FIT. AND THE BETA IS FITTED BY A BRENT SEARCH over a scale, so its digits carry the optimiser's tolerances: see the `brent-optimizer` suite.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "CreateSomaticPanelOfNormalsDump",
+          "golden": null,
+          "why": "Nine sites over three normal samples, plus the same sites over four, and a germline resource covering three of them, run seven ways: the default, the resource, a germline probability of 1.0 and of 0.0001, a minimum of one sample and of three, and the fourth sample. The resource is indexed in the dump, because it is queried by interval and is refused without an index."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/BrentOptimizerDump.java
+++ b/tools/readfilter-conformance/BrentOptimizerDump.java
@@ -1,0 +1,95 @@
+/*
+ * OptimizationUtils' univariate maximiser, taken from the reference.
+ *
+ * Apache Commons' Brent optimiser as GATK calls it, which is what fits the beta shape of a
+ * somatic panel of normals. It is golden-section search with parabolic interpolation, and where it
+ * stops is decided by two tolerances rather than by the function.
+ *
+ * Seven behaviours this is built to catch.
+ *
+ *   - IT RETURNS THE POINT IT LAST EVALUATED, not an exactly converged one, so the answer carries
+ *     the tolerances in its digits;
+ *   - A FUNCTION THAT IS EXACTLY A PARABOLA IS SOLVED IN ONE STEP by the interpolation, so the
+ *     tolerances do not reach it at all: every setting returns the vertex exactly. The tolerances
+ *     are only visible on a function the interpolation cannot fit;
+ *   - THE INITIAL GUESS MOVES THE ANSWER for a function with more than one maximum, because the
+ *     search is local;
+ *   - A GUESS AT AN INTERVAL END is still accepted, and the search runs one-sided from it;
+ *   - MAXIMISING IS MINIMISING THE NEGATIVE, so a symmetric function gives a symmetric answer;
+ *   - THE EVALUATION BUDGET IS A REFUSAL, not a silent stop: exceeding it throws;
+ *   - AND A GUESS OUTSIDE THE INTERVAL IS REFUSED before anything is evaluated.
+ *
+ * Output:
+ *
+ *     max\t<label>=<point>,<value>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: BrentOptimizerDump
+ */
+
+import org.broadinstitute.hellbender.utils.OptimizationUtils;
+
+import java.util.function.DoubleUnaryOperator;
+
+public class BrentOptimizerDump {
+
+    static void max(final String label, final DoubleUnaryOperator function, final double min,
+                    final double max, final double guess, final double relativeTolerance,
+                    final double absoluteTolerance, final int maxEvaluations) {
+        try {
+            final org.apache.commons.math3.optim.univariate.UnivariatePointValuePair result =
+                    OptimizationUtils.max(function, min, max, guess, relativeTolerance,
+                            absoluteTolerance, maxEvaluations);
+            System.out.printf("max\t%s=%.14f,%.14f%n", label, result.getPoint(),
+                    result.getValue());
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(cause.getMessage())));
+        }
+    }
+
+    public static void main(final String[] args) {
+        System.out.println("# BrentOptimizerDump: where the univariate maximiser stops");
+
+        // A parabola with its peak at 3, which every setting should find.
+        final DoubleUnaryOperator parabola = x -> -(x - 3.0) * (x - 3.0) + 10.0;
+        max("parabola-default", parabola, 0.0, 10.0, 1.0, 0.001, 0.001, 1000);
+        // The same peak under tighter tolerances, which stops somewhere else.
+        max("parabola-tight", parabola, 0.0, 10.0, 1.0, 1e-12, 1e-12, 1000);
+        max("parabola-loose", parabola, 0.0, 10.0, 1.0, 0.1, 0.1, 1000);
+        // The same function from the other side of the peak.
+        max("parabola-guess-high", parabola, 0.0, 10.0, 9.0, 0.001, 0.001, 1000);
+        // A guess sitting exactly on the peak.
+        max("parabola-guess-exact", parabola, 0.0, 10.0, 3.0, 0.001, 0.001, 1000);
+        // A guess at an end of the interval.
+        max("parabola-guess-at-min", parabola, 0.0, 10.0, 0.0, 0.001, 0.001, 1000);
+        max("parabola-guess-at-max", parabola, 0.0, 10.0, 10.0, 0.001, 0.001, 1000);
+
+        // The settings the panel of normals uses, on a function shaped like its likelihood. This
+        // one the interpolation cannot fit, so the tolerances decide where it stops.
+        final DoubleUnaryOperator panelLike = s -> -Math.abs(Math.log(s) - Math.log(7.0)) - s / 50.0;
+        max("panel-settings", panelLike, 0.01, 100.0, 1.0, 0.01, 0.1, 100);
+        max("panel-tight", panelLike, 0.01, 100.0, 1.0, 1e-12, 1e-12, 1000);
+        max("panel-loose", panelLike, 0.01, 100.0, 1.0, 0.5, 0.5, 1000);
+
+        // Two maxima, where the guess decides which one is found.
+        final DoubleUnaryOperator twoPeaks = x -> Math.sin(x);
+        max("two-peaks-low-guess", twoPeaks, 0.0, 20.0, 1.0, 0.001, 0.001, 1000);
+        max("two-peaks-high-guess", twoPeaks, 0.0, 20.0, 14.0, 0.001, 0.001, 1000);
+
+        // A symmetric function, whose answer is symmetric too.
+        max("symmetric", x -> -x * x, -5.0, 5.0, 2.0, 0.001, 0.001, 1000);
+
+        // A budget too small to converge.
+        max("too-few-evaluations", parabola, 0.0, 10.0, 1.0, 1e-14, 1e-14, 5);
+        // A guess outside the interval.
+        max("guess-below-min", parabola, 0.0, 10.0, -1.0, 0.001, 0.001, 1000);
+        max("guess-above-max", parabola, 0.0, 10.0, 11.0, 0.001, 0.001, 1000);
+        // An interval whose ends are the wrong way round.
+        max("inverted-interval", parabola, 10.0, 0.0, 5.0, 0.001, 0.001, 1000);
+    }
+}

--- a/tools/readfilter-conformance/CreateSomaticPanelOfNormalsDump.java
+++ b/tools/readfilter-conformance/CreateSomaticPanelOfNormalsDump.java
@@ -1,0 +1,203 @@
+/*
+ * CreateSomaticPanelOfNormals' panel, taken from the reference.
+ *
+ * Which sites recur across normal samples often enough to be called artefacts, and with what
+ * allele-fraction shape. A site is kept when enough samples carry an alternate that is more likely
+ * to be an artefact than to be germline, and the shape is a beta fitted to those samples' counts.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - A SITE WITH NO ALTERNATE ALLELE IS SKIPPED, and so is one whose only alternate is the
+ *     spanning deletion;
+ *   - THE GERMLINE TEST IS SKIPPED ENTIRELY FOR A MULTIALLELIC SITE: every genotype counts,
+ *     whatever its counts say, which is a documented TODO rather than a rule;
+ *   - A GENOTYPE WITH NO ALTERNATE READ NEVER COUNTS, whatever the germline frequency;
+ *   - WITH NO GERMLINE RESOURCE EVERY ALTERNATE COUNTS, because a frequency of zero is below the
+ *     negligible threshold and the germline probability is returned as zero;
+ *   - A HIGH GERMLINE FREQUENCY REMOVES A HET-LOOKING GENOTYPE and leaves a low-fraction one, which
+ *     is the whole point of the resource;
+ *   - --min-sample-count IS COMPARED AGAINST THE SURVIVORS, not against the samples;
+ *   - FRACTION IS OVER ALL SAMPLES IN THE HEADER, not over the survivors, so it falls when a
+ *     sample is added that carries nothing;
+ *   - THE BETA IS FITTED BY A BRENT SEARCH over a scale, whose base shape is the empirical mean and
+ *     whose answer therefore carries the optimiser's tolerances;
+ *   - AND A GENOTYPE WITHOUT AD CONTRIBUTES NOTHING TO THE FIT even when it counted for the site.
+ *
+ * Output:
+ *
+ *     vcf\t<label>=<the whole input vcf, escaped>
+ *     germline\tmain=<the germline resource vcf, escaped>
+ *     out\t<label>=<the whole output vcf without its header, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: CreateSomaticPanelOfNormalsDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.mutect.CreateSomaticPanelOfNormals;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CreateSomaticPanelOfNormalsDump {
+
+    static final int CONTIG_LENGTH = 199980;
+
+    static List<String> header(final List<String> samples) {
+        return new ArrayList<>(List.of(
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=" + CONTIG_LENGTH + ">",
+                "##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele frequency\">",
+                "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+                "##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allele depths\">",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t" + String.join("\t", samples)));
+    }
+
+    /** One site. `genotypes` are `GT:AD` strings, or `.` for a genotype with no AD at all. */
+    static String site(final int position, final String reference, final String alternate,
+                       final String... genotypes) {
+        final List<String> columns = new ArrayList<>();
+        for (final String genotype : genotypes) {
+            columns.add(genotype);
+        }
+        return "chr1\t" + position + "\t.\t" + reference + "\t" + alternate + "\t.\t.\t.\tGT:AD\t"
+                + String.join("\t", columns);
+    }
+
+    static String buildVcf(final List<String> samples, final List<String> sites) {
+        final List<String> lines = header(samples);
+        lines.addAll(sites);
+        lines.add("");
+        return String.join("\n", lines);
+    }
+
+    /** Three normals, one site per behaviour. */
+    static String buildMain() {
+        final List<String> sites = new ArrayList<>();
+        // No alternate at all.
+        sites.add(site(1000, "A", ".", "0/0:20,0", "0/0:20,0", "0/0:20,0"));
+        // Only the spanning deletion.
+        sites.add(site(2000, "A", "*", "0/1:18,2", "0/1:18,2", "0/0:20,0"));
+        // Two samples carrying a clear low-fraction alternate, one carrying none.
+        sites.add(site(3000, "A", "C", "0/1:18,2", "0/1:17,3", "0/0:20,0"));
+        // Only ONE sample carrying it, which the default minimum of two refuses.
+        sites.add(site(4000, "A", "C", "0/1:18,2", "0/0:20,0", "0/0:20,0"));
+        // All three carrying it, so the fraction is one.
+        sites.add(site(5000, "A", "C", "0/1:18,2", "0/1:17,3", "0/1:16,4"));
+        // Two samples at a half fraction, which looks germline where the resource says so.
+        sites.add(site(6000, "A", "C", "0/1:10,10", "0/1:11,9", "0/0:20,0"));
+        // Multiallelic, where the germline test is skipped for every genotype.
+        sites.add(site(7000, "A", "C,G", "0/1:10,10,0", "0/1:11,9,0", "0/0:20,0,0"));
+        // One sample with no AD at all beside one with counts.
+        sites.add(site(8000, "A", "C", "0/1:18,2", "0/1", "0/1:16,4"));
+        // Very deep counts, which sharpen the fitted beta.
+        sites.add(site(9000, "A", "C", "0/1:1800,200", "0/1:1700,300", "0/0:2000,0"));
+        return buildVcf(List.of("n1", "n2", "n3"), sites);
+    }
+
+    /** The same sites with a fourth sample that carries nothing, to move FRACTION. */
+    static String buildFourSamples() {
+        final List<String> sites = new ArrayList<>();
+        sites.add(site(3000, "A", "C", "0/1:18,2", "0/1:17,3", "0/0:20,0", "0/0:20,0"));
+        sites.add(site(5000, "A", "C", "0/1:18,2", "0/1:17,3", "0/1:16,4", "0/0:20,0"));
+        return buildVcf(List.of("n1", "n2", "n3", "n4"), sites);
+    }
+
+    /** A germline resource giving 6000 a high frequency and 3000 none. */
+    static String buildGermline() {
+        return String.join("\n",
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=" + CONTIG_LENGTH + ">",
+                "##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele frequency\">",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO",
+                "chr1\t6000\t.\tA\tC\t.\t.\tAF=0.4",
+                "chr1\t7000\t.\tA\tC\t.\t.\tAF=0.4",
+                "chr1\t9000\t.\tA\tC\t.\t.\tAF=0.4",
+                "");
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("panel-of-normals-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# CreateSomaticPanelOfNormalsDump: which sites recur across normals "
+                + "often enough to be artefacts");
+
+        final String main = buildMain();
+        final String four = buildFourSamples();
+        final String germline = buildGermline();
+        final Path mainPath = write(dir, "normals.vcf", main);
+        final Path fourPath = write(dir, "four.vcf", four);
+        final Path germlinePath = write(dir, "germline.vcf", germline);
+        // The germline resource is QUERIED by interval, so it needs an index beside it: without
+        // one the run is refused before a record is read.
+        htsjdk.tribble.index.Index index = htsjdk.tribble.index.IndexFactory.createLinearIndex(
+                germlinePath.toFile(), new htsjdk.variant.vcf.VCFCodec());
+        index.writeBasedOnFeatureFile(germlinePath.toFile());
+        System.out.printf("vcf\tmain=%s%n", ReferenceQueryDump.escape(main));
+        System.out.printf("vcf\tfour=%s%n", ReferenceQueryDump.escape(four));
+        System.out.printf("germline\tmain=%s%n", ReferenceQueryDump.escape(germline));
+
+        run(dir, "default", mainPath, List.of());
+        // With the germline resource, which removes the half-fraction site.
+        run(dir, "germline", mainPath, List.of("--germline-resource", germlinePath.toString()));
+        // A germline probability threshold high enough to keep everything again.
+        run(dir, "germline-permissive", mainPath, List.of(
+                "--germline-resource", germlinePath.toString(),
+                "--max-germline-probability", "1.0"));
+        // And one low enough to drop what the default keeps.
+        run(dir, "germline-strict", mainPath, List.of(
+                "--germline-resource", germlinePath.toString(),
+                "--max-germline-probability", "0.0001"));
+        // A minimum of one sample, which keeps the singleton site.
+        run(dir, "min-one", mainPath, List.of("--min-sample-count", "1"));
+        // A minimum of three, which drops the two-sample sites.
+        run(dir, "min-three", mainPath, List.of("--min-sample-count", "3"));
+        // A fourth sample carrying nothing, which moves FRACTION without moving anything else.
+        run(dir, "four-samples", fourPath, List.of());
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path input, final List<String> extra)
+            throws Exception {
+        final Path out = dir.resolve("out-" + label + ".vcf");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-V", input.toString(),
+                "-O", out.toString()));
+        argv.addAll(extra);
+        try {
+            new CreateSomaticPanelOfNormals().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            return;
+        }
+        final StringBuilder body = new StringBuilder();
+        for (final String line : Files.readString(out).split("\n", -1)) {
+            if (!line.startsWith("##") && !line.isEmpty()) {
+                body.append(line).append("\n");
+            }
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(body.toString(), dir)));
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Two suites for one brick. The panel's BETA field is fitted by Apache Commons'
Brent optimiser through OptimizationUtils.max, which nothing in gatk-engine
ports yet, so the optimiser is measured on its own as well: without it the
panel's second INFO field cannot be reproduced at all.

The optimiser first. A function that is exactly a parabola is solved in one
step by the parabolic interpolation, so the tolerances never reach it: the
same vertex comes back at 1e-12 and at 0.1, from a guess on either side, from
a guess sitting on it and from a guess at either end of the interval. The
tolerances are only visible on a function the interpolation cannot fit, and
there they are not cosmetic: a function peaking at 7 is answered 6.925 at the
panel's own settings, 7.000 at 1e-12 and 15.444 at 0.5, which is not a maximum
at all. The search is local, so sine over nought to twenty answers 7.854 from
a guess of 1 and 14.141 from a guess of 14. It returns the point it last
evaluated, so a symmetric function answers with a negative zero. And three
things are refused rather than clamped: too small a budget, a guess outside
the interval, and an interval the wrong way round.

The first version of that dump claimed the tolerances change where the search
stops and demonstrated it only on parabolas, where they provably do not. The
non-parabolic cases were added once the output said so.

Then the panel. A site with no alternate is skipped, and so is one whose only
alternate is the spanning deletion. The germline test is skipped entirely for
a multiallelic site, which the source marks as a TODO rather than a rule, and
the fixture shows a half-fraction multiallelic site surviving the germline
frequency that removes the biallelic one beside it.

With no germline resource every alternate counts, because a frequency of zero
is below the negligible threshold and the probability is returned as exactly
zero. No threshold can therefore drop a site the resource does not mention,
which is why --max-germline-probability 0.0001 changes nothing beyond what the
resource itself removed. At an AF of 0.4 the site at a tenth alternate
fraction survives and the one at a half does not, which is the whole point.

FRACTION is over all samples in the header rather than over the survivors, so
adding a fourth sample that carries nothing takes it from 0.667 to 0.500
without moving the BETA. A genotype without AD counts for the site and
contributes nothing to the fit.

The germline resource is indexed in the dump: it is queried by interval and
the run is refused without an index, which the first run found.

Both suites run twice in the pinned container with identical output. No
goldens yet: this is the measurement half of the brick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)