### PR TITLE
Measure RampedHaplotypeCaller's ramps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,10 @@ jobs:
             index: "50/50"
             slug: "filter-alignment-artifacts-learn-read-orientation-model-brent-optimizer-create-somatic-panel-of-normals"
             suites: "filter-alignment-artifacts learn-read-orientation-model brent-optimizer create-somatic-panel-of-normals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "ramped-haplotype-caller"
+            suites: "ramped-haplotype-caller"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 158 | 50.8% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 141 | 45.3% |
+| not started | 140 | 45.0% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (110 of 190 started)
+## gatk-origin tools (111 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -176,6 +176,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `PrintReads` | record-transform | oracle-backed | printreads | 1 | not measured |
 | `PrintReadsHeader` | record-transform | oracle-backed | print-reads-header | 1 | not measured |
 | `PrintSVEvidence` | unclassified | oracle-backed | print-sv-evidence | 1 | not measured |
+| `RampedHaplotypeCaller` | assembly-caller | golden-pending | ramped-haplotype-caller | 1 | not measured |
 | `ReadAnonymizer` | unclassified | oracle-backed | read-anonymizer | 1 | not measured |
 | `ReferenceBlockConcordance` | unclassified | oracle-backed | reference-block-concordance | 1 | not measured |
 | `RemoveNearbyIndels` | variant-transform | oracle-backed | remove-nearby-indels | 1 | not measured |
@@ -200,9 +201,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>80 not started</summary>
+<details><summary>79 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `RampedHaplotypeCaller`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5801,6 +5801,26 @@
           "why": "Nine sites over three normal samples, plus the same sites over four, and a germline resource covering three of them, run seven ways: the default, the resource, a germline probability of 1.0 and of 0.0001, a minimum of one sample and of three, and the fourth sample. The resource is indexed in the dump, because it is queried by interval and is refused without an index. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33035486743, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "ramped-haplotype-caller",
+      "status": "golden-pending",
+      "title": "the shape of a ramp state file, and the orderings it compares under",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "RampedHaplotypeCaller"
+      ],
+      "why": "A ZIP ENTRY IS NAMED `<contig>-<start>-<end>/<name>` when it belongs to a region and by its bare name when it does not, so the region prefix is a directory made out of coordinates. `info.json` IS WRITTEN LAST, after every region entry, and with a two-space indent that JSON.org COMPACTS FOR A SINGLE-KEY OBJECT: `assembly.region.count` and `assembly.region.name` come back as `\"assembly\": {\"region\": {` on one line, because the outer object has one key. AN INFO KEY IS A DOTTED PATH and every missing level of it is created as an object. THE HAPLOTYPE TABLE IS A CSV WITH A FIXED HEADER whose reference column is 1 or 0 and whose score is `Double.toString`. A REFERENCE HAPLOTYPE SORTS LAST, because the comparator subtracts the reference flags and a true is one. THE HAPLOTYPE COMPARATOR COMPARES THE SCORE BY SIGN rather than by difference, so two scores 1e-10 apart are still ordered rather than collapsing to zero. THE READ COMPARATOR STARTS FROM THE STRAND, so a reverse read at position 1000 sorts after a forward read at 5000. THE VERIFICATION REFUSES A SIZE MISMATCH BEFORE COMPARING ANYTHING and otherwise names the index it failed on. AND THE BAM INDEX PATH IS BUILT BY `String.replace`, which replaces EVERY `.bam` in the path: `/x/run.bam.d/reads.bam` becomes `/x/run.bai.d/reads.bai`, and a path with no `.bam` at all comes back unchanged.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "RampedHaplotypeCallerDump",
+          "golden": null,
+          "why": "One ramp file written through a subclass that exposes the off ramp's protected methods, reported as its entry names in write order and two of its entries whole; then three haplotypes and three reads through both comparators, five verification calls, and the derived names and paths. The caller itself is not run: this tool is HaplotypeCaller with a different engine, and the engine is milestone G3's. What is measured is the ramp format and the orderings, which are the tool's own."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/RampedHaplotypeCallerDump.java
+++ b/tools/readfilter-conformance/RampedHaplotypeCallerDump.java
@@ -1,0 +1,242 @@
+/*
+ * RampedHaplotypeCaller's ramps, taken from the reference.
+ *
+ * A ramp is a state file: an off ramp halts the caller at one step and writes a zip, an on ramp
+ * restarts it from that zip. What is decidable without running the caller is the file's own shape,
+ * the two orderings the ramps compare their contents under, and what the comparison refuses.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - A ZIP ENTRY IS NAMED `<contig>-<start>-<end>/<name>` when it belongs to a region and by its
+ *     bare name when it does not, so the region prefix is a directory made out of coordinates;
+ *   - `info.json` IS WRITTEN LAST and with a two-space indent, whatever was added to it;
+ *   - AN INFO KEY IS A DOTTED PATH, and every missing level of it is created as an object;
+ *   - THE HAPLOTYPE TABLE IS A CSV WITH A FIXED HEADER, whose reference column is 1 or 0 and whose
+ *     score is `Double.toString`;
+ *   - A REFERENCE HAPLOTYPE SORTS LAST, because the comparator subtracts the reference flags and a
+ *     true is one;
+ *   - THE HAPLOTYPE COMPARATOR FALLS THROUGH SIX KEYS and compares the score by SIGN rather than by
+ *     difference, so two scores a hair apart are still ordered;
+ *   - THE READ COMPARATOR STARTS FROM THE STRAND, so a reverse read sorts after a forward one
+ *     whatever their positions;
+ *   - THE VERIFICATION REFUSES A SIZE MISMATCH BEFORE IT COMPARES ANYTHING, and otherwise names the
+ *     index it failed on;
+ *   - AND THE BAM INDEX PATH IS BUILT BY `String.replace`, which replaces EVERY `.bam` in the path
+ *     rather than the last one.
+ *
+ * Output:
+ *
+ *     entry\t<label>=<the zip entry names, comma separated, in write order>
+ *     content\t<label>=<one entry's bytes, escaped>
+ *     order\t<label>=<the sorted ids, comma separated>
+ *     compare\t<label>=<the comparator's sign>
+ *     path\t<label>=<a derived path>
+ *     name\t<label>=<a derived name>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: RampedHaplotypeCallerDump
+ */
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.TextCigarCodec;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ramps.OffRampBase;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ramps.RampUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class RampedHaplotypeCallerDump {
+
+    /** The off ramp's own methods are protected, so a subclass is what reaches them. */
+    static class Ramp extends OffRampBase {
+        Ramp(final String filename) throws Exception {
+            super(filename);
+        }
+
+        void put(final htsjdk.samtools.util.Locatable loc, final String name,
+                 final byte[] bytes) throws Exception {
+            addEntry(loc, name, bytes);
+        }
+
+        void putHaplotypes(final htsjdk.samtools.util.Locatable loc,
+                           final String name, final List<Haplotype> value) throws Exception {
+            addHaplotypes(loc, name, value);
+        }
+
+        void putInfo(final String name, final Object value) {
+            addInfo(info, name, value);
+        }
+
+        String locSuffix(final htsjdk.samtools.util.Locatable loc) {
+            return getLocFilenameSuffix(loc);
+        }
+
+        String suppName(final String name, final boolean supp) {
+            return getReadSuppName(name, supp);
+        }
+
+        Path indexPath(final Path bam) {
+            return getBamIndexPath(bam);
+        }
+    }
+
+    static SAMFileHeader header() {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", 199980))));
+        return header;
+    }
+
+    static Haplotype haplotype(final String bases, final boolean reference, final int start,
+                               final int end, final String cigar, final double score) {
+        final Haplotype h = new Haplotype(bases.getBytes(), reference,
+                new SimpleInterval("chr1", start, end), TextCigarCodec.decode(cigar));
+        h.setScore(score);
+        return h;
+    }
+
+    static GATKRead read(final SAMFileHeader header, final String name, final int start,
+                         final String cigar, final String bases, final boolean reverse) {
+        final SAMRecord record = new SAMRecord(header);
+        record.setReadName(name);
+        record.setReferenceName("chr1");
+        record.setAlignmentStart(start);
+        record.setCigarString(cigar);
+        record.setMappingQuality(60);
+        record.setReadBases(bases.getBytes());
+        final byte[] qualities = new byte[bases.length()];
+        Arrays.fill(qualities, (byte) 30);
+        record.setBaseQualities(qualities);
+        record.setReadNegativeStrandFlag(reverse);
+        return new SAMRecordToGATKReadAdapter(record);
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("ramped-haplotype-caller-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# RampedHaplotypeCallerDump: the shape of a ramp state file, and the "
+                + "orderings it compares under");
+
+        final SAMFileHeader header = header();
+        final SimpleInterval loc = new SimpleInterval("chr1", 1000, 2000);
+
+        // The three haplotypes the table is written from: one reference and two not, one of the
+        // two carrying a score a hair from the other's.
+        final List<Haplotype> haplotypes = new ArrayList<>(List.of(
+                haplotype("ACGTACGT", false, 1000, 1007, "8M", -12.5),
+                haplotype("ACGTTCGT", true, 1000, 1007, "8M", 0.0),
+                haplotype("ACGTACGA", false, 1000, 1007, "8M", -12.5000000001)));
+
+        // A ramp with one region and one root-level entry.
+        final Path rampPath = dir.resolve("ramp.zip");
+        final Ramp ramp = new Ramp(rampPath.toString());
+        ramp.put(loc, "reads.txt", "one\ntwo\n".getBytes());
+        ramp.putHaplotypes(loc, "haplotypes.csv", haplotypes);
+        ramp.put(null, "root.txt", "at the root\n".getBytes());
+        // A dotted key, whose missing levels are created.
+        ramp.putInfo("assembly.region.count", 3);
+        ramp.putInfo("assembly.region.name", "first");
+        ramp.putInfo("flat", true);
+        ramp.close();
+
+        // The entry names, in the order they were written.
+        final List<String> names = new ArrayList<>();
+        try (final ZipFile zip = new ZipFile(rampPath.toFile())) {
+            for (final ZipEntry entry : Collections.list(zip.entries())) {
+                names.add(entry.getName());
+            }
+            System.out.printf("entry\tramp=%s%n", String.join(",", names));
+            for (final String name : new String[] {"chr1-1000-2000/haplotypes.csv", "info.json"}) {
+                final ZipEntry entry = zip.getEntry(name);
+                System.out.printf("content\t%s=%s%n", name, ReferenceQueryDump.escape(
+                        new String(zip.getInputStream(entry).readAllBytes())));
+            }
+        }
+
+        // The two orderings.
+        final List<Haplotype> sortedHaplotypes = new ArrayList<>(haplotypes);
+        sortedHaplotypes.sort(new RampUtils.HaplotypeComparator());
+        final List<String> haplotypeOrder = new ArrayList<>();
+        for (final Haplotype h : sortedHaplotypes) {
+            haplotypeOrder.add(h.getBaseString());
+        }
+        System.out.printf("order\thaplotypes=%s%n", String.join(",", haplotypeOrder));
+        // The score comparison is by SIGN, so a difference of 1e-10 still orders.
+        System.out.printf("compare\tscore-hair=%d%n", Integer.signum(
+                new RampUtils.HaplotypeComparator().compare(haplotypes.get(0), haplotypes.get(2))));
+        System.out.printf("compare\treference-last=%d%n", Integer.signum(
+                new RampUtils.HaplotypeComparator().compare(haplotypes.get(1), haplotypes.get(0))));
+
+        final List<GATKRead> reads = new ArrayList<>(List.of(
+                read(header, "r-reverse-early", 1000, "8M", "ACGTACGT", true),
+                read(header, "r-forward-late", 5000, "8M", "ACGTACGT", false),
+                read(header, "r-forward-early", 1000, "8M", "ACGTACGT", false)));
+        final List<GATKRead> sortedReads = new ArrayList<>(reads);
+        sortedReads.sort(new RampUtils.GATKReadComparator());
+        final List<String> readOrder = new ArrayList<>();
+        for (final GATKRead r : sortedReads) {
+            readOrder.add(r.getName());
+        }
+        System.out.printf("order\treads=%s%n", String.join(",", readOrder));
+        System.out.printf("compare\tstrand-first=%d%n", Integer.signum(
+                new RampUtils.GATKReadComparator().compare(reads.get(0), reads.get(1))));
+
+        // The verification, and what it refuses.
+        verify("haplotypes-same", () -> RampUtils.compareHaplotypes(haplotypes,
+                new ArrayList<>(haplotypes)));
+        verify("haplotypes-size", () -> RampUtils.compareHaplotypes(haplotypes,
+                haplotypes.subList(0, 2)));
+        final List<Haplotype> changed = new ArrayList<>(haplotypes.subList(0, 2));
+        changed.add(haplotype("TTTTTTTT", false, 1000, 1007, "8M", -12.5000000001));
+        verify("haplotypes-different", () -> RampUtils.compareHaplotypes(haplotypes, changed));
+        verify("reads-same", () -> RampUtils.compareReads(reads, new ArrayList<>(reads)));
+        verify("reads-size", () -> RampUtils.compareReads(reads, reads.subList(0, 2)));
+
+        // The derived names and paths.
+        System.out.printf("name\tloc-suffix=%s%n", ramp.locSuffix(loc));
+        System.out.printf("name\tsupp-true=%s%n", ramp.suppName("readname", true));
+        System.out.printf("name\tsupp-false=%s%n", ramp.suppName("readname", false));
+        // `String.replace` replaces EVERY occurrence, so a path with `.bam` in a directory name
+        // has that replaced too.
+        System.out.printf("path\tplain=%s%n",
+                ramp.indexPath(Path.of("/x/reads.bam")).toString());
+        System.out.printf("path\ttwice=%s%n",
+                ramp.indexPath(Path.of("/x/run.bam.d/reads.bam")).toString());
+        System.out.printf("path\tnone=%s%n",
+                ramp.indexPath(Path.of("/x/reads.cram")).toString());
+    }
+
+    interface Check {
+        void run();
+    }
+
+    static void verify(final String label, final Check check) {
+        try {
+            check.run();
+            System.out.printf("error\t%s\tNONE:accepted%n", label);
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(cause.getMessage())));
+        }
+    }
+}


### PR DESCRIPTION
The tool is HaplotypeCaller with a different engine, and the engine is
milestone G3's. What is the tool's own is the ramp: a state file an off ramp
writes at one step and an on ramp restarts from. Its shape, the two orderings
its contents are compared under and what the comparison refuses are all
decidable without running the caller, so those are measured. No golden yet:
this is the measurement half of the brick.

A zip entry is named `<contig>-<start>-<end>/<name>` when it belongs to a
region and by its bare name when it does not, so the region prefix is a
directory made out of coordinates. `info.json` is written last, after every
region entry.

Its two-space indent is JSON.org's, which COMPACTS a single-key object: the
two dotted keys `assembly.region.count` and `assembly.region.name` come back
as `"assembly": {"region": {` on one line, because the outer object has only
one key. That is a property of the writer rather than of the tool, and it is
in the golden because it is in the file.

The haplotype table is a CSV with a fixed header whose reference column is 1
or 0 and whose score is Double.toString. A reference haplotype sorts LAST,
because the comparator subtracts the reference flags and a true is one. The
score is compared by SIGN rather than by difference, so two scores 1e-10 apart
are still ordered rather than collapsing to zero, and the fixture carries such
a pair. The read comparator starts from the strand, so a reverse read at 1000
sorts after a forward read at 5000.

The verification refuses a size mismatch before comparing anything and
otherwise names the index it failed on.

And the bam index path is built by String.replace, which replaces EVERY `.bam`
in the path rather than the last one: `/x/run.bam.d/reads.bam` becomes
`/x/run.bai.d/reads.bai`. A path with no `.bam` comes back unchanged.

The off ramp's own methods are protected, so the dump reaches them through a
subclass rather than by running the caller.

Run twice in the pinned container with identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)