### PR TITLE
Measure SeriesStats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,10 @@ jobs:
             index: "50/50"
             slug: "filter-alignment-artifacts-learn-read-orientation-model-brent-optimizer-create-somatic-panel-of-normals-ramped-haplotype-caller"
             suites: "filter-alignment-artifacts learn-read-orientation-model brent-optimizer create-somatic-panel-of-normals ramped-haplotype-caller"
+          - group: golden-pending
+            index: "1/1"
+            slug: "series-stats"
+            suites: "series-stats"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 159 | 51.1% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 140 | 45.0% |
+| not started | 139 | 44.7% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (111 of 190 started)
+## gatk-origin tools (112 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -150,6 +150,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |
 | `GetPileupSummaries` | locus-walker | oracle-backed | get-pileup-summaries | 1 | not measured |
 | `GetSampleName` | reporting-walker | oracle-backed | get-sample-name | 1 | not measured |
+| `GroundTruthScorer` | flow-based | golden-pending | series-stats | 1 | not measured |
 | `GroupedSVCluster` | sv-caller | oracle-backed | grouped-sv-cluster | 1 | not measured |
 | `GtfToBed` | assembly-caller | oracle-backed | gtf-to-bed | 1 | not measured |
 | `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file | 1 | not measured |
@@ -201,9 +202,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>79 not started</summary>
+<details><summary>78 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `GroundTruthScorer`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5821,6 +5821,26 @@
           "why": "One ramp file written through a subclass that exposes the off ramp's protected methods, reported as its entry names in write order and two of its entries whole; then three haplotypes and three reads through both comparators, five verification calls, and the derived names and paths. The caller itself is not run: this tool is HaplotypeCaller with a different engine, and the engine is milestone G3's. What is measured is the ramp format and the orderings, which are the tool's own. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33041444608, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "series-stats",
+      "status": "golden-pending",
+      "title": "the accumulator the ground-truth tools keep their numbers in",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "GroundTruthScorer"
+      ],
+      "why": "A PERCENTILE IS AN OBSERVED VALUE, never an interpolation: the walk returns a BIN KEY, so the median of the even-sized set {1,2,8,9} is 8 rather than 5. THE PERCENTILE INDEX IS TRUNCATED, `(int)(count * p / 100)`, which is why it is the THIRD smallest of four rather than the second. A SINGLE VALUE SHORT-CIRCUITS to the LAST added rather than to the only bin. AN EMPTY SERIES REPORTS NaN for min, max, mean, median and deviation, and zero for the counts. THE STANDARD DEVIATION DIVIDES BY THE COUNT rather than by the count less one, so it is the population deviation. THE BINS ARE A TreeMap OVER Double, so -0.0 SORTS BEFORE 0.0 and the two are SEPARATE BINS, which makes `getUniq` three for {0.0, -0.0, 1.0}; a NaN sorts after everything, and poisons min, max, mean and the deviation while leaving the median a real value. THE CSV IS WRITTEN AS INTEGERS ONLY WHEN EVERY VALUE ARRIVED THROUGH `add(int)`, which is a property of the ADD PATH and not of the values: two whole numbers added as doubles are written `1.000000`, and one double among two integers switches the whole file. AND THE DIGEST OF AN EMPTY SERIES CLAIMS min=0, max=0, median=0, because an empty series counts as integer-keyed and `(int)Double.NaN` is zero in Java.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "SeriesStatsDump",
+          "golden": null,
+          "why": "Nine series through every statistic the class reports, eight percentiles each, their bins in map order, their digests, and four CSV files. Every number is printed to ten decimal places. This is a suite for a PRIMITIVE rather than for a tool: `SeriesStats` is what both ground-truth tools keep their numbers in, and neither of them can be ported without it."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/SeriesStatsDump.java
+++ b/tools/readfilter-conformance/SeriesStatsDump.java
@@ -1,0 +1,157 @@
+/*
+ * SeriesStats, taken from the reference.
+ *
+ * The accumulator the ground-truth tools keep their numbers in. It is a sorted map from value to
+ * count rather than a list, and every statistic it reports is computed off that map, which is what
+ * makes several of them not the statistic their name suggests.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - A PERCENTILE IS AN OBSERVED VALUE, never an interpolation: the walk returns a BIN KEY, so the
+ *     median of an even-sized set is one of its members rather than the mean of two;
+ *   - THE PERCENTILE INDEX IS TRUNCATED, `(int)(count * p / 100)`, so the 50th of four values is
+ *     the third smallest rather than the second;
+ *   - A SINGLE VALUE SHORT-CIRCUITS to the LAST added rather than to the only bin, which is the
+ *     same thing until it is not;
+ *   - AN EMPTY SERIES REPORTS NaN for every statistic and zero for the counts;
+ *   - THE STANDARD DEVIATION DIVIDES BY THE COUNT, not by the count less one, so it is the
+ *     population deviation;
+ *   - THE BINS ARE A TreeMap OVER Double, so -0.0 SORTS BEFORE 0.0 and the two are separate bins,
+ *     while a NaN sorts after everything;
+ *   - `getUniq` IS THE NUMBER OF BINS, so those two zeros count as two;
+ *   - THE CSV IS WRITTEN AS INTEGERS only when every value arrived through `add(int)`, and one
+ *     double is enough to switch the whole file to `%f`;
+ *   - AND `add(int)` CALLS `add(double)` FIRST, so the integer count is incremented after the
+ *     value is already binned.
+ *
+ * Output:
+ *
+ *     stat\t<label>=<count>,<uniq>,<min>,<max>,<mean>,<median>,<std>,<last>
+ *     pct\t<label>=<the requested percentiles, comma separated>
+ *     bins\t<label>=<key:count, comma separated, in map order>
+ *     csv\t<label>=<the whole csv, escaped>
+ *     digest\t<label>=<toDigest>
+ *
+ * Usage: SeriesStatsDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.groundtruth.SeriesStats;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SeriesStatsDump {
+
+    static String d(final double value) {
+        return String.format("%.10f", value);
+    }
+
+    static void report(final String label, final SeriesStats stats) {
+        System.out.printf("stat\t%s=%d,%d,%s,%s,%s,%s,%s,%s%n", label,
+                stats.getCount(), stats.getUniq(), d(stats.getMin()), d(stats.getMax()),
+                d(stats.getMean()), d(stats.getMedian()), d(stats.getStd()), d(stats.getLast()));
+        final List<String> percentiles = new ArrayList<>();
+        for (final double p : new double[] {0, 10, 25, 50, 75, 90, 99, 100}) {
+            percentiles.add(d(stats.getPercentile(p)));
+        }
+        System.out.printf("pct\t%s=%s%n", label, String.join(",", percentiles));
+        final List<String> bins = new ArrayList<>();
+        for (final Map.Entry<Double, AtomicInteger> entry : stats.getBins().entrySet()) {
+            bins.add(entry.getKey() + ":" + entry.getValue().get());
+        }
+        System.out.printf("bins\t%s=%s%n", label, String.join(",", bins));
+        System.out.printf("digest\t%s=%s%n", label, stats.toDigest());
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("series-stats-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# SeriesStatsDump: the accumulator the ground-truth tools keep their "
+                + "numbers in");
+
+        // Nothing at all.
+        report("empty", new SeriesStats());
+
+        // One value, which short-circuits every percentile.
+        final SeriesStats one = new SeriesStats();
+        one.add(7);
+        report("one", one);
+
+        // An EVEN number of values whose middle two differ, which is where an interpolating median
+        // and this one part company.
+        final SeriesStats even = new SeriesStats();
+        for (final int v : new int[] {1, 2, 8, 9}) {
+            even.add(v);
+        }
+        report("even", even);
+
+        // An odd number.
+        final SeriesStats odd = new SeriesStats();
+        for (final int v : new int[] {1, 2, 8, 9, 100}) {
+            odd.add(v);
+        }
+        report("odd", odd);
+
+        // Repeats, so a bin carries more than one and the walk has to step over it.
+        final SeriesStats repeated = new SeriesStats();
+        for (final int v : new int[] {5, 5, 5, 5, 5, 5, 5, 5, 5, 100}) {
+            repeated.add(v);
+        }
+        report("repeated", repeated);
+
+        // The two zeros, which a TreeMap over Double keeps apart.
+        final SeriesStats zeros = new SeriesStats();
+        zeros.add(0.0);
+        zeros.add(-0.0);
+        zeros.add(1.0);
+        report("zeros", zeros);
+
+        // A NaN, which sorts after everything.
+        final SeriesStats withNan = new SeriesStats();
+        withNan.add(1.0);
+        withNan.add(Double.NaN);
+        withNan.add(2.0);
+        report("nan", withNan);
+
+        // Doubles, whose deviation is not a whole number.
+        final SeriesStats doubles = new SeriesStats();
+        for (final double v : new double[] {1.5, 2.25, 2.25, 10.0}) {
+            doubles.add(v);
+        }
+        report("doubles", doubles);
+
+        // The CSV, integer keys and not.
+        final Path intCsv = dir.resolve("int.csv");
+        even.csvWrite(intCsv.toString());
+        System.out.printf("csv\tint=%s%n",
+                ReferenceQueryDump.escape(Files.readString(intCsv)));
+        final Path doubleCsv = dir.resolve("double.csv");
+        doubles.csvWrite(doubleCsv.toString());
+        System.out.printf("csv\tdouble=%s%n",
+                ReferenceQueryDump.escape(Files.readString(doubleCsv)));
+        // One double among the integers, which switches the WHOLE file.
+        final SeriesStats mixed = new SeriesStats();
+        mixed.add(1);
+        mixed.add(2);
+        mixed.add(3.5);
+        final Path mixedCsv = dir.resolve("mixed.csv");
+        mixed.csvWrite(mixedCsv.toString());
+        System.out.printf("csv\tmixed=%s%n",
+                ReferenceQueryDump.escape(Files.readString(mixedCsv)));
+        report("mixed", mixed);
+        // And a series of integers whose VALUES are whole but which arrived as doubles.
+        final SeriesStats wholeDoubles = new SeriesStats();
+        wholeDoubles.add(1.0);
+        wholeDoubles.add(2.0);
+        final Path wholeCsv = dir.resolve("whole.csv");
+        wholeDoubles.csvWrite(wholeCsv.toString());
+        System.out.printf("csv\twhole=%s%n",
+                ReferenceQueryDump.escape(Files.readString(wholeCsv)));
+    }
+}


### PR DESCRIPTION
The accumulator both ground-truth tools keep their numbers in. It is a sorted
map from value to count rather than a list, and every statistic it reports is
computed off that map, which is what makes several of them not the statistic
their name suggests. No golden yet: this is the measurement half.

This does NOT close #623. GroundTruthScorer itself is not measured here, only
the primitive it and GroundTruthReadsBuilder both depend on; neither tool can
be ported without it.

A percentile is an observed value, never an interpolation: the walk returns a
BIN KEY. The index it walks to is truncated, (int)(count * p / 100), so the
median of {1,2,8,9} is 8, the third smallest of four, rather than the 5 an
interpolating median would give.

The bins are a TreeMap over Double, so -0.0 sorts BEFORE 0.0 and the two are
separate bins: getUniq is three for {0.0, -0.0, 1.0}. A NaN sorts after
everything and poisons min, max, mean and the deviation while leaving the
median a real value, which the fixture shows as one series.

The standard deviation divides by the count rather than by the count less one,
so it is the population deviation.

The CSV is written as integers only when every value arrived through
add(int), which is a property of the ADD PATH rather than of the values. Two
whole numbers added as doubles come out as 1.000000, and one double among two
integers switches the whole file. The fixture carries all three cases.

And the digest of an empty series claims min=0, max=0, median=0. An empty
series has count == intCount, so it takes the integer branch, and
(int)Double.NaN is zero in Java. Every other reader of the same series is
told NaN.

Run twice in the pinned container with identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)