### PR TITLE
Measure DepthOfCoverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,10 @@ jobs:
             index: "51/51"
             slug: "series-stats"
             suites: "series-stats"
+          - group: golden-pending
+            index: "1/1"
+            slug: "depth-of-coverage"
+            suites: "depth-of-coverage"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 160 | 51.4% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 139 | 44.7% |
+| not started | 138 | 44.4% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (112 of 190 started)
+## gatk-origin tools (113 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -127,6 +127,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountVariants` | variant-walker | oracle-backed | count-variants | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |
 | `DenoiseReadCounts` | cnv-segmentation | oracle-backed | denoise-read-counts | 1 | not measured |
+| `DepthOfCoverage` | locus-walker | golden-pending | depth-of-coverage | 1 | not measured |
 | `DownsampleByDuplicateSet` | unclassified | oracle-backed | downsample-by-duplicate-set | 1 | not measured |
 | `DumpTabixIndex` | reporting-walker | oracle-backed | dump-tabix-index | 1 | not measured |
 | `EvaluateInfoFieldConcordance` | variant-walker | oracle-backed | evaluate-info-field-concordance | 1 | not measured |
@@ -202,9 +203,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>78 not started</summary>
+<details><summary>77 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DepthOfCoverage`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VCFComparator`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5841,6 +5841,26 @@
           "why": "Nine series through every statistic the class reports, eight percentiles each, their bins in map order, their digests, and four CSV files. Every number is printed to ten decimal places. This is a suite for a PRIMITIVE rather than for a tool: `SeriesStats` is what both ground-truth tools keep their numbers in, and neither of them can be ported without it. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33042957764, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "depth-of-coverage",
+      "status": "golden-pending",
+      "title": "how deep the reads lie over a reference",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "DepthOfCoverage"
+      ],
+      "why": "THE PER-LOCUS TABLE IS EVERY BASE OF EVERY INTERVAL, including the five before the reads and the five after, so its length is the intervals' and not the reads'. THE PARTITION IS THE SAMPLE, so the two read groups of sampleA are ONE column of depth two rather than two columns of one. --min-base-quality FILTERS A BASE RATHER THAN A READ, so raising it to 10 takes sampleB from 3 to 2 at every locus its low-quality read covered and changes nothing anywhere else, and --max-base-quality DOES THE SAME FROM ABOVE, which is a ceiling no other coverage tool has. --print-base-counts ADDS A PER-BASE BREAKDOWN in a fixed `A: C: G: T: N:` order, each pair followed by a space, so every row ends with one. EACH `omit` ARGUMENT REMOVES ITS OWN FILE and leaves the others, so which files a run writes is a function of the arguments alone: --omit-locus-table removes the two cumulative tables, --omit-depth-output-at-each-base removes the base file itself, --omit-per-sample-statistics removes the two summaries and --omit-interval-statistics the two interval tables. THE SUMMARY CARRIES A `Total` ROW WHOSE QUANTILES ARE `N/A`, because a quantile over the partitions is not a quantile over anything the tool measured. --omit-interval-statistics AND --calculate-coverage-over-genes ARE MUTUALLY EXCLUSIVE and the refusal names both. AND A QUALITY OUTSIDE 0..127 IS REFUSED BY THE ARGUMENT ITSELF with two DIFFERENT exceptions: 200 fails constructing a Byte and -1 fails the declared range.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "DepthOfCoverageDump",
+          "golden": null,
+          "why": "Five reads over three read groups of two samples, an interval that runs five bases past them on each side, run eight ways and refused three: the default, base counts, a raised minimum base quality, a lowered maximum, each of the four omissions, then both interval arguments together and a base quality above and below the byte range. Every file each run wrote is reported whole, and the set of suffixes is reported as its own line."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/DepthOfCoverageDump.java
+++ b/tools/readfilter-conformance/DepthOfCoverageDump.java
@@ -1,0 +1,223 @@
+/*
+ * DepthOfCoverage's tables, taken from the reference.
+ *
+ * How deep the reads lie over a reference, counted per locus, per sample and per interval. The tool
+ * writes a family of files rather than one, and which of them appear is decided by four `omit`
+ * arguments rather than by the data.
+ *
+ * Ten behaviours this is built to catch.
+ *
+ *   - THE PER-LOCUS TABLE IS EVERY BASE OF EVERY INTERVAL, including those no read reaches, so its
+ *     length is the intervals' and not the reads';
+ *   - --min-base-quality FILTERS A BASE RATHER THAN A READ, so one low base lowers the depth at one
+ *     locus and nowhere else;
+ *   - --max-base-quality DOES THE SAME FROM ABOVE, which is a filter no other coverage tool has;
+ *   - THE PARTITION IS THE SAMPLE, so two read groups of one sample are one column;
+ *   - --print-base-counts ADDS A PER-BASE BREAKDOWN in a fixed `A: C: G: T: N:` order, each pair
+ *     followed by a space, so every row ends with one;
+ *   - THE CUMULATIVE TABLES COUNT LOCI AT OR ABOVE EACH DEPTH, so their first column is every
+ *     locus and they fall monotonically;
+ *   - EACH `omit` ARGUMENT REMOVES ITS OWN FILE and leaves the others, so the set of files written
+ *     is a function of the arguments alone;
+ *   - --omit-interval-statistics AND --calculate-coverage-over-genes ARE MUTUALLY EXCLUSIVE, and
+ *     the refusal names both;
+ *   - A QUALITY OUTSIDE 0..127 IS REFUSED BY THE ARGUMENT ITSELF, before a read is seen;
+ *   - AND THE SUMMARY CARRIES A `Total` ROW whose quantiles are `N/A`, because a quantile over
+ *     the partitions is not a quantile over anything the tool measured.
+ *
+ * Output:
+ *
+ *     files\t<label>=<the suffixes written, sorted, comma separated>
+ *     out\t<label>.<suffix>=<that file, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: DepthOfCoverageDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.tools.walkers.coverage.DepthOfCoverage;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class DepthOfCoverageDump {
+
+    static final int CONTIG_LENGTH = 199980;
+
+    static SAMFileHeader header() {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", CONTIG_LENGTH))));
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        // TWO read groups of ONE sample, and one of another: the partition is the SAMPLE.
+        header.addReadGroup(group("rgA1", "sampleA"));
+        header.addReadGroup(group("rgA2", "sampleA"));
+        header.addReadGroup(group("rgB", "sampleB"));
+        return header;
+    }
+
+    static SAMReadGroupRecord group(final String id, final String sample) {
+        final SAMReadGroupRecord group = new SAMReadGroupRecord(id);
+        group.setSample(sample);
+        group.setPlatform("ILLUMINA");
+        return group;
+    }
+
+    static SAMRecord read(final SAMFileHeader header, final String name, final String readGroup,
+                          final int start, final int length, final int baseQuality) {
+        final SAMRecord record = new SAMRecord(header);
+        record.setReadName(name);
+        record.setReferenceName("chr1");
+        record.setAlignmentStart(start);
+        record.setCigarString(length + "M");
+        record.setMappingQuality(60);
+        final StringBuilder bases = new StringBuilder();
+        while (bases.length() < length) {
+            bases.append("ACGT");
+        }
+        record.setReadBases(bases.substring(0, length).getBytes(StandardCharsets.UTF_8));
+        final byte[] qualities = new byte[length];
+        Arrays.fill(qualities, (byte) baseQuality);
+        record.setBaseQualities(qualities);
+        record.setAttribute("RG", readGroup);
+        return record;
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("depth-of-coverage-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# DepthOfCoverageDump: how deep the reads lie over a reference");
+
+        final Path fasta = writeReference(dir);
+        writeDictionary(dir);
+
+        final SAMFileHeader header = header();
+        final List<SAMRecord> records = new ArrayList<>();
+        // sampleA, two read groups over the same ten bases: one column of depth two.
+        records.add(read(header, "a1", "rgA1", 1000, 10, 30));
+        records.add(read(header, "a2", "rgA2", 1000, 10, 30));
+        // sampleB over the first five only, so the depth steps down inside the interval.
+        records.add(read(header, "b1", "rgB", 1000, 5, 30));
+        // A read whose bases are all at quality 5, below the floor the runs use.
+        records.add(read(header, "lowq", "rgB", 1000, 10, 5));
+        // A read whose bases are all at quality 60, above the ceiling one run sets.
+        records.add(read(header, "highq", "rgB", 1000, 10, 60));
+        records.sort((a, b) -> Integer.compare(a.getAlignmentStart(), b.getAlignmentStart()));
+
+        final Path bam = dir.resolve("reads.bam");
+        try (final SAMFileWriter writer = new SAMFileWriterFactory().setCreateIndex(true)
+                .makeBAMWriter(header, true, bam.toFile())) {
+            for (final SAMRecord record : records) {
+                writer.addAlignment(record);
+            }
+        }
+
+        // An interval that runs past the reads on both sides, so the table carries uncovered bases.
+        final Path intervals = write(dir, "intervals.list", "chr1:995-1015\n");
+
+        run(dir, "default", bam, fasta, intervals, List.of());
+        run(dir, "base-counts", bam, fasta, intervals, List.of("--print-base-counts", "true"));
+        run(dir, "min-baseq", bam, fasta, intervals, List.of("--min-base-quality", "10"));
+        run(dir, "max-baseq", bam, fasta, intervals, List.of("--max-base-quality", "40"));
+        run(dir, "omit-locus-table", bam, fasta, intervals, List.of("--omit-locus-table", "true"));
+        run(dir, "omit-per-base", bam, fasta, intervals,
+                List.of("--omit-depth-output-at-each-base", "true"));
+        run(dir, "omit-per-sample", bam, fasta, intervals,
+                List.of("--omit-per-sample-statistics", "true"));
+        run(dir, "omit-intervals", bam, fasta, intervals,
+                List.of("--omit-interval-statistics", "true"));
+
+        // The two mutually exclusive arguments.
+        run(dir, "both-interval-arguments", bam, fasta, intervals, List.of(
+                "--omit-interval-statistics", "true",
+                "--calculate-coverage-over-genes", intervals.toString()));
+        // A quality the argument itself refuses.
+        run(dir, "quality-too-high", bam, fasta, intervals,
+                List.of("--min-base-quality", "200"));
+        run(dir, "quality-negative", bam, fasta, intervals,
+                List.of("--min-base-quality", "-1"));
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path bam, final Path fasta,
+                    final Path intervals, final List<String> extra) throws Exception {
+        final Path base = dir.resolve("out-" + label);
+        final List<String> argv = new ArrayList<>(List.of(
+                "-I", bam.toString(),
+                "-R", fasta.toString(),
+                "-L", intervals.toString(),
+                "-O", base.toString()));
+        argv.addAll(extra);
+        try {
+            new DepthOfCoverage().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        // Whatever the run wrote, by suffix.
+        final List<String> suffixes = new ArrayList<>();
+        try (final java.util.stream.Stream<Path> listing = Files.list(dir)) {
+            for (final Path path : listing.sorted().toList()) {
+                final String name = path.getFileName().toString();
+                if (name.startsWith("out-" + label)) {
+                    suffixes.add(name.substring(("out-" + label).length()));
+                }
+            }
+        }
+        java.util.Collections.sort(suffixes);
+        System.out.printf("files\t%s=%s%n", label, String.join(",", suffixes));
+        for (final String suffix : suffixes) {
+            final Path path = dir.resolve("out-" + label + suffix);
+            System.out.printf("out\t%s%s=%s%n", label, suffix.isEmpty() ? ".base" : suffix,
+                    ReferenceQueryDump.escape(masked(Files.readString(path), dir)));
+        }
+    }
+
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("reference.fasta");
+        final StringBuilder bases = new StringBuilder(">chr1\n");
+        for (int i = 0; i < CONTIG_LENGTH / 60; i++) {
+            bases.append("ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n");
+        }
+        Files.writeString(fasta, bases.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        return fasta;
+    }
+
+    /** One contig, because the dictionary and the FASTA index must agree on their number. */
+    static void writeDictionary(final Path dir) throws Exception {
+        final SAMSequenceDictionary dictionary = new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", CONTIG_LENGTH)));
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(dictionary);
+        try (final java.io.Writer writer = Files.newBufferedWriter(dir.resolve("reference.dict"))) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, header);
+        }
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Five reads over three read groups of two samples, an interval that runs five
bases past them on each side, run eight ways and refused three. No golden yet:
this is the measurement half of the brick.

The per-locus table is every base of every interval, including the five before
the reads and the five after, so its length is the intervals' and not the
reads'.

The partition is the SAMPLE. sampleA's two read groups are one column of depth
two rather than two columns of one, which the fixture is built to show.

--min-base-quality filters a BASE rather than a read: raising it to 10 takes
sampleB from 3 to 2 at every locus its low-quality read covered and changes
nothing anywhere else. --max-base-quality does the same from above, which is a
ceiling no other coverage tool has, and the fixture carries a read at quality
60 for it.

--print-base-counts adds a breakdown in a fixed `A: C: G: T: N:` order, each
pair followed by a space, so every row ends with one. The header said A/C/G/T
before the output was read.

Each omit argument removes its own file and leaves the others, so which files
a run writes is a function of the arguments alone. The suffixes are reported
as their own line for each of the eight runs.

The summary carries a `Total` row whose quantiles are N/A, because a quantile
over the partitions is not a quantile over anything the tool measured.

Two of the three refusals come from the argument parser rather than from the
tool, and they are different exceptions: --min-base-quality 200 fails
constructing a Byte and -1 fails the declared range. The third is the mutual
exclusion between --omit-interval-statistics and
--calculate-coverage-over-genes.

The first run refused every case with "Sequence dictionary and index contain
different numbers of contigs": the shared dictionary writer declares two
contigs and this fixture's FASTA has one. It writes its own now.

Run twice in the pinned container with identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)