### PR TITLE
Sort the extra variant into VCFComparator's fixture

### DIFF
--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5878,7 +5878,7 @@
         {
           "dump": "VCFComparatorDump",
           "golden": null,
-          "why": "One expected VCF of three sites and eight actuals, each a single change away from it, run twenty-two ways: identical, an extra variant called confidently and the same one at genotype quality zero, a QUAL difference alone and under three arguments, two kinds of filter difference, an extra allele and a missing one under two arguments each, an INFO difference under three, a dbSNP id, positions-only, warn-on-errors, and the two input shapes the tool refuses. Every input VCF is reported whole beside the results."
+          "why": "One expected VCF of three sites and eight actuals, each a single change away from it, run twenty-two ways: identical, an extra variant called confidently and the same one at genotype quality zero, a QUAL difference alone and under three arguments, two kinds of filter difference, an extra allele and a missing one under two arguments each, an INFO difference under three, a dbSNP id, positions-only, warn-on-errors, and the two input shapes the tool refuses. Every input VCF is reported whole beside the results. The extra variant is INSERTED into the record list rather than appended, because the driving iterator refuses a VCF whose records are not in position order."
         }
       ]
     }

--- a/tools/readfilter-conformance/VCFComparatorDump.java
+++ b/tools/readfilter-conformance/VCFComparatorDump.java
@@ -113,13 +113,16 @@ public class VCFComparatorDump {
         // A variant only in actual, whose genotypes are confidently called. The unmatched-variant
         // complaint is guarded on a genotype quality of ZERO, so this one passes.
         final List<String> extraSite = baseline();
-        extraSite.add(site(3000, ".", "T", "A", "300.00", "PASS", "AC=1;DP=40", "0/1:70",
+        // INSERTED before the site at 4000, not appended: the driving iterator refuses a VCF whose
+        // records are not in position order.
+        extraSite.add(2, site(3000, ".", "T", "A", "300.00", "PASS", "AC=1;DP=40", "0/1:70",
                 "0/0:70"));
         run(dir, "extra-variant", expectedPath, writeActual(dir, "extra", extraSite), List.of());
         // The same variant with a genotype quality of zero, which is what the complaint is looking
         // for.
         final List<String> extraGq0 = baseline();
-        extraGq0.add(site(3000, ".", "T", "A", "300.00", "PASS", "AC=1;DP=40", "0/1:0", "0/0:0"));
+        extraGq0.add(2, site(3000, ".", "T", "A", "300.00", "PASS", "AC=1;DP=40", "0/1:0",
+                "0/0:0"));
         final Path extraGq0Path = writeActual(dir, "extra-gq0", extraGq0);
         run(dir, "extra-variant-gq0", expectedPath, extraGq0Path, List.of());
         run(dir, "extra-variant-gq0-ignored", expectedPath, extraGq0Path,


### PR DESCRIPTION
The extra variant was appended to the record list, and a later change added a
two-alternate site at position 4000 to the baseline, so the actual VCF ran
1000, 2000, 4000, 3000. The driving iterator refuses that, and all three
extra-variant runs came back with "The elements of the input Iterators are not
sorted" instead of what they were built to measure.

It is inserted at its position now. The three runs report what they were meant
to: a variant present on one side alone and confidently called passes in
silence, the same one at genotype quality zero is an unmatched variant, and
--ignore-gq0 silences that too.

No other run is affected.

Run twice in the pinned container with identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)