### PR TITLE
Measure VariantAnnotator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,10 @@ jobs:
             index: "51/51"
             slug: "series-stats-depth-of-coverage-vcf-comparator"
             suites: "series-stats depth-of-coverage vcf-comparator"
+          - group: golden-pending
+            index: "1/1"
+            slug: "variant-annotator"
+            suites: "variant-annotator"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 162 | 52.1% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 137 | 44.1% |
+| not started | 136 | 43.7% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (114 of 190 started)
+## gatk-origin tools (115 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -201,12 +201,13 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VCFComparator` | unclassified | oracle-backed | vcf-comparator | 1 | not measured |
 | `ValidateBasicSomaticShortMutations` | variant-walker | oracle-backed | validate-basic-somatic-short-mutations | 1 | not measured |
 | `ValidateVariants` | variant-walker | oracle-backed | validate-variants | 1 | not measured |
+| `VariantAnnotator` | unclassified | golden-pending | variant-annotator | 1 | not measured |
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>76 not started</summary>
+<details><summary>75 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VariantAnnotator`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CombineGVCFs`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `ReblockGVCF`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VariantEval`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5881,6 +5881,26 @@
           "why": "One expected VCF of three sites and eight actuals, each a single change away from it, run twenty-two ways: identical, an extra variant called confidently and the same one at genotype quality zero, a QUAL difference alone and under three arguments, two kinds of filter difference, an extra allele and a missing one under two arguments each, an INFO difference under three, a dbSNP id, positions-only, warn-on-errors, and the two input shapes the tool refuses. Every input VCF is reported whole beside the results. The extra variant is INSERTED into the record list rather than appended, because the driving iterator refuses a VCF whose records are not in position order. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33045739945, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "variant-annotator",
+      "status": "golden-pending",
+      "title": "how one VCF is annotated from another",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "VariantAnnotator"
+      ],
+      "why": "THE RESOURCE IS NAMED BY ITS TAG and the annotation's key is `<tag>.<field>`, so the SAME FILE UNDER TWO TAGS IS TWO ANNOTATIONS. AN EXPRESSION MAY NAME `ID`, `ALT` OR `FILTER` as well as an INFO field. A RECORD WITH NO RESOURCE AT ITS POSITION IS LEFT ALONE rather than annotated with nothing. A PER-ALLELE FIELD CANNOT CROSS TO A DIFFERENT ALTERNATE: `AC` is Number=A, and at the site where the resource's alternate differs from the input's it is withheld whatever the arguments say, while the SCALAR `NOTE` crosses freely and so do `ID`, `ALT` and `FILTER`. --resource-allele-concordance IS WHAT WITHHOLDS THE SCALAR ONE, and it changes nothing about the per-allele one, which was already withheld. --comp ADDS A BARE FLAG under the tag alone rather than a key and a value, and it is subject to the same allele test. AN EXPRESSION NAMING A FIELD THE RESOURCE DOES NOT CARRY ADDS NOTHING AND IS NOT REFUSED, while an expression whose TAG names no resource IS refused, with `The requested expression 'nothere.AC' is invalid, could not find vcf input file`: an unknown field is silent and an unknown file is not. AND THE OUTPUT KEEPS EVERY ANNOTATION THE INPUT ALREADY CARRIED, which the `NOTE=kept` on the first site is there to show.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "VariantAnnotatorDump",
+          "golden": null,
+          "why": "Four input sites and a resource covering three of them, one with a different alternate, each resource record carrying both a per-allele field and a scalar one, run eleven ways: one expression, a scalar one with and without allele concordance, two expressions, the same file under two tags, ID/ALT/FILTER together, allele concordance over the per-allele field, an unknown field, an unknown tag, a comparison file, and no resource at all. The resource is indexed in the dump, because it is queried by interval."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/VariantAnnotatorDump.java
+++ b/tools/readfilter-conformance/VariantAnnotatorDump.java
@@ -1,0 +1,194 @@
+/*
+ * VariantAnnotator's copied annotations, taken from the reference.
+ *
+ * How one VCF is annotated from another. A resource file is tagged with a name, an expression names
+ * one of its fields, and the value lands on any record at the same position. What is measurable is
+ * which records are annotated, under what key, and what happens when the two files disagree about
+ * the alleles.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - THE RESOURCE IS NAMED BY ITS TAG and the annotation's key is `<tag>.<field>`, so the same
+ *     file under two tags is two annotations;
+ *   - AN EXPRESSION CAN NAME AN INFO FIELD, `ID`, `ALT` OR `FILTER`, not just an INFO one;
+ *   - A RECORD WITH NO RESOURCE AT ITS POSITION IS LEFT ALONE rather than annotated with nothing;
+ *   - A PER-ALLELE FIELD CANNOT CROSS TO A DIFFERENT ALTERNATE and is withheld by default, while
+ *     a SCALAR one and the ID, ALT and FILTER fields cross freely;
+ *   - --resource-allele-concordance IS WHAT WITHHOLDS THE SCALAR ONE too;
+ *   - --comparison ADDS ITS OWN ANNOTATION under the tag alone;
+ *   - AN EXPRESSION NAMING A FIELD THE RESOURCE DOES NOT HAVE ADDS NOTHING, silently;
+ *   - AN EXPRESSION WHOSE TAG NAMES NO RESOURCE IS REFUSED, which the unknown FIELD is not;
+ *   - AND THE OUTPUT KEEPS EVERY ANNOTATION THE INPUT ALREADY CARRIED.
+ *
+ * Output:
+ *
+ *     vcf\t<label>=<that vcf, escaped>
+ *     out\t<label>=<the whole output vcf without its header, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: VariantAnnotatorDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotator;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class VariantAnnotatorDump {
+
+    static final int CONTIG_LENGTH = 199980;
+
+    static List<String> header() {
+        return new ArrayList<>(List.of(
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=" + CONTIG_LENGTH + ">",
+                "##FILTER=<ID=LOW,Description=\"Low\">",
+                "##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count\">",
+                "##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele frequency\">",
+                "##INFO=<ID=NOTE,Number=1,Type=String,Description=\"A note\">",
+                "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts1"));
+    }
+
+    static String site(final int position, final String id, final String reference,
+                       final String alternate, final String filter, final String info) {
+        return "chr1\t" + position + "\t" + id + "\t" + reference + "\t" + alternate
+                + "\t100.00\t" + filter + "\t" + info + "\tGT\t0/1";
+    }
+
+    static String vcf(final List<String> sites) {
+        final List<String> lines = header();
+        lines.addAll(sites);
+        lines.add("");
+        return String.join("\n", lines);
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("variant-annotator-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# VariantAnnotatorDump: how one VCF is annotated from another");
+
+        final Path fasta = writeReference(dir);
+
+        // The input: four sites, one of which the resource does not mention.
+        final String input = vcf(List.of(
+                site(1000, ".", "A", "C", "PASS", "NOTE=kept"),
+                site(2000, ".", "G", "T", "PASS", "."),
+                site(3000, ".", "C", "A", "PASS", "."),
+                site(4000, ".", "T", "G", "PASS", ".")));
+        final Path inputPath = write(dir, "input.vcf", input);
+        System.out.printf("vcf\tinput=%s%n", ReferenceQueryDump.escape(input));
+
+        // The resource: the same first three positions, one of them with a DIFFERENT alternate.
+        // Each record carries a PER-ALLELE field (AC, Number=A) and a SCALAR one (NOTE,
+        // Number=1), so a value that cannot be mapped to a different alternate is told apart from
+        // one that can.
+        final String resource = vcf(List.of(
+                site(1000, "rs1", "A", "C", "PASS", "AC=5;AF=0.25;NOTE=first"),
+                site(2000, "rs2", "G", "A", "LOW", "AC=7;AF=0.35;NOTE=second"),
+                site(3000, ".", "C", "A", "PASS", "AC=9;AF=0.45;NOTE=third")));
+        final Path resourcePath = write(dir, "resource.vcf", resource);
+        // The resource is QUERIED by interval, so it needs an index beside it.
+        htsjdk.tribble.index.IndexFactory.createLinearIndex(resourcePath.toFile(),
+                new htsjdk.variant.vcf.VCFCodec()).writeBasedOnFeatureFile(resourcePath.toFile());
+        System.out.printf("vcf\tresource=%s%n", ReferenceQueryDump.escape(resource));
+
+        run(dir, "one-expression", inputPath, fasta,
+                List.of("--resource:res", resourcePath.toString(), "-E", "res.AC"));
+        // The scalar field, whose value does not depend on which alternate it belongs to.
+        run(dir, "scalar-expression", inputPath, fasta,
+                List.of("--resource:res", resourcePath.toString(), "-E", "res.NOTE"));
+        run(dir, "scalar-concordance", inputPath, fasta,
+                List.of("--resource:res", resourcePath.toString(), "-E", "res.NOTE",
+                        "--resource-allele-concordance", "true"));
+        // Two expressions from one resource, and the same file under a second tag.
+        run(dir, "two-expressions", inputPath, fasta,
+                List.of("--resource:res", resourcePath.toString(), "-E", "res.AC", "-E", "res.AF"));
+        run(dir, "two-tags", inputPath, fasta,
+                List.of("--resource:res", resourcePath.toString(),
+                        "--resource:other", resourcePath.toString(),
+                        "-E", "res.AC", "-E", "other.AC"));
+        // The three non-INFO fields an expression may name.
+        run(dir, "id-alt-filter", inputPath, fasta,
+                List.of("--resource:res", resourcePath.toString(),
+                        "-E", "res.ID", "-E", "res.ALT", "-E", "res.FILTER"));
+        // Allele concordance, which withholds the value where the alternates differ.
+        run(dir, "allele-concordance", inputPath, fasta,
+                List.of("--resource:res", resourcePath.toString(), "-E", "res.AC",
+                        "--resource-allele-concordance", "true"));
+        // A field the resource does not carry, and a tag that names no resource.
+        run(dir, "unknown-field", inputPath, fasta,
+                List.of("--resource:res", resourcePath.toString(), "-E", "res.MISSING"));
+        run(dir, "unknown-tag", inputPath, fasta,
+                List.of("--resource:res", resourcePath.toString(), "-E", "nothere.AC"));
+        // A comparison file, which annotates under the tag alone.
+        run(dir, "comparison", inputPath, fasta,
+                List.of("--comp:cmp", resourcePath.toString()));
+        // No resource at all, which copies the input through.
+        run(dir, "no-resource", inputPath, fasta, List.of());
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path input, final Path fasta,
+                    final List<String> extra) throws Exception {
+        final Path out = dir.resolve("out-" + label + ".vcf");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-V", input.toString(),
+                "-O", out.toString(),
+                "-R", fasta.toString()));
+        argv.addAll(extra);
+        try {
+            new VariantAnnotator().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            return;
+        }
+        final StringBuilder body = new StringBuilder();
+        for (final String line : Files.readString(out).split("\n", -1)) {
+            if (!line.startsWith("##") && !line.isEmpty()) {
+                body.append(line).append("\n");
+            }
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(body.toString(), dir)));
+    }
+
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("reference.fasta");
+        final StringBuilder bases = new StringBuilder(">chr1\n");
+        for (int i = 0; i < CONTIG_LENGTH / 60; i++) {
+            bases.append("ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n");
+        }
+        Files.writeString(fasta, bases.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        final htsjdk.samtools.SAMFileHeader header = new htsjdk.samtools.SAMFileHeader();
+        header.setSequenceDictionary(new htsjdk.samtools.SAMSequenceDictionary(List.of(
+                new htsjdk.samtools.SAMSequenceRecord("chr1", CONTIG_LENGTH))));
+        try (final java.io.Writer writer = Files.newBufferedWriter(dir.resolve("reference.dict"))) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, header);
+        }
+        return fasta;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Four input sites and a resource covering three of them, one with a different
alternate, run eleven ways. No golden yet: this is the measurement half of the
brick.

The resource is named by its TAG and the annotation's key is `<tag>.<field>`,
so the same file under two tags is two annotations. An expression may name ID,
ALT or FILTER as well as an INFO field.

A per-allele field cannot cross to a different alternate. AC is Number=A, and
at the site where the resource's alternate differs from the input's it is
withheld whatever the arguments say, while a scalar field crosses freely and
so do ID, ALT and FILTER. --resource-allele-concordance is what withholds the
SCALAR one; it changes nothing about the per-allele one, which was already
withheld.

The first fixture carried only per-allele fields and made the flag look like a
no-op. Each resource record now carries a scalar field beside the per-allele
one, which is what separates "cannot be mapped" from "chose not to map".

--comp adds a bare flag under the tag alone rather than a key and a value.

An expression naming a field the resource does not carry adds nothing and is
NOT refused; an expression whose TAG names no resource IS refused, with "The
requested expression 'nothere.AC' is invalid, could not find vcf input file".
An unknown field is silent and an unknown file is not.

The resource is indexed in the dump: it is queried by interval and the run is
refused without an index, which the first run found.

Run twice in the pinned container with identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)