### PR TITLE
Measure VariantEval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,10 @@ jobs:
             index: "52/52"
             slug: "combine-gvcfs"
             suites: "combine-gvcfs"
+          - group: golden-pending
+            index: "1/1"
+            slug: "variant-eval"
+            suites: "variant-eval"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 165 | 53.1% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 134 | 43.1% |
+| not started | 133 | 42.8% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (117 of 190 started)
+## gatk-origin tools (118 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -204,12 +204,13 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ValidateBasicSomaticShortMutations` | variant-walker | oracle-backed | validate-basic-somatic-short-mutations | 1 | not measured |
 | `ValidateVariants` | variant-walker | oracle-backed | validate-variants | 1 | not measured |
 | `VariantAnnotator` | unclassified | oracle-backed | variant-annotator | 1 | not measured |
+| `VariantEval` | variant-walker | golden-pending | variant-eval | 1 | not measured |
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>73 not started</summary>
+<details><summary>72 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VariantEval`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5941,6 +5941,26 @@
           "why": "Three single-sample GVCFs whose block edges deliberately fall inside each other's, one of them stopping early and two of them carrying a variant where the others have a block, run eight ways and refused once: three samples, two, base-pair resolution, two grids, both band arguments together, called genotypes, one sample alone, and the same file given twice. Every input GVCF is reported whole beside the outputs, and each is indexed in the dump because the walker queries them by interval. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33050568322, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "variant-eval",
+      "status": "golden-pending",
+      "title": "how a call set is counted against a comparison one",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "VariantEval"
+      ],
+      "why": "THE REPORT IS ONE TABLE PER MODULE, and the default set is nine of them. THE STANDARD STRATIFIERS APPLY UNLESS TURNED OFF, so every table carries an `all` row and a row per novelty even when none were asked for, and --do-not-use-all-standard-stratifications collapses the three into one. NOVELTY IS DECIDED BY THE dbSNP TRACK AND NOT BY --comp: the same file given as `--comp` leaves all seven sites novel and given as `--dbsnp` splits them three known and four novel, which is the whole of the difference between the two arguments here. A STRATIFIER MULTIPLIES THE ROWS rather than adding a column: `VariantType` takes one table of three rows to eighteen. `CountVariants` COUNTS BY TYPE and `TiTvVariantEvaluator` BY SUBSTITUTION, so the same seven records are summarised under two different questions. A MULTIALLELIC SITE COUNTS ONCE AS A SNP in CountVariants rather than once per alternate. --select-expression ADDS A NAMED SUBSET as another stratum, doubling the rows. AN UNKNOWN MODULE AND AN UNKNOWN STRATIFIER ARE REFUSED WITH THE SAME WORDING, `Module <name> could not be found`, so the two namespaces share one message. AND --list ENDS THE PROCESS: it prints the module names and exits the JVM, which the golden records by carrying the marker written before it and not the one written after.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "VariantEvalDump",
+          "golden": null,
+          "why": "Seven eval records covering two transitions, two transversions, an insertion, a deletion and a multiallelic site, a comparison file matching three of them, run twelve ways and refused twice: with and without the comparison, the same file as dbSNP, four modules on their own, the standard stratifiers off, a stratifier on, a named subset, two unknown names and --list. Both input VCFs are reported whole and indexed in the dump, because the walker queries them by interval."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/VariantEvalDump.java
+++ b/tools/readfilter-conformance/VariantEvalDump.java
@@ -1,0 +1,201 @@
+/*
+ * VariantEval's report, taken from the reference.
+ *
+ * How a call set is counted against a comparison one. The tool writes a GATKReport of one table per
+ * evaluation module, each stratified by whatever stratifiers were asked for, and what a row counts
+ * depends on the stratification as much as on the data.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - THE REPORT IS ONE TABLE PER MODULE, and --list names the modules without reading a record;
+ *   - THE STANDARD STRATIFIERS APPLY UNLESS TURNED OFF, so every table has an `all` row and a row
+ *     per novelty even when none were asked for;
+ *   - NOVELTY IS DECIDED BY THE dbSNP TRACK AND NOT BY --comp: the same file given as `--comp`
+ *     leaves every site novel and given as `--dbsnp` splits them, which is the whole of the
+ *     difference between the two arguments here;
+ *   - A STRATIFIER MULTIPLIES THE ROWS rather than adding a column;
+ *   - `CountVariants` COUNTS BY TYPE and `TiTvVariantEvaluator` BY SUBSTITUTION, so the same file
+ *     is summarised twice under different questions;
+ *   - AN INDEL'S LENGTH IS SIGNED, insertions positive and deletions negative;
+ *   - A MULTIALLELIC SITE IS ITS OWN CATEGORY rather than being counted once per alternate;
+ *   - --select-expression ADDS A NAMED SUBSET as another stratum;
+ *   - AND AN UNKNOWN MODULE NAME IS REFUSED, naming what it could not find.
+ *
+ * Output:
+ *
+ *     vcf\t<label>=<that vcf, escaped>
+ *     out\t<label>=<the whole report, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: VariantEvalDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.varianteval.VariantEval;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class VariantEvalDump {
+
+    static final int CONTIG_LENGTH = 199980;
+
+    static List<String> header() {
+        return new ArrayList<>(List.of(
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=" + CONTIG_LENGTH + ">",
+                "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts1"));
+    }
+
+    static String site(final int position, final String reference, final String alternate,
+                       final String genotype) {
+        return "chr1\t" + position + "\t.\t" + reference + "\t" + alternate
+                + "\t100.00\tPASS\t.\tGT\t" + genotype;
+    }
+
+    static String vcf(final List<String> sites) {
+        final List<String> lines = header();
+        lines.addAll(sites);
+        lines.add("");
+        return String.join("\n", lines);
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("variant-eval-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# VariantEvalDump: how a call set is counted against a comparison one");
+
+        final Path fasta = writeReference(dir);
+
+        // The eval set: transitions, transversions, an insertion, a deletion, a multiallelic.
+        final String eval = vcf(List.of(
+                site(1000, "A", "G", "0/1"),          // transition
+                site(2000, "C", "T", "0/1"),          // transition
+                site(3000, "A", "C", "0/1"),          // transversion
+                site(4000, "G", "T", "1/1"),          // transversion
+                site(5000, "A", "ACGT", "0/1"),       // insertion of three
+                site(6000, "ACGT", "A", "0/1"),       // deletion of three
+                site(7000, "A", "C,G", "1/2")));      // multiallelic
+        final Path evalPath = writeIndexed(dir, "eval.vcf", eval, "eval");
+
+        // The comparison set: three of the seven positions, so the rest are novel.
+        final String comp = vcf(List.of(
+                site(1000, "A", "G", "0/1"),
+                site(3000, "A", "C", "0/1"),
+                site(5000, "A", "ACGT", "0/1")));
+        final Path compPath = writeIndexed(dir, "comp.vcf", comp, "comp");
+
+        run(dir, "no-comp", fasta, List.of("--eval", evalPath.toString()));
+        // The SAME comparison file given as dbSNP, which is what the novelty stratifier reads.
+        run(dir, "dbsnp", fasta, List.of("--eval", evalPath.toString(),
+                "--dbsnp", compPath.toString(),
+                "--do-not-use-all-standard-modules", "true", "-EV", "CountVariants"));
+        run(dir, "with-comp", fasta,
+                List.of("--eval", evalPath.toString(), "--comp", compPath.toString()));
+        // One module at a time, with the standard stratifiers turned off.
+        run(dir, "count-variants", fasta, List.of("--eval", evalPath.toString(),
+                "--comp", compPath.toString(),
+                "--do-not-use-all-standard-modules", "true", "-EV", "CountVariants"));
+        run(dir, "titv", fasta, List.of("--eval", evalPath.toString(),
+                "--comp", compPath.toString(),
+                "--do-not-use-all-standard-modules", "true", "-EV", "TiTvVariantEvaluator"));
+        run(dir, "indel-length", fasta, List.of("--eval", evalPath.toString(),
+                "--do-not-use-all-standard-modules", "true", "-EV", "IndelLengthHistogram"));
+        run(dir, "multiallelic", fasta, List.of("--eval", evalPath.toString(),
+                "--do-not-use-all-standard-modules", "true", "-EV", "MultiallelicSummary"));
+        // The standard stratifiers off, which removes the novelty rows.
+        run(dir, "no-standard-stratifiers", fasta, List.of("--eval", evalPath.toString(),
+                "--comp", compPath.toString(),
+                "--do-not-use-all-standard-modules", "true", "-EV", "CountVariants",
+                "--do-not-use-all-standard-stratifications", "true"));
+        // A stratifier that multiplies the rows.
+        run(dir, "stratify-by-type", fasta, List.of("--eval", evalPath.toString(),
+                "--do-not-use-all-standard-modules", "true", "-EV", "CountVariants",
+                "-ST", "VariantType"));
+        // A named subset.
+        run(dir, "select-expression", fasta, List.of("--eval", evalPath.toString(),
+                "--do-not-use-all-standard-modules", "true", "-EV", "CountVariants",
+                "-select", "QUAL > 50", "-select-name", "highqual"));
+        // An unknown module, and an unknown stratifier.
+        run(dir, "unknown-module", fasta, List.of("--eval", evalPath.toString(),
+                "-EV", "NoSuchEvaluator"));
+        run(dir, "unknown-stratifier", fasta, List.of("--eval", evalPath.toString(),
+                "-ST", "NoSuchStratifier"));
+        // --list is LAST because it ENDS THE PROCESS: it prints the module names and exits the
+        // JVM. The marker below is written BEFORE the call and the one after it never is, which is
+        // how the golden records that.
+        System.out.println("none\tlist=about to run, which ends the process");
+        run(dir, "list", fasta, List.of("--eval", evalPath.toString(), "--list", "true"));
+        System.out.println("none\tafter-list=this line is never reached");
+    }
+
+    static Path writeIndexed(final Path dir, final String name, final String text,
+                             final String label) throws Exception {
+        System.out.printf("vcf\t%s=%s%n", label, ReferenceQueryDump.escape(text));
+        final Path path = write(dir, name, text);
+        htsjdk.tribble.index.IndexFactory.createLinearIndex(path.toFile(),
+                new htsjdk.variant.vcf.VCFCodec()).writeBasedOnFeatureFile(path.toFile());
+        return path;
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path fasta,
+                    final List<String> extra) throws Exception {
+        final Path out = dir.resolve("out-" + label + ".txt");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-O", out.toString(),
+                "-R", fasta.toString()));
+        argv.addAll(extra);
+        try {
+            new VariantEval().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            // Some runs return without writing anything and without throwing: --list prints the
+            // modules and stops, and an unrecognised module name does the same. Reported rather
+            // than passed over in silence.
+            System.out.printf("none\t%s=no output file%n", label);
+            return;
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(Files.readString(out), dir)));
+    }
+
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("reference.fasta");
+        final StringBuilder bases = new StringBuilder(">chr1\n");
+        for (int i = 0; i < CONTIG_LENGTH / 60; i++) {
+            bases.append("ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n");
+        }
+        Files.writeString(fasta, bases.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        final htsjdk.samtools.SAMFileHeader header = new htsjdk.samtools.SAMFileHeader();
+        header.setSequenceDictionary(new htsjdk.samtools.SAMSequenceDictionary(List.of(
+                new htsjdk.samtools.SAMSequenceRecord("chr1", CONTIG_LENGTH))));
+        try (final java.io.Writer writer = Files.newBufferedWriter(dir.resolve("reference.dict"))) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, header);
+        }
+        return fasta;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Two commits: the hand-written half, then the generated half.

**`15058a8` Measure VariantEval** — the dump and its manifest entry. Seven eval
records, a comparison file matching three of them, twelve runs and two
refusals.

**`REGEN` Regenerate the workflow and the dashboard** — `ci.yml` and
`STATUS.md`, both produced by their generators from the manifest above. Nothing
here is hand-written, and separating it keeps the reviewable half small.

Two things the first output corrected:

- novelty is decided by the **dbSNP** track and not by `--comp`. The same file
  given as `--comp` leaves all seven sites novel; given as `--dbsnp` it splits
  them three known and four novel. The fixture runs both.
- `--list` **ends the process**. Three runs produced no row at all until that
  was found, because everything after the `--list` call was unreachable. It is
  last now, with a marker before it and another after it, and the golden carries
  only the first.

No golden yet: this is the measurement half of the brick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)