### PR TITLE
Measure GenotypeGVCFs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,10 @@ jobs:
             index: "52/52"
             slug: "combine-gvcfs-variant-eval"
             suites: "combine-gvcfs variant-eval"
+          - group: golden-pending
+            index: "1/1"
+            slug: "genotype-gvcfs"
+            suites: "genotype-gvcfs"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 166 | 53.4% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 133 | 42.8% |
+| not started | 132 | 42.4% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (118 of 190 started)
+## gatk-origin tools (119 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -149,6 +149,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GatherTranches` | unclassified | oracle-backed | gather-tranches | 1 | not measured |
 | `GatherVcfsCloud` | variant-transform | oracle-backed | gather-vcfs | 1 | not measured |
 | `GeneExpressionEvaluation` | locus-walker | oracle-backed | gene-expression-evaluation | 1 | not measured |
+| `GenotypeGVCFs` | assembly-caller | golden-pending | genotype-gvcfs | 1 | not measured |
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |
 | `GetPileupSummaries` | locus-walker | oracle-backed | get-pileup-summaries | 1 | not measured |
 | `GetSampleName` | reporting-walker | oracle-backed | get-sample-name | 1 | not measured |
@@ -208,9 +209,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>72 not started</summary>
+<details><summary>71 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GenotypeGVCFs`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5961,6 +5961,26 @@
           "why": "Seven eval records covering two transitions, two transversions, an insertion, a deletion and a multiallelic site, a comparison file matching three of them, run twelve ways and refused twice: with and without the comparison, the same file as dbSNP, four modules on their own, the standard stratifiers off, a stratifier on, a named subset, two unknown names and --list. Both input VCFs are reported whole and indexed in the dump, because the walker queries them by interval. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33064822968, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "genotype-gvcfs",
+      "status": "golden-pending",
+      "title": "how a GVCF becomes a genotyped VCF",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "GenotypeGVCFs"
+      ],
+      "why": "A REFERENCE BLOCK IS NEVER WRITTEN by default: the output is a VCF and not a GVCF. <NON_REF> IS REMOVED FROM THE ALTERNATES of every site that survives, and an ALTERNATE NO SAMPLE CARRIES IS DROPPED with it, so a site the GVCF wrote as `C,G,<NON_REF>` comes out as `C`. THE GENOTYPES ARE CALLED FROM THE LIKELIHOODS RATHER THAN COPIED, and the call can DISAGREE with the one the GVCF carried: the site whose likelihoods are `3,0,900` is written `0/1` in the input and called `0/0` here, because the calling prior moves a three-point margin. THE CALLING THRESHOLD DOES NOT DECIDE EMISSION: what is written is decided by the CALL, so that site is dropped at a threshold of 2 as surely as at 50, and only --include-non-variant-sites brings it back. THAT ARGUMENT EXPANDS A REFERENCE BLOCK INTO ONE RECORD PER BASE rather than writing the block, so a five-base block becomes five records. --sample-ploidy CHANGES NOTHING when the likelihood arrays are diploid, which is the control that says the ploidy is read off the data. AND THE SITE ANNOTATIONS ARE COMPUTED FROM THE CALLED GENOTYPES, so AC, AN and AF describe the output rather than the input.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "GenotypeGVCFsDump",
+          "golden": null,
+          "why": "A five-base reference block and five variants covering a confident heterozygote, a confident homozygote, a site whose best likelihood is the reference, a marginal site three points from one, and a site with an alternate no sample carries, run six ways: the default, all sites, two calling thresholds either side of the marginal site's quality, the raw annotations kept, and a ploidy of one. The block is five bases because --include-non-variant-sites expands it one record per base."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/GenotypeGVCFsDump.java
+++ b/tools/readfilter-conformance/GenotypeGVCFsDump.java
@@ -1,0 +1,186 @@
+/*
+ * GenotypeGVCFs' calls, taken from the reference.
+ *
+ * How a GVCF becomes a genotyped VCF. Every reference block is dropped, every variant is
+ * re-genotyped from its likelihoods against a calling threshold, and <NON_REF> is removed from the
+ * alleles that survive.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - A REFERENCE BLOCK IS NEVER WRITTEN: the output is a VCF and not a GVCF;
+ *   - <NON_REF> IS REMOVED FROM THE ALTERNATES of every site that is written;
+ *   - A SITE WHOSE BEST GENOTYPE IS REFERENCE IS DROPPED, and --include-non-variant-sites writes it
+ *     anyway, which is the only way to see what the calling threshold removed;
+ *   - THE CALLING THRESHOLD DOES NOT DECIDE EMISSION: what is written is decided by the CALL, so
+ *     a site whose called genotype is reference is dropped at a threshold of 2 as surely as at 50,
+ *     and only --include-non-variant-sites brings it back. The two threshold runs are here as the
+ *     controls that say so;
+ *   - AN ALTERNATE NO SAMPLE CARRIES IS DROPPED and the likelihoods are re-indexed around it;
+ *   - THE GENOTYPES ARE CALLED FROM THE LIKELIHOODS, not copied, so a sample's GT can differ from
+ *     the one the GVCF carried;
+ *   - THE SITE ANNOTATIONS ARE COMPUTED FROM THE CALLED GENOTYPES, so AC, AN and AF describe the
+ *     output;
+ *   - --keep-combined-raw-annotations RETAINS THE RAW FIELDS beside the finalised ones;
+ *   - AND --sample-ploidy CHANGES NOTHING when the likelihood arrays are diploid, which is the
+ *     control that says the ploidy is read off the data rather than off the argument.
+ *
+ * Output:
+ *
+ *     vcf\tinput=<the gvcf, escaped>
+ *     out\t<label>=<the whole output vcf without its header, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: GenotypeGVCFsDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.GenotypeGVCFs;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GenotypeGVCFsDump {
+
+    static final int CONTIG_LENGTH = 199980;
+
+    static List<String> header() {
+        return new ArrayList<>(List.of(
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=" + CONTIG_LENGTH + ">",
+                "##ALT=<ID=NON_REF,Description=\"Any other allele\">",
+                "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End\">",
+                "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+                "##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allele depths\">",
+                "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Depth\">",
+                "##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Genotype quality\">",
+                "##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description=\"Minimum depth\">",
+                "##FORMAT=<ID=PL,Number=G,Type=Integer,Description=\"Likelihoods\">",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts1"));
+    }
+
+    static String block(final int start, final int end) {
+        return "chr1\t" + start + "\t.\tA\t<NON_REF>\t.\t.\tEND=" + end
+                + "\tGT:DP:GQ:MIN_DP:PL\t0/0:20:40:20:0,40,400";
+    }
+
+    /** A variant, whose PL array decides what it is genotyped as. */
+    static String variant(final int position, final String alternates, final String genotype,
+                          final String likelihoods) {
+        final int alleles = alternates.split(",").length + 2;
+        final StringBuilder depths = new StringBuilder("8");
+        for (int i = 1; i < alleles; i++) {
+            depths.append(",").append(i == 1 ? 4 : 0);
+        }
+        return "chr1\t" + position + "\t.\tA\t" + alternates + ",<NON_REF>\t.\t.\t."
+                + "\tGT:AD:DP:GQ:PL\t" + genotype + ":" + depths + ":12:50:" + likelihoods;
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("genotype-gvcfs-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# GenotypeGVCFsDump: how a GVCF becomes a genotyped VCF");
+
+        final Path fasta = writeReference(dir);
+
+        final List<String> sites = new ArrayList<>(header());
+        // A reference block, which never reaches the output.
+        // Five bases only: --include-non-variant-sites expands a block into one record per BASE,
+        // so a longer one would bury every other run's output in the report.
+        sites.add(block(1000, 1004));
+        // A confident heterozygote: the middle likelihood is the best.
+        sites.add(variant(1100, "C", "0/1", "900,0,900,900,900,900"));
+        // A confident homozygous variant.
+        sites.add(variant(1200, "C", "1/1", "900,900,0,900,900,900"));
+        // A site whose best likelihood is the REFERENCE, which the threshold drops.
+        sites.add(variant(1300, "C", "0/0", "0,60,600,60,600,600"));
+        // A marginal site, three quality points above a reference call.
+        sites.add(variant(1400, "C", "0/1", "3,0,900,3,3,3"));
+        // Two alternates, only the first of which the sample carries.
+        sites.add(variant(1500, "C,G", "0/1",
+                "900,0,900,900,900,900,900,900,900,900"));
+        sites.add("");
+        final String input = String.join("\n", sites);
+        final Path inputPath = write(dir, "input.g.vcf", input);
+        htsjdk.tribble.index.IndexFactory.createLinearIndex(inputPath.toFile(),
+                new htsjdk.variant.vcf.VCFCodec()).writeBasedOnFeatureFile(inputPath.toFile());
+        System.out.printf("vcf\tinput=%s%n", ReferenceQueryDump.escape(input));
+
+        run(dir, "default", inputPath, fasta, List.of());
+        run(dir, "all-sites", inputPath, fasta,
+                List.of("--include-non-variant-sites", "true"));
+        // The calling threshold, above and below the marginal site.
+        run(dir, "call-threshold-2", inputPath, fasta,
+                List.of("--standard-min-confidence-threshold-for-calling", "2"));
+        run(dir, "call-threshold-50", inputPath, fasta,
+                List.of("--standard-min-confidence-threshold-for-calling", "50"));
+        // The raw annotations kept beside the finalised ones.
+        run(dir, "keep-combined", inputPath, fasta,
+                List.of("--keep-combined-raw-annotations", "true"));
+        // A ploidy the genotyper is told to assume, which does not match the likelihood arrays.
+        run(dir, "ploidy-one", inputPath, fasta, List.of("--sample-ploidy", "1"));
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path input, final Path fasta,
+                    final List<String> extra) throws Exception {
+        final Path out = dir.resolve("out-" + label + ".vcf");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-V", input.toString(),
+                "-O", out.toString(),
+                "-R", fasta.toString()));
+        argv.addAll(extra);
+        try {
+            new GenotypeGVCFs().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            System.out.printf("none\t%s=no output file%n", label);
+            return;
+        }
+        final StringBuilder body = new StringBuilder();
+        for (final String line : Files.readString(out).split("\n", -1)) {
+            if (!line.startsWith("##") && !line.isEmpty()) {
+                body.append(line).append("\n");
+            }
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(body.toString(), dir)));
+    }
+
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("reference.fasta");
+        final StringBuilder bases = new StringBuilder(">chr1\n");
+        for (int i = 0; i < CONTIG_LENGTH / 60; i++) {
+            bases.append("ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n");
+        }
+        Files.writeString(fasta, bases.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        final htsjdk.samtools.SAMFileHeader header = new htsjdk.samtools.SAMFileHeader();
+        header.setSequenceDictionary(new htsjdk.samtools.SAMSequenceDictionary(List.of(
+                new htsjdk.samtools.SAMSequenceRecord("chr1", CONTIG_LENGTH))));
+        try (final java.io.Writer writer = Files.newBufferedWriter(dir.resolve("reference.dict"))) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, header);
+        }
+        return fasta;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Two commits: the hand-written half, then the generated half.

**`845ef7c` Measure GenotypeGVCFs** — a five-base reference block and five
variants, run six ways.

**`f558c73` Regenerate the workflow and the dashboard** — mechanical output of
the two generators.

The genotypes are called from the likelihoods rather than copied, and the call
can **disagree** with the one the GVCF carried: the site whose likelihoods are
`3,0,900` is written `0/1` in the input and called `0/0` here, because the
calling prior moves a three-point margin.

The calling threshold does **not** decide emission. What is written is decided
by the call, so that site is dropped at a threshold of 2 as surely as at 50,
and only `--include-non-variant-sites` brings it back. The two threshold runs
are kept as the controls that say so rather than removed for changing nothing,
and the same goes for `--sample-ploidy`.

Taken after **GnarlyGenotyper was parked** (#621): that tool needs an input in
the shape GenomicsDB produces, and with a hand-written combined GVCF it marks
every site LowQual and never genotypes, so its golden would have recorded the
tool refusing to work.

No golden yet: this is the measurement half of the brick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)