### PR TITLE
Measure StructuralVariantDiscoverer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,10 @@ jobs:
             index: "52/52"
             slug: "combine-gvcfs-variant-eval-genotype-gvcfs"
             suites: "combine-gvcfs variant-eval genotype-gvcfs"
+          - group: golden-pending
+            index: "1/1"
+            slug: "structural-variant-discoverer"
+            suites: "structural-variant-discoverer"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 167 | 53.7% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 132 | 42.4% |
+| not started | 131 | 42.1% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (119 of 190 started)
+## gatk-origin tools (120 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -197,6 +197,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `SplitIntervals` | interval-utility | oracle-backed | split-intervals | 1 | not measured |
 | `SplitNCigarReads` | record-transform | oracle-backed | split-n-cigar-reads | 1 | not measured |
 | `SplitReads` | record-transform | oracle-backed | split-reads | 1 | not measured |
+| `StructuralVariantDiscoverer` | unclassified | golden-pending | structural-variant-discoverer | 1 | not measured |
 | `TagGermlineEvents` | unclassified | oracle-backed | tag-germline-events | 1 | not measured |
 | `TransferReadTags` | record-transform | oracle-backed | transfer-read-tags | 1 | not measured |
 | `UnmarkDuplicates` | record-transform | oracle-backed | record-transform | 1 | not measured |
@@ -209,9 +210,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>71 not started</summary>
+<details><summary>70 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariantDiscoverer`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -5981,6 +5981,26 @@
           "why": "A five-base reference block and five variants covering a confident heterozygote, a confident homozygote, a site whose best likelihood is the reference, a marginal site three points from one, and a site with an alternate no sample carries, run six ways: the default, all sites, two calling thresholds either side of the marginal site's quality, the raw annotations kept, and a ploidy of one. The block is five bases because --include-non-variant-sites expands it one record per base. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33066147023, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "structural-variant-discoverer",
+      "status": "golden-pending",
+      "title": "how split alignments become a structural variant",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "StructuralVariantDiscoverer"
+      ],
+      "why": "THE READS MUST BE QUERYNAME-SORTED, refused outright otherwise, because the tool gathers a contig's alignments by walking consecutive records of the same name. A CONTIG ALIGNING IN TWO PIECES WITH A REFERENCE GAP IS A DELETION whose length is the gap: two hundred-base pieces six hundred apart give `<DEL>` over 10099 to 10599. A CONTIG WHOSE PIECES OVERLAP ON THE REFERENCE IS A TANDEM DUPLICATION rather than nothing: the overlap becomes the repeat unit and the call is `<DUP>` with a duplication number of 1,2. THE SAME TWO PIECES WITH THE SECOND ON THE OTHER STRAND PRODUCE NOTHING: a strand flip alone is not an inversion signature and the contig is dropped in silence, which is the measurement that a signature needs more than a strand. A CONTIG WITH ONE ALIGNMENT PRODUCES NOTHING, and so do a secondary alignment and an unmapped record, both filtered before any signature is read. THE OUTPUT IS A VCF WHOSE ALTERNATES ARE SYMBOLIC, one record per adjacency, and whose ID names the type and the interval. AND THE CONTIG NAMES ARE CARRIED THROUGH in `CTG_NAMES`, so each call says which contig made it.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "StructuralVariantDiscovererDump",
+          "golden": null,
+          "why": "Six assembled contigs over one reference contig: two pieces with a gap, two with a strand flip, one piece alone, two that overlap, a secondary alignment and an unmapped record, run twice: queryname-sorted and coordinate-sorted. The reads are reported as a line each. The BAM is written UNSORTED and htsjdk puts it in queryname order, because the fixture is written in the order the behaviours read best rather than alphabetically."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/StructuralVariantDiscovererDump.java
+++ b/tools/readfilter-conformance/StructuralVariantDiscovererDump.java
@@ -1,0 +1,217 @@
+/*
+ * StructuralVariantDiscoverer's calls, taken from the reference.
+ *
+ * How the split alignments of an assembled contig become a structural variant. A contig that aligns
+ * in two pieces with a gap between them is a deletion; the same two pieces in the other order or on
+ * the other strand are something else; and which it is comes from the SIGNATURE of the pair rather
+ * than from any argument.
+ *
+ * Eight behaviours this is built to catch.
+ *
+ *   - THE READS MUST BE QUERYNAME-SORTED, refused outright otherwise, because the tool gathers a
+ *     contig's alignments by walking consecutive records of the same name;
+ *   - A CONTIG ALIGNING IN TWO PIECES WITH A REFERENCE GAP IS A DELETION, whose length is the gap;
+ *   - THE SAME TWO PIECES WITH THE SECOND ON THE OTHER STRAND PRODUCE NOTHING: a strand flip
+ *     alone is not an inversion signature, and the contig is dropped in silence;
+ *   - A CONTIG WITH ONE ALIGNMENT PRODUCES NOTHING, whatever else is in the file;
+ *   - A SECONDARY ALIGNMENT IS FILTERED and an UNMAPPED one too, before any signature is read;
+ *   - THE SAMPLE ID COMES FROM THE READ GROUP, so the output's one sample is the header's;
+ *   - THE OUTPUT IS A VCF WHOSE ALTERNATES ARE SYMBOLIC, one record per adjacency rather than one
+ *     per contig;
+ *   - AND A CONTIG WHOSE PIECES OVERLAP ON THE REFERENCE IS A TANDEM DUPLICATION rather than
+ *     nothing: the overlap becomes the repeat unit, and the call is <DUP> with a duplication
+ *     number of 1,2.
+ *
+ * Output:
+ *
+ *     bam\treads=<one line per record: name flags contig start mapq cigar>
+ *     out\t<label>=<the whole output vcf without its header, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: StructuralVariantDiscovererDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.tools.StructuralVariantDiscoverer;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class StructuralVariantDiscovererDump {
+
+    static final int CONTIG_LENGTH = 199980;
+
+    static SAMFileHeader header(final SAMFileHeader.SortOrder order) {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", CONTIG_LENGTH))));
+        header.setSortOrder(order);
+        final SAMReadGroupRecord group = new SAMReadGroupRecord("rg1");
+        group.setSample("sampleA");
+        group.setPlatform("ILLUMINA");
+        header.addReadGroup(group);
+        return header;
+    }
+
+    /** One alignment of an assembled contig. */
+    static SAMRecord piece(final SAMFileHeader header, final String name, final int start,
+                           final String cigar, final boolean reverse, final boolean supplementary,
+                           final int length) {
+        final SAMRecord record = new SAMRecord(header);
+        record.setReadName(name);
+        record.setReferenceName("chr1");
+        record.setAlignmentStart(start);
+        record.setCigarString(cigar);
+        record.setMappingQuality(60);
+        final StringBuilder bases = new StringBuilder();
+        while (bases.length() < length) {
+            bases.append("ACGT");
+        }
+        record.setReadBases(bases.substring(0, length).getBytes(StandardCharsets.UTF_8));
+        final byte[] qualities = new byte[length];
+        Arrays.fill(qualities, (byte) 30);
+        record.setBaseQualities(qualities);
+        record.setReadNegativeStrandFlag(reverse);
+        record.setSupplementaryAlignmentFlag(supplementary);
+        record.setAttribute("RG", "rg1");
+        return record;
+    }
+
+    static String describe(final List<SAMRecord> records) {
+        final StringBuilder text = new StringBuilder();
+        for (final SAMRecord record : records) {
+            text.append(record.getReadName()).append('\t')
+                    .append(record.getFlags()).append('\t')
+                    .append(record.getReferenceName()).append('\t')
+                    .append(record.getAlignmentStart()).append('\t')
+                    .append(record.getMappingQuality()).append('\t')
+                    .append(record.getCigarString()).append('\n');
+        }
+        return text.toString();
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("sv-discoverer-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# StructuralVariantDiscovererDump: how split alignments become a "
+                + "structural variant");
+
+        final Path fasta = writeReference(dir);
+        final SAMFileHeader queryname = header(SAMFileHeader.SortOrder.queryname);
+
+        final List<SAMRecord> records = new ArrayList<>();
+        // A deletion: two pieces of one contig with a 500-base gap on the reference.
+        records.add(piece(queryname, "ctg-del", 10000, "100M100S", false, false, 200));
+        records.add(piece(queryname, "ctg-del", 10600, "100S100M", false, true, 200));
+        // The second piece on the other strand, which turns out to produce no call at all.
+        records.add(piece(queryname, "ctg-inv", 20000, "100M100S", false, false, 200));
+        records.add(piece(queryname, "ctg-inv", 20600, "100S100M", true, true, 200));
+        // One alignment only, which is no adjacency at all.
+        records.add(piece(queryname, "ctg-single", 30000, "200M", false, false, 200));
+        // Two pieces that OVERLAP on the reference rather than leaving a gap, which is read as a
+        // tandem duplication.
+        records.add(piece(queryname, "ctg-overlap", 40000, "100M100S", false, false, 200));
+        records.add(piece(queryname, "ctg-overlap", 40050, "100S100M", false, true, 200));
+        // A secondary alignment and an unmapped record, both filtered before any signature.
+        final SAMRecord secondary = piece(queryname, "ctg-secondary", 50000, "200M", false, false,
+                200);
+        secondary.setSecondaryAlignment(true);
+        records.add(secondary);
+        final SAMRecord unmapped = piece(queryname, "ctg-unmapped", 60000, "200M", false, false,
+                200);
+        unmapped.setReadUnmappedFlag(true);
+        records.add(unmapped);
+
+        final Path bam = dir.resolve("contigs.bam");
+        // presorted=false, so htsjdk puts the records in queryname order itself: the fixture is
+        // written in the order the behaviours read best, which is not alphabetical.
+        try (final SAMFileWriter writer = new SAMFileWriterFactory()
+                .makeBAMWriter(queryname, false, bam.toFile())) {
+            for (final SAMRecord record : records) {
+                writer.addAlignment(record);
+            }
+        }
+        System.out.printf("bam\treads=%s%n", ReferenceQueryDump.escape(describe(records)));
+
+        run(dir, "default", bam, fasta, List.of());
+
+        // The same records in coordinate order, which the tool refuses.
+        final SAMFileHeader coordinate = header(SAMFileHeader.SortOrder.coordinate);
+        final Path sorted = dir.resolve("coordinate.bam");
+        try (final SAMFileWriter writer = new SAMFileWriterFactory().setCreateIndex(true)
+                .makeBAMWriter(coordinate, false, sorted.toFile())) {
+            for (final SAMRecord record : records) {
+                final SAMRecord copy = record.deepCopy();
+                copy.setHeader(coordinate);
+                writer.addAlignment(copy);
+            }
+        }
+        run(dir, "coordinate-sorted", sorted, fasta, List.of());
+    }
+
+    static void run(final Path dir, final String label, final Path bam, final Path fasta,
+                    final List<String> extra) throws Exception {
+        final Path out = dir.resolve("out-" + label + ".vcf");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-I", bam.toString(),
+                "-O", out.toString(),
+                "-R", fasta.toString()));
+        argv.addAll(extra);
+        try {
+            new StructuralVariantDiscoverer().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            System.out.printf("none\t%s=no output file%n", label);
+            return;
+        }
+        final StringBuilder body = new StringBuilder();
+        for (final String line : Files.readString(out).split("\n", -1)) {
+            if (!line.startsWith("##") && !line.isEmpty()) {
+                body.append(line).append("\n");
+            }
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(body.toString(), dir)));
+    }
+
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("reference.fasta");
+        final StringBuilder bases = new StringBuilder(">chr1\n");
+        for (int i = 0; i < CONTIG_LENGTH / 60; i++) {
+            bases.append("ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n");
+        }
+        Files.writeString(fasta, bases.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", CONTIG_LENGTH))));
+        try (final java.io.Writer writer = Files.newBufferedWriter(dir.resolve("reference.dict"))) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, header);
+        }
+        return fasta;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Two commits: the hand-written half, then the generated half.

Six assembled contigs over one reference contig, run twice.

Two of the header's claims were written before the output was read and are
corrected in this commit:

- the two pieces with the second on the other strand produce **nothing**. A
  strand flip alone is not an inversion signature and the contig is dropped in
  silence, which is itself the measurement: a signature needs more than a
  strand.
- the two pieces that overlap on the reference are a **tandem duplication**,
  not merely "not a deletion". The overlap becomes the repeat unit and the call
  is `<DUP>` with a duplication number of 1,2.

The BAM is written unsorted and htsjdk puts it in queryname order. The first
attempt wrote it presorted and died on "Alignments added out of order": the
fixture is written in the order the behaviours read best, which is not
alphabetical.

No golden yet: this is the measurement half of the brick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)