### PR TITLE
Measure FuncotateSegments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,10 @@ jobs:
             index: "52/52"
             slug: "combine-gvcfs-variant-eval-genotype-gvcfs-structural-variant-discoverer"
             suites: "combine-gvcfs variant-eval genotype-gvcfs structural-variant-discoverer"
+          - group: golden-pending
+            index: "1/1"
+            slug: "funcotate-segments"
+            suites: "funcotate-segments"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 168 | 54.0% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 131 | 42.1% |
+| not started | 130 | 41.8% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (120 of 190 started)
+## gatk-origin tools (121 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -142,6 +142,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `FilterVariantTranches` | variant-transform | oracle-backed | filter-variant-tranches | 1 | not measured |
 | `FixMisencodedBaseQualityReads` | record-transform | oracle-backed | fix-misencoded | 1 | not measured |
 | `FlagStat` | reporting-walker | oracle-backed | counting-walkers | 1 | not measured |
+| `FuncotateSegments` | variant-walker | golden-pending | funcotate-segments | 1 | not measured |
 | `FuncotatorDataSourceDownloader` | variant-walker | oracle-backed | funcotator-data-source-downloader | 1 | not measured |
 | `GatherBQSRReports` | unclassified | oracle-backed | gather-bqsr-reports | 1 | not measured |
 | `GatherNormalArtifactData` | unclassified | oracle-backed | mutect-gathers | 1 | not measured |
@@ -210,9 +211,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantFiltration` | variant-transform | oracle-backed | variant-filtration | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>70 not started</summary>
+<details><summary>69 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `FuncotateSegments`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VariantRecalibrator`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `ExtractVariantAnnotations`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowFeatureMapper`, `FlowPairHMMAlignReadsToHaplotypes`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeBasedVariantRecaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`, `VariantRecalibrator`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6001,6 +6001,26 @@
           "why": "Six assembled contigs over one reference contig: two pieces with a gap, two with a strand flip, one piece alone, two that overlap, a secondary alignment and an unmapped record, run twice: queryname-sorted and coordinate-sorted. The reads are reported as a line each. The BAM is written UNSORTED and htsjdk puts it in queryname order, because the fixture is written in the order the behaviours read best rather than alphabetically. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of run 33067307177, and byte for byte what this laptop produced."
         }
       ]
+    },
+    {
+      "id": "funcotate-segments",
+      "status": "golden-pending",
+      "title": "how a segment file is annotated from a folder of data sources",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "FuncotateSegments"
+      ],
+      "why": "PENDING: written once the measurement is read.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "FuncotateSegmentsDump",
+          "golden": null,
+          "why": "PENDING: written once the measurement is read."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/FuncotateSegmentsDump.java
+++ b/tools/readfilter-conformance/FuncotateSegmentsDump.java
@@ -1,0 +1,279 @@
+/*
+ * FuncotateSegments' annotated segments, taken from the reference.
+ *
+ * How a copy-number segment file is annotated from a folder of data sources. The folder's SHAPE is
+ * as much of the tool as the annotation is: a manifest whose version must fall in a range, a
+ * directory per source, a directory per reference version inside it, and a properties file that
+ * says how to read the data.
+ *
+ * Ten behaviours this is built to catch.
+ *
+ *   - THE DATA SOURCE FOLDER IS THREE LEVELS DEEP: root, source name, reference version;
+ *   - THE MANIFEST'S VERSION MUST FALL IN A RANGE, and a folder outside it is REFUSED, not
+ *     skipped: a typo in the version stops the run;
+ *   - A MISSING MANIFEST IS NOT REFUSED, though: the version check simply never happens and the
+ *     sources load, so the file that guards the range is the one file that is optional;
+ *   - A REFERENCE VERSION WITH NO DIRECTORY UNDER ANY SOURCE IS ALSO REFUSED, with a different
+ *     message, and the same folder answers normally for the version it does have;
+ *   - THE CONFIG FILE'S REQUIRED KEYS DEPEND ON ITS `type`, and a locatable XSV without its
+ *     `end_column` is refused by name;
+ *   - A GENCODE SOURCE IS REQUIRED, whatever else the folder holds: the renderers look for
+ *     `Gencode_<version>_genes`, and the prefix is the source's own `name` key, capital G
+ *     included, so a source named `gencode` in lower case annotates nothing findable;
+ *   - A SEGMENT UNDER 150 BASES IS REFUSED rather than written through unannotated, and the
+ *     complaint is about the variant context and not about the segment file;
+ *   - THE SEG OUTPUT'S COLUMNS ARE A FIXED SET plus one group per source, so the locatable XSV
+ *     source beside GENCODE contributes nothing visible to it;
+ *   - A SEGMENT OVERLAPPING NO GENE IS STILL WRITTEN, with its Gencode columns empty, while the
+ *     absent columns of a segment file are `__UNKNOWN__` and not empty;
+ *   - AND EVERY RUN WRITES A SECOND FILE, `<output>.gene_list.txt`, one row per gene and exon,
+ *     which holds ONLY the genes a segment covers: the segments covering nothing are absent from
+ *     it, and a gene gets one row for the whole-segment `genes` field and one per exon.
+ *
+ * Output:
+ *
+ *     tsv\t<label>=<that file, escaped>
+ *     out\t<label>=<the whole output, escaped>
+ *     genes\t<label>=<the gene list beside it, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: FuncotateSegmentsDump
+ */
+
+import org.broadinstitute.hellbender.tools.funcotator.FuncotateSegments;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FuncotateSegmentsDump {
+
+    static final int CONTIG_LENGTH = 199980;
+
+    /** A data-source root: a manifest and one locatable XSV source under the given version. */
+    static Path dataSources(final Path dir, final String name, final String manifestVersion,
+                            final String refVersion, final boolean writeManifest) throws Exception {
+        final Path root = dir.resolve(name);
+        Files.createDirectories(root);
+        if (writeManifest) {
+            Files.writeString(root.resolve("MANIFEST.txt"),
+                    "Version: " + manifestVersion + "\nSource: test\nAlternate Source: test\n",
+                    StandardCharsets.UTF_8);
+        }
+        final Path source = root.resolve("regions").resolve(refVersion);
+        Files.createDirectories(source);
+        Files.writeString(source.resolve("regions.tsv"), String.join("\n",
+                "CONTIG\tSTART\tEND\tLABEL\tSCORE",
+                "chr1\t1000\t1999\tfirst\t10",
+                "chr1\t1500\t2499\tsecond\t20",
+                "chr1\t9000\t9999\tfar\t30",
+                ""), StandardCharsets.UTF_8);
+        Files.writeString(source.resolve("regions.config"), String.join("\n",
+                "name = regions",
+                "version = 1",
+                "src_file = regions.tsv",
+                "origin_location = test",
+                "preprocessing_script =",
+                "type = locatableXSV",
+                // The three are column INDICES and not names, whatever the header row says.
+                "contig_column = 0",
+                "start_column = 1",
+                "end_column = 2",
+                "xsv_delimiter = \\t",
+                ""), StandardCharsets.UTF_8);
+        writeGencode(root, refVersion);
+        return root;
+    }
+
+    /**
+     * A Gencode source, which the tool REQUIRES: without one it refuses before any annotation.
+     *
+     * The GTF is the same shape as SVAnnotate's fixture, and the transcript FASTA beside it is
+     * what `gencode_fasta_path` names.
+     */
+    static void writeGencode(final Path root, final String refVersion) throws Exception {
+        final Path source = root.resolve("gencode").resolve(refVersion);
+        Files.createDirectories(source);
+
+        final String attributes = "gene_id \"ENSG00000000001.1\"; transcript_id "
+                + "\"ENST00000000001.1\"; gene_type \"protein_coding\"; gene_name \"ALPHA\"; "
+                + "transcript_type \"protein_coding\"; transcript_name \"ALPHA-201\"; "
+                + "tag \"basic\"; transcript_status \"KNOWN\"; level 1;";
+        final List<String> gtf = new ArrayList<>();
+        // Exactly five header lines, in this order, or the codec refuses the file.
+        gtf.add("##description: evidence-based annotation of the human genome, version 43 (test)");
+        gtf.add("##provider: GENCODE");
+        gtf.add("##contact: gencode@test");
+        gtf.add("##format: gtf");
+        gtf.add("##date: 2022-01-01");
+        gtf.add("chr1\tHAVANA\tgene\t1000\t2000\t.\t+\t.\tgene_id \"ENSG00000000001.1\"; "
+                + "gene_type \"protein_coding\"; gene_name \"ALPHA\"; level 1;");
+        gtf.add("chr1\tHAVANA\ttranscript\t1000\t2000\t.\t+\t.\t" + attributes);
+        gtf.add("chr1\tHAVANA\texon\t1000\t1200\t.\t+\t.\t" + attributes + " exon_number 1; "
+                + "exon_id \"ENSE00000000001.1\";");
+        gtf.add("chr1\tHAVANA\tCDS\t1000\t1200\t.\t+\t0\t" + attributes + " exon_number 1; "
+                + "exon_id \"ENSE00000000001.1\";");
+        gtf.add("chr1\tHAVANA\tstart_codon\t1000\t1002\t.\t+\t0\t" + attributes
+                + " exon_number 1; exon_id \"ENSE00000000001.1\";");
+        gtf.add("chr1\tHAVANA\tstop_codon\t1198\t1200\t.\t+\t0\t" + attributes
+                + " exon_number 1; exon_id \"ENSE00000000001.1\";");
+        gtf.add("");
+        final Path gtfPath = source.resolve("gencode.gtf");
+        Files.writeString(gtfPath, String.join("\n", gtf), StandardCharsets.UTF_8);
+        // The GTF is QUERIED by interval, so it needs an index beside it too.
+        htsjdk.tribble.index.IndexFactory.createLinearIndex(gtfPath.toFile(),
+                new org.broadinstitute.hellbender.utils.codecs.gtf.GencodeGtfCodec())
+                .writeBasedOnFeatureFile(gtfPath.toFile());
+
+        final StringBuilder transcripts = new StringBuilder(">ENST00000000001.1\n");
+        for (int i = 0; i < 4; i++) {
+            transcripts.append("ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n");
+        }
+        final Path transcriptFasta = source.resolve("gencode.transcripts.fasta");
+        Files.writeString(transcriptFasta, transcripts.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(transcriptFasta, true);
+        // The transcript FASTA needs a dictionary beside it as well as an index.
+        final htsjdk.samtools.SAMFileHeader transcriptHeader = new htsjdk.samtools.SAMFileHeader();
+        transcriptHeader.setSequenceDictionary(new htsjdk.samtools.SAMSequenceDictionary(List.of(
+                new htsjdk.samtools.SAMSequenceRecord("ENST00000000001.1", 240))));
+        try (final java.io.Writer writer = Files.newBufferedWriter(
+                source.resolve("gencode.transcripts.dict"))) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, transcriptHeader);
+        }
+
+        Files.writeString(source.resolve("gencode.config"), String.join("\n",
+                // The field prefix is the datasource NAME, and the gene-list renderer looks for
+                // `Gencode_<version>_genes` with a capital G: lowercase here finds nothing.
+                "name = Gencode",
+                "version = 1",
+                "src_file = gencode.gtf",
+                "origin_location = test",
+                "preprocessing_script =",
+                "type = gencode",
+                "gencode_fasta_path = gencode.transcripts.fasta",
+                "ncbi_build_version = " + refVersion,
+                ""), StandardCharsets.UTF_8);
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("funcotate-segments-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# FuncotateSegmentsDump: how a segment file is annotated from a folder "
+                + "of data sources");
+
+        final Path fasta = writeReference(dir);
+
+        // The segments: one overlapping both source records, one overlapping neither, one
+        // overlapping the far record alone.
+        final String segments = String.join("\n",
+                "CONTIG\tSTART\tEND\tCALL",
+                "chr1\t1200\t1800\t+",
+                "chr1\t5000\t5500\t0",
+                // Over 150 bases, which is the minimum for a segment: see the short-segment run.
+                "chr1\t9400\t9900\t-",
+                "");
+        final Path segmentsPath = write(dir, "segments.seg", segments);
+        System.out.printf("tsv\tsegments=%s%n", ReferenceQueryDump.escape(segments));
+
+        final Path good = dataSources(dir, "ds-good", "1.7.hg38.20220101", "hg38", true);
+        final Path oldVersion = dataSources(dir, "ds-old", "1.2.hg38.20150101", "hg38", true);
+        final Path noManifest = dataSources(dir, "ds-none", "1.7.hg38.20220101", "hg38", false);
+        final Path hg19Only = dataSources(dir, "ds-hg19", "1.7.hg38.20220101", "hg19", true);
+
+        run(dir, "annotated", segmentsPath, fasta, good, "hg38", List.of());
+        // A version outside the accepted range, which is skipped in silence.
+        run(dir, "old-version", segmentsPath, fasta, oldVersion, "hg38", List.of());
+        // No manifest at all, which is also a skip.
+        run(dir, "no-manifest", segmentsPath, fasta, noManifest, "hg38", List.of());
+        // A source with no directory for the requested reference version.
+        run(dir, "wrong-ref-version", segmentsPath, fasta, hg19Only, "hg38", List.of());
+        // The same folder answered for the version it does have.
+        run(dir, "hg19", segmentsPath, fasta, hg19Only, "hg19", List.of());
+
+        // A config missing a required key for its type.
+        final Path broken = dataSources(dir, "ds-broken", "1.7.hg38.20220101", "hg38", true);
+        final Path config = broken.resolve("regions").resolve("hg38").resolve("regions.config");
+        Files.writeString(config, Files.readString(config).replace("end_column = 2\n", ""),
+                StandardCharsets.UTF_8);
+        run(dir, "missing-config-key", segmentsPath, fasta, broken, "hg38", List.of());
+
+        // A segment of 101 bases, under the 150-base minimum, which is REFUSED rather than
+        // written through unannotated.
+        final Path shortSegments = write(dir, "short.seg", String.join("\n",
+                "CONTIG\tSTART\tEND\tCALL",
+                "chr1\t1200\t1300\t+",
+                ""));
+        run(dir, "short-segment", shortSegments, fasta, good, "hg38", List.of());
+
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path segments, final Path fasta,
+                    final Path dataSources, final String refVersion, final List<String> extra)
+            throws Exception {
+        final Path out = dir.resolve("out-" + label + ".seg");
+        final List<String> argv = new ArrayList<>(List.of(
+                "--segments", segments.toString(),
+                "-O", out.toString(),
+                "-R", fasta.toString(),
+                "--data-sources-path", dataSources.toString(),
+                "--ref-version", refVersion,
+                "--output-file-format", "SEG"));
+        argv.addAll(extra);
+        try {
+            new FuncotateSegments().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            System.out.printf("none\t%s=no output file%n", label);
+            return;
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(Files.readString(out), dir)));
+        // Every run writes a SECOND file beside the first, one row per gene and exon.
+        final Path geneList = dir.resolve(out.getFileName() + ".gene_list.txt");
+        if (Files.exists(geneList)) {
+            System.out.printf("genes\t%s=%s%n", label,
+                    ReferenceQueryDump.escape(masked(Files.readString(geneList), dir)));
+        } else {
+            System.out.printf("none\t%s=no gene list%n", label);
+        }
+    }
+
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("reference.fasta");
+        final StringBuilder bases = new StringBuilder(">chr1\n");
+        for (int i = 0; i < CONTIG_LENGTH / 60; i++) {
+            bases.append("ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n");
+        }
+        Files.writeString(fasta, bases.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        final htsjdk.samtools.SAMFileHeader header = new htsjdk.samtools.SAMFileHeader();
+        header.setSequenceDictionary(new htsjdk.samtools.SAMSequenceDictionary(List.of(
+                new htsjdk.samtools.SAMSequenceRecord("chr1", CONTIG_LENGTH))));
+        try (final java.io.Writer writer = Files.newBufferedWriter(dir.resolve("reference.dict"))) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, header);
+        }
+        return fasta;
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
A copy-number segment file annotated from a folder of data sources, for #556. The folder's
shape is as much of the tool as the annotation is, so most of the runs vary the folder rather
than the segments: a manifest version outside the accepted range, no manifest at all, a
reference version with no directory, the same folder answered for the version it does have, a
config missing a required key for its type, and a segment under the minimum length.

Building the fixture falsified three claims I had written from reading the code:

- a manifest version outside the range is refused, not skipped in silence;
- a reference version with no directory is refused too;
- a missing manifest is not refused at all, because the version check simply never runs.

A GENCODE source is required whatever else the folder holds, and its column prefix is the
source's own `name` key rather than its directory, capital G included. A source named
`gencode` in lower case annotates nothing the renderers can find.

Two commits: the dump and its manifest entry, then the mechanical generator output.

The golden is `null` and the suite is `golden-pending`, so CI produces a `candidate-goldens`
artefact rather than comparing. Freezing it is the follow-up PR, which is where #556 is
resolved.