### PR TITLE
Measure FlowPairHMMAlignReadsToHaplotypes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,10 @@ jobs:
             index: "53/53"
             slug: "extract-variant-annotations-variant-recalibrator-haplotype-based-variant-recaller-flow-feature-mapper"
             suites: "extract-variant-annotations variant-recalibrator haplotype-based-variant-recaller flow-feature-mapper"
+          - group: golden-pending
+            index: "1/1"
+            slug: "flow-pairhmm-align-reads-to-haplotypes"
+            suites: "flow-pairhmm-align-reads-to-haplotypes"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 173 | 55.6% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 126 | 40.5% |
+| not started | 125 | 40.2% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (125 of 190 started)
+## gatk-origin tools (126 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -144,6 +144,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `FixMisencodedBaseQualityReads` | record-transform | oracle-backed | fix-misencoded | 1 | not measured |
 | `FlagStat` | reporting-walker | oracle-backed | counting-walkers | 1 | not measured |
 | `FlowFeatureMapper` | flow-based | oracle-backed | flow-feature-mapper | 1 | not measured |
+| `FlowPairHMMAlignReadsToHaplotypes` | flow-based | golden-pending | flow-pairhmm-align-reads-to-haplotypes | 1 | not measured |
 | `FuncotateSegments` | variant-walker | oracle-backed | funcotate-segments | 1 | not measured |
 | `FuncotatorDataSourceDownloader` | variant-walker | oracle-backed | funcotator-data-source-downloader | 1 | not measured |
 | `GatherBQSRReports` | unclassified | oracle-backed | gather-bqsr-reports | 1 | not measured |
@@ -215,9 +216,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantRecalibrator` | variant-transform | oracle-backed | variant-recalibrator | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>65 not started</summary>
+<details><summary>64 not started</summary>
 
-`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `FlowPairHMMAlignReadsToHaplotypes`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
+`AlleleFrequencyQC`, `AnalyzeSaturationMutagenesis`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CalibrateDragstrModel`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6101,6 +6101,26 @@
           "why": "Ten runs over one BAM of seven reads: the defaults, two surround settings, the duplicate read in, three score bounds, a copied attribute, an interval, and the mode that reports every base."
         }
       ]
+    },
+    {
+      "id": "flow-pairhmm-align-reads-to-haplotypes",
+      "status": "golden-pending",
+      "title": "every read scored against every haplotype, and what the concise format makes of it",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "FlowPairHMMAlignReadsToHaplotypes"
+      ],
+      "why": "PENDING: written once the measurement is read.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "FlowPairHMMAlignReadsToHaplotypesDump",
+          "golden": null,
+          "why": "PENDING: written once the measurement is read."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/FlowPairHMMAlignReadsToHaplotypesDump.java
+++ b/tools/readfilter-conformance/FlowPairHMMAlignReadsToHaplotypesDump.java
@@ -1,0 +1,258 @@
+/*
+ * FlowPairHMMAlignReadsToHaplotypes' read-by-haplotype matrix, taken from the reference.
+ *
+ * Every read scored against every haplotype of a FASTA, written either as the whole matrix or as
+ * one line per read naming its best haplotype. The alignment engine's arithmetic is not what this
+ * measures: what it measures is the two output formats, and above all what the concise one makes
+ * of the reference haplotype.
+ *
+ * Ten behaviours this is built to catch.
+ *
+ *   - THE EXPANDED FORMAT IS ONE COLUMN PER HAPLOTYPE, headed by the FASTA's own names in the
+ *     FASTA's own order, and one row per read;
+ *   - THE CONCISE FORMAT IS FIVE COLUMNS: the read, its best haplotype, that score, and the two
+ *     differences;
+ *   - THE REFERENCE SCORE IS ONLY RECORDED WHILE THE REFERENCE IS THE BEST HAPLOTYPE SO FAR,
+ *     the assignment sitting inside the branch that raises the best score, so a reference that
+ *     comes after a better haplotype is never recorded at all;
+ *   - WHICH MAKES THE COLUMN DEPEND ON THE FASTA'S ORDER: the same haplotypes with the reference
+ *     first report a real difference and with the reference last report `Infinity`;
+ *   - AND WITH NO --ref-haplotype, OR ONE THE FASTA DOES NOT NAME, every row reports `Infinity`;
+ *   - A READ THAT MATCHES NO HAPLOTYPE HAS NO BEST ONE: its name column is EMPTY, its score is
+ *     `-Infinity`, and both differences are `NaN`, being an infinity less itself;
+ *   - THE TWO ENGINES DISAGREE ABOUT THAT READ, FlowBased leaving it unmatched where
+ *     FlowBasedHMM gives it the reference;
+ *   - THE BEST HAPLOTYPE IS THE FIRST OF AN EXACT TIE, the comparison being strict, though two
+ *     scores that PRINT the same need not be tied: a `Diff_from_second` of 0.000 is a rounded
+ *     difference and not an equality;
+ *   - EVERY SCORE IS PRINTED WITH THREE DECIMALS, and an infinity prints as `Infinity` rather
+ *     than as a number;
+ *   - AND AN ENGINE THE TOOL DOES NOT HAVE IS A BARE RuntimeException naming the two it does.
+ *
+ * Output:
+ *
+ *     fasta\t<label>=<that fasta, escaped>
+ *     sam\t<label>=<that bam as sam, without its header, escaped>
+ *     out\t<label>=<the whole output file, escaped>
+ *     none\t<label>=<what was not written>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: FlowPairHMMAlignReadsToHaplotypesDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.tools.walkers.featuremapping.FlowPairHMMAlignReadsToHaplotypes;
+import org.broadinstitute.hellbender.utils.read.FlowBasedRead;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FlowPairHMMAlignReadsToHaplotypesDump {
+
+    static final int CONTIG_LENGTH = 9960;
+    static final String FLOW_ORDER = "TGCA";
+    static final String UNIT = "TGCA";
+    /** Where every haplotype and every read starts. */
+    static final int START = 1000;
+    static final int LENGTH = 40;
+
+    static byte referenceBase(final int position) {
+        return (byte) UNIT.charAt((position - 1) % UNIT.length());
+    }
+
+    static byte[] referenceBases(final int start, final int length) {
+        final byte[] bases = new byte[length];
+        for (int i = 0; i < length; i++) {
+            bases[i] = referenceBase(start + i);
+        }
+        return bases;
+    }
+
+    /** The reference bases with the offsets given substituted. */
+    static String withChanges(final int... offsets) {
+        final byte[] bases = referenceBases(START, LENGTH);
+        for (final int offset : offsets) {
+            bases[offset] = bases[offset] == 'T' ? (byte) 'A' : (byte) 'T';
+        }
+        return new String(bases, StandardCharsets.UTF_8);
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("flow-pairhmm-align-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# FlowPairHMMAlignReadsToHaplotypesDump: every read scored against "
+                + "every haplotype, and what the concise format makes of it");
+
+        // The haplotypes: the reference itself and three that differ from it in one, two and
+        // three places.
+        final String fasta = String.join("\n",
+                ">hap_ref", withChanges(),
+                ">hap_one", withChanges(10),
+                ">hap_two", withChanges(10, 20),
+                ">hap_three", withChanges(10, 20, 30),
+                "");
+        final Path fastaPath = write(dir, "haplotypes.fasta", fasta);
+        System.out.printf("fasta\thaplotypes=%s%n", ReferenceQueryDump.escape(fasta));
+
+        final Path bam = dir.resolve("reads.bam").toAbsolutePath();
+        writeReads(bam);
+        System.out.printf("sam\treads=%s%n", ReferenceQueryDump.escape(asSam(bam)));
+
+        // The expanded format, with and without a named reference haplotype: the reference is
+        // named in the FASTA either way, so only the concise format can tell the difference.
+        run(dir, "expanded", bam, fastaPath, List.of());
+        run(dir, "expanded-ref", bam, fastaPath, List.of("--ref-haplotype", "hap_ref"));
+        // The concise format, which is where the reference score is read.
+        run(dir, "concise-ref", bam, fastaPath,
+                List.of("--concise-output-format", "true", "--ref-haplotype", "hap_ref"));
+        // The same with no reference haplotype at all.
+        run(dir, "concise-no-ref", bam, fastaPath,
+                List.of("--concise-output-format", "true"));
+        // A reference haplotype that the FASTA does not name, which is the same as none.
+        run(dir, "concise-unknown-ref", bam, fastaPath,
+                List.of("--concise-output-format", "true", "--ref-haplotype", "nothere"));
+        // The other engine, on both formats.
+        run(dir, "hmm-expanded", bam, fastaPath, List.of("-E", "FlowBasedHMM"));
+        run(dir, "hmm-concise", bam, fastaPath,
+                List.of("-E", "FlowBasedHMM", "--concise-output-format", "true",
+                        "--ref-haplotype", "hap_ref"));
+        // An engine the tool does not have.
+        run(dir, "unknown-engine", bam, fastaPath, List.of("-E", "PairHMM"));
+
+        // The SAME haplotypes with the reference LAST, which is what the reference score's
+        // recording condition turns on: it is only ever set while the reference is the best
+        // haplotype so far, so a reference that comes after a better one is never recorded.
+        final String reordered = String.join("\n",
+                ">hap_one", withChanges(10),
+                ">hap_two", withChanges(10, 20),
+                ">hap_three", withChanges(10, 20, 30),
+                ">hap_ref", withChanges(),
+                "");
+        final Path reorderedPath = write(dir, "reordered.fasta", reordered);
+        System.out.printf("fasta\treordered=%s%n", ReferenceQueryDump.escape(reordered));
+        run(dir, "concise-ref-last", bam, reorderedPath,
+                List.of("--concise-output-format", "true", "--ref-haplotype", "hap_ref"));
+        run(dir, "expanded-ref-last", bam, reorderedPath, List.of());
+
+        // Two haplotypes equally far from the reference read, so its two best scores tie.
+        final String tied = String.join("\n",
+                ">hap_ref", withChanges(),
+                ">hap_left", withChanges(10),
+                ">hap_right", withChanges(20),
+                "");
+        final Path tiedPath = write(dir, "tied.fasta", tied);
+        System.out.printf("fasta\ttied=%s%n", ReferenceQueryDump.escape(tied));
+        run(dir, "concise-tied", bam, tiedPath,
+                List.of("--concise-output-format", "true", "--ref-haplotype", "hap_ref"));
+        run(dir, "expanded-tied", bam, tiedPath, List.of());
+    }
+
+    /**
+     * The reads. One matching each haplotype exactly, and one matching none.
+     *
+     * The read that matches the reference exactly is the one whose concise line names the
+     * reference as best; the others are the ones whose reference difference is an infinity.
+     */
+    static void writeReads(final Path bam) {
+        final SAMFileHeader header = readHeader();
+        try (final SAMFileWriter writer = new SAMFileWriterFactory()
+                .setCreateIndex(true)
+                .makeBAMWriter(header, true, bam.toFile())) {
+            writer.addAlignment(record(header, "r-like-ref", withChanges()));
+            writer.addAlignment(record(header, "r-like-one", withChanges(10)));
+            writer.addAlignment(record(header, "r-like-two", withChanges(10, 20)));
+            writer.addAlignment(record(header, "r-like-three", withChanges(10, 20, 30)));
+            writer.addAlignment(record(header, "r-like-none", withChanges(5, 15, 25, 35)));
+        }
+    }
+
+    static SAMRecord record(final SAMFileHeader header, final String name, final String bases) {
+        final SAMRecord record = new SAMRecord(header);
+        record.setReadName(name);
+        record.setReferenceName("chr1");
+        record.setAlignmentStart(START);
+        record.setCigarString(bases.length() + "M");
+        record.setReadBases(bases.getBytes(StandardCharsets.UTF_8));
+        final byte[] quality = new byte[bases.length()];
+        Arrays.fill(quality, (byte) 40);
+        record.setBaseQualities(quality);
+        record.setMappingQuality(60);
+        record.setAttribute("RG", "rg1");
+        // A `tp` of all zeros: every base's quality is the probability of its own hmer length.
+        record.setAttribute(FlowBasedRead.FLOW_MATRIX_TAG_NAME, new byte[bases.length()]);
+        return record;
+    }
+
+    static SAMFileHeader readHeader() {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", CONTIG_LENGTH))));
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        final SAMReadGroupRecord group = new SAMReadGroupRecord("rg1");
+        group.setPlatform("ULTIMA");
+        group.setFlowOrder(FLOW_ORDER);
+        group.setSample("sm1");
+        header.addReadGroup(group);
+        return header;
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static String asSam(final Path bam) throws Exception {
+        final StringBuilder text = new StringBuilder();
+        try (final htsjdk.samtools.SamReader reader =
+                     htsjdk.samtools.SamReaderFactory.makeDefault().open(bam.toFile())) {
+            for (final SAMRecord record : reader) {
+                text.append(record.getSAMString());
+            }
+        }
+        return text.toString();
+    }
+
+    static void run(final Path dir, final String label, final Path bam, final Path fasta,
+                    final List<String> extra) throws Exception {
+        final Path out = dir.resolve("out-" + label + ".tsv");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-I", bam.toString(),
+                "-H", fasta.toString(),
+                "-O", out.toString()));
+        argv.addAll(extra);
+        try {
+            new FlowPairHMMAlignReadsToHaplotypes().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            System.out.printf("none\t%s=no matrix file%n", label);
+            return;
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(Files.readString(out), dir)));
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Every read scored against every haplotype of a FASTA, in both output formats, for #620. Twelve
runs over one BAM of five reads and three haplotype FASTAs: the same haplotypes with the
reference first and with the reference last, a pair of haplotypes equally far from one read,
both engines, no reference haplotype, a reference the FASTA does not name, and an engine the
tool does not have.

The alignment engine's arithmetic is not what this measures. The reordered FASTA is.

The concise format's reference score is assigned inside the branch that raises the best score,
so it is only ever recorded while the reference is the best haplotype seen so far. With the
reference first in the FASTA every row reports a real difference; with the same haplotypes and
the reference last, every read whose best haplotype is not the reference reports `Infinity`
instead. `Diff_from_ref` depends on the order of the input file and not only on its contents.

A read that matches no haplotype comes out with an empty name column, a score of `-Infinity`
and both differences `NaN`, an infinity less itself. The two engines disagree about that read:
FlowBased leaves it unmatched where FlowBasedHMM gives it the reference.

The tied fixture showed that a `Diff_from_second` of 0.000 is a rounded difference rather than
an equality: the two haplotypes are not symmetric in flow space, so the scores that print the
same are not the same.

Two commits: the dump and its manifest entry, then the mechanical generator output.

The golden is `null` and the suite is `golden-pending`, so CI produces a `candidate-goldens`
artefact rather than comparing. Freezing it is the follow-up PR, which is where #620 is
resolved.