### PR TITLE
Measure CreateReadCountPanelOfNormals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,10 @@ jobs:
             index: "54/54"
             slug: "calibrate-dragstr-model-analyze-saturation-mutagenesis"
             suites: "calibrate-dragstr-model analyze-saturation-mutagenesis"
+          - group: golden-pending
+            index: "1/1"
+            slug: "create-read-count-panel-of-normals"
+            suites: "create-read-count-panel-of-normals"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 176 | 56.6% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 123 | 39.5% |
+| not started | 122 | 39.2% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (128 of 190 started)
+## gatk-origin tools (129 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -128,6 +128,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
 | `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
 | `CountVariants` | variant-walker | oracle-backed | count-variants | 1 | not measured |
+| `CreateReadCountPanelOfNormals` | cnv-segmentation | golden-pending | create-read-count-panel-of-normals | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |
 | `DenoiseReadCounts` | cnv-segmentation | oracle-backed | denoise-read-counts | 1 | not measured |
 | `DepthOfCoverage` | locus-walker | oracle-backed | depth-of-coverage | 1 | not measured |
@@ -218,9 +219,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantRecalibrator` | variant-transform | oracle-backed | variant-recalibrator | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>62 not started</summary>
+<details><summary>61 not started</summary>
 
-`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `CreateReadCountPanelOfNormals`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
+`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6161,6 +6161,26 @@
           "why": "Ten configurations over one BAM of seventeen reads, plus a pair of runs that share a JVM: the defaults, a lower observation threshold, a wider flank, a higher mapping-quality floor, a longer minimum length, unpaired mode, the disjoint pairs combined, a two-interval ORF, and the two refusals."
         }
       ]
+    },
+    {
+      "id": "create-read-count-panel-of-normals",
+      "status": "golden-pending",
+      "title": "which intervals and which samples reach the panel",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "CreateReadCountPanelOfNormals"
+      ],
+      "why": "PENDING: written once the measurement is read.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "CreateReadCountPanelOfNormalsDump",
+          "golden": null,
+          "why": "PENDING: written once the measurement is read."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/CreateReadCountPanelOfNormalsDump.java
+++ b/tools/readfilter-conformance/CreateReadCountPanelOfNormalsDump.java
@@ -1,0 +1,293 @@
+/*
+ * CreateReadCountPanelOfNormals' panel, taken from the reference.
+ *
+ * A panel of normals is a set of read-count files reduced to the intervals worth keeping, the
+ * median of each of those intervals, and a basis of eigensamples. The singular value
+ * decomposition is not what this measures, being a distributed solver's: what it measures is
+ * everything that decides which intervals and which samples reach it.
+ *
+ * Eleven behaviours this is built to catch.
+ *
+ *   - THE TOOL IS A SPARK ONE, so it needs a master even with nothing to distribute, and it
+ *     needs a JVM that exports `sun.nio.ch` to it;
+ *   - THE COUNTS BECOME FRACTIONAL COVERAGE FIRST, each sample divided by its own total, so a
+ *     sample sequenced twice as deeply as another contributes the same and is not an outlier;
+ *   - AN INTERVAL WHOSE MEDIAN FRACTIONAL COVERAGE IS UNDER THE PERCENTILE IS DROPPED, which is
+ *     what takes out the two intervals every sample reads near zero;
+ *   - AN INTERVAL WITH TOO MANY ZEROS ACROSS THE SAMPLES IS DROPPED TOO, and that filter is much
+ *     the harsher of the two: on this panel it leaves two intervals where the median filter
+ *     leaves most of them;
+ *   - A SAMPLE WITH TOO MANY ZEROS IS DROPPED, which is what takes out the nearly-empty one;
+ *   - A SAMPLE WHOSE MEDIAN IS EXTREME IS DROPPED FROM BOTH ENDS, the percentile being applied
+ *     twice, so a percentile of twenty takes two samples of nine;
+ *   - THE PANEL KEEPS BOTH THE ORIGINAL INTERVALS AND THE SURVIVING ONES, so the file says what
+ *     was dropped as well as what was kept, and the ORIGINAL count is the input's whatever the
+ *     filters did;
+ *   - THE NUMBER OF EIGENSAMPLES IS CAPPED AT THE NUMBER OF SAMPLES THAT SURVIVED, so asking for
+ *     a hundred over nine samples with one filtered out gives eight;
+ *   - A PANEL OF ONE SAMPLE IS ACCEPTED, has no eigensamples, and REFUSES to hand over its
+ *     singular values rather than handing over an empty array;
+ *   - AND THE INPUTS MUST AGREE ON THEIR INTERVALS, one that does not being refused by name.
+ *
+ * Output:
+ *
+ *     counts\t<label>=<that read-count file, escaped>
+ *     panel\t<label>\t<field>=<value>
+ *     matrix\t<label>\t<name>=<one value per line, escaped>
+ *     none\t<label>=<what was not written>
+ *     error\t<label>\t<the tool's own message>
+ *     error\t<label>\t<field>\t<exception class>:<message>
+ *
+ * Usage: CreateReadCountPanelOfNormalsDump
+ */
+
+import org.broadinstitute.hellbender.tools.copynumber.CreateReadCountPanelOfNormals;
+import org.broadinstitute.hellbender.tools.copynumber.denoising.HDF5SVDReadCountPanelOfNormals;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CreateReadCountPanelOfNormalsDump {
+
+    static final int INTERVALS = 40;
+    static final int CONTIG_LENGTH = 40000;
+
+    /** One interval of the shared interval list: 1000 bases every 1000. */
+    static int start(final int index) {
+        return index * 1000 + 1;
+    }
+
+    static int end(final int index) {
+        return (index + 1) * 1000;
+    }
+
+    /**
+     * One read-count file: the SAM-style header the reader wants, then one row per interval.
+     */
+    static String counts(final String sample, final int[] values) {
+        final List<String> lines = new ArrayList<>();
+        lines.add("@HD\tVN:1.6");
+        lines.add("@SQ\tSN:chr1\tLN:" + CONTIG_LENGTH);
+        lines.add("@RG\tID:GATKCopyNumber\tSM:" + sample);
+        lines.add("CONTIG\tSTART\tEND\tCOUNT");
+        for (int i = 0; i < values.length; i++) {
+            lines.add("chr1\t" + start(i) + "\t" + end(i) + "\t" + values[i]);
+        }
+        lines.add("");
+        return String.join("\n", lines);
+    }
+
+    /**
+     * The panel's samples.
+     *
+     * Six ordinary ones, one sequenced twice as deeply, one that is nearly all zeros, and one
+     * whose median is far above the rest.
+     */
+    static int[] sampleCounts(final int sample) {
+        final int[] values = new int[INTERVALS];
+        for (int i = 0; i < INTERVALS; i++) {
+            // A repeating profile so the intervals differ from one another, plus a per-sample
+            // offset so the samples differ too.
+            final int base = 100 + (i * 7) % 23 + (sample * 3) % 11;
+            switch (sample) {
+                case 6 -> values[i] = base * 2;              // twice as deep
+                case 7 -> values[i] = i < 4 ? base : 0;      // nearly all zeros
+                case 8 -> values[i] = base * 20;             // an extreme median
+                default -> values[i] = base;
+            }
+            // The first two intervals are near zero in every sample, so their median is low.
+            if (i < 2) {
+                values[i] = sample == 7 ? 0 : 1;
+            }
+            // One interval is zero in three samples, which is over the interval percentage.
+            if (i == 20 && sample < 3) {
+                values[i] = 0;
+            }
+        }
+        return values;
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("create-read-count-pon-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# CreateReadCountPanelOfNormalsDump: which intervals and which "
+                + "samples reach the panel");
+
+        final List<Path> inputs = new ArrayList<>();
+        for (int sample = 0; sample < 9; sample++) {
+            final String text = counts("sample" + sample, sampleCounts(sample));
+            final Path path = write(dir, "sample" + sample + ".counts.tsv", text);
+            inputs.add(path);
+            if (sample < 2 || sample >= 6) {
+                // The ordinary samples are all alike, so only the first two and the three odd
+                // ones are printed.
+                System.out.printf("counts\tsample%d=%s%n", sample,
+                        ReferenceQueryDump.escape(text));
+            }
+        }
+
+        run(dir, "default", inputs, List.of());
+        // No filtering at all, which keeps every interval and every sample.
+        run(dir, "no-filtering", inputs, List.of(
+                "--minimum-interval-median-percentile", "0.0",
+                "--maximum-zeros-in-sample-percentage", "100.0",
+                "--maximum-zeros-in-interval-percentage", "100.0",
+                "--extreme-sample-median-percentile", "0.0",
+                "--extreme-outlier-truncation-percentile", "0.0"));
+        // Each filter on its own, against that baseline.
+        run(dir, "interval-median-only", inputs, List.of(
+                "--minimum-interval-median-percentile", "10.0",
+                "--maximum-zeros-in-sample-percentage", "100.0",
+                "--maximum-zeros-in-interval-percentage", "100.0",
+                "--extreme-sample-median-percentile", "0.0",
+                "--extreme-outlier-truncation-percentile", "0.0"));
+        run(dir, "zeros-in-sample-only", inputs, List.of(
+                "--minimum-interval-median-percentile", "0.0",
+                "--maximum-zeros-in-sample-percentage", "5.0",
+                "--maximum-zeros-in-interval-percentage", "100.0",
+                "--extreme-sample-median-percentile", "0.0",
+                "--extreme-outlier-truncation-percentile", "0.0"));
+        run(dir, "zeros-in-interval-only", inputs, List.of(
+                "--minimum-interval-median-percentile", "0.0",
+                "--maximum-zeros-in-sample-percentage", "100.0",
+                "--maximum-zeros-in-interval-percentage", "5.0",
+                "--extreme-sample-median-percentile", "0.0",
+                "--extreme-outlier-truncation-percentile", "0.0"));
+        run(dir, "extreme-sample-only", inputs, List.of(
+                "--minimum-interval-median-percentile", "0.0",
+                "--maximum-zeros-in-sample-percentage", "100.0",
+                "--maximum-zeros-in-interval-percentage", "100.0",
+                "--extreme-sample-median-percentile", "20.0",
+                "--extreme-outlier-truncation-percentile", "0.0"));
+        // The zeros left alone rather than imputed.
+        run(dir, "no-imputation", inputs, List.of("--do-impute-zeros", "false"));
+        // Fewer eigensamples than samples, and more.
+        run(dir, "two-eigensamples", inputs, List.of("--number-of-eigensamples", "2"));
+        run(dir, "hundred-eigensamples", inputs, List.of("--number-of-eigensamples", "100"));
+        // A panel of one sample.
+        run(dir, "one-sample", inputs.subList(0, 1), List.of());
+        // An input whose intervals do not match the others'.
+        final int[] shifted = sampleCounts(0);
+        final List<String> lines = new ArrayList<>(
+                List.of(counts("odd", shifted).split("\n", -1)));
+        lines.set(4, "chr1\t2\t1000\t1");
+        final Path odd = write(dir, "odd.counts.tsv", String.join("\n", lines));
+        final List<Path> mixed = new ArrayList<>(inputs.subList(0, 3));
+        mixed.add(odd);
+        run(dir, "mismatched-intervals", mixed, List.of());
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final List<Path> inputs,
+                    final List<String> extra) throws Exception {
+        final Path out = dir.resolve("out-" + label + ".pon.hdf5");
+        final List<String> argv = new ArrayList<>();
+        for (final Path input : inputs) {
+            argv.add("-I");
+            argv.add(input.toString());
+        }
+        argv.add("-O");
+        argv.add(out.toString());
+        // The tool is a SPARK one, the singular value decomposition being distributed, so it
+        // needs a master even when there is nothing to distribute.
+        argv.add("--spark-master");
+        argv.add("local[1]");
+        argv.addAll(extra);
+        // Spark reaches into `sun.nio.ch`, which a modern JDK does not export, so the tool runs
+        // in a JVM of its own with the exports its own launcher passes.
+        final List<String> command = new ArrayList<>(List.of(
+                "java",
+                "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+                "--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED",
+                "--add-opens", "java.base/java.nio=ALL-UNNAMED",
+                "--add-opens", "java.base/java.util=ALL-UNNAMED",
+                "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+                "--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED",
+                "-cp", System.getenv("ORACLE_CP"),
+                "org.broadinstitute.hellbender.Main", "CreateReadCountPanelOfNormals"));
+        command.addAll(argv);
+        final Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        final String log = new String(process.getInputStream().readAllBytes(),
+                StandardCharsets.UTF_8);
+        if (process.waitFor() != 0) {
+            String message = "exit " + process.exitValue();
+            for (final String line : log.split("\n")) {
+                final String trimmed = line.trim();
+                if (trimmed.startsWith("A USER ERROR has occurred:")
+                        || trimmed.startsWith("Exception in thread")
+                        || trimmed.contains("Exception:")
+                        || trimmed.contains("Error:")) {
+                    message = trimmed;
+                    break;
+                }
+            }
+            System.out.printf("error\t%s\t%s%n", label,
+                    ReferenceQueryDump.escape(masked(message, dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            System.out.printf("none\t%s=no panel%n", label);
+            return;
+        }
+        try (final org.broadinstitute.hdf5.HDF5File file =
+                     new org.broadinstitute.hdf5.HDF5File(new File(out.toString()))) {
+            final HDF5SVDReadCountPanelOfNormals panel = HDF5SVDReadCountPanelOfNormals.read(file);
+            System.out.printf("panel\t%s\tversion=%s%n", label,
+                    Double.toString(panel.getVersion()));
+            System.out.printf("panel\t%s\teigensamples=%d%n", label, panel.getNumEigensamples());
+            System.out.printf("panel\t%s\toriginal-intervals=%d%n", label,
+                    panel.getOriginalIntervals().size());
+            System.out.printf("panel\t%s\tpanel-intervals=%s%n", label,
+                    places(panel.getPanelIntervals()));
+            System.out.printf("panel\t%s\tsamples=%d%n", label,
+                    panel.getOriginalReadCounts().length);
+            System.out.printf("matrix\t%s\tfractional-medians=%s%n", label,
+                    ReferenceQueryDump.escape(vector(panel.getPanelIntervalFractionalMedians())));
+            // The singular values are the SVD's own, computed by a distributed solver: only
+            // their COUNT is reported, the values themselves not being what this measures. A
+            // panel with no eigensamples REFUSES to hand them over rather than handing over an
+            // empty array, so the reader is asked inside its own guard.
+            try {
+                System.out.printf("panel\t%s\tsingular-values=%d%n", label,
+                        panel.getSingularValues().length);
+            } catch (final Exception e) {
+                System.out.printf("error\t%s\tsingular-values\t%s:%s%n", label,
+                        e.getClass().getName(),
+                        ReferenceQueryDump.escape(masked(String.valueOf(e.getMessage()), dir)));
+            }
+        }
+    }
+
+    /** The intervals a panel kept, as `start-end` and comma-separated. */
+    static String places(final List<org.broadinstitute.hellbender.utils.SimpleInterval> intervals) {
+        final List<String> parts = new ArrayList<>();
+        for (final org.broadinstitute.hellbender.utils.SimpleInterval interval : intervals) {
+            parts.add(interval.getStart() + "-" + interval.getEnd());
+        }
+        return String.join(",", parts);
+    }
+
+    /** One vector, each value rendered by Double.toString. */
+    static String vector(final double[] values) {
+        final List<String> parts = new ArrayList<>();
+        for (final double value : values) {
+            parts.add(Double.toString(value));
+        }
+        return String.join("\n", parts) + "\n";
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Which intervals and which samples reach the panel, for #543. Eleven runs over nine read-count
files: the defaults, no filtering at all, each of the four filters on its own against that
baseline, the zeros left alone, two eigensample counts, a panel of one sample, and an input
whose intervals do not match.

The tool turned out to be a **Spark** one, which the milestone's own title says it is not. It
needs a master even with nothing to distribute, and it needs a JVM that exports `sun.nio.ch` to
it, so every run goes through a subprocess with the exports GATK's own launcher passes. Its
singular values are that solver's, so only their count is reported and the values are left
alone.

Two things the runs settled:

- the zeros-in-interval filter is much the harsher of the two interval filters. On this panel it
  leaves two intervals where the median filter leaves most of them;
- a panel of one sample refuses to hand over its singular values rather than handing over an
  empty array, which took a guard of its own around the reader: without it the dump died before
  its last run.

Two commits: the dump and its manifest entry, then the mechanical generator output.

The golden is `null` and the suite is `golden-pending`, so CI produces a `candidate-goldens`
artefact rather than comparing. Freezing it is the follow-up PR, which is where #543 is
resolved.