### PR TITLE
Measure GroundTruthReadsBuilder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,10 @@ jobs:
             index: "54/54"
             slug: "calibrate-dragstr-model-analyze-saturation-mutagenesis-create-read-count-panel-of-normals"
             suites: "calibrate-dragstr-model analyze-saturation-mutagenesis create-read-count-panel-of-normals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "ground-truth-reads-builder"
+            suites: "ground-truth-reads-builder"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 177 | 56.9% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 122 | 39.2% |
+| not started | 121 | 38.9% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (129 of 190 started)
+## gatk-origin tools (130 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -160,6 +160,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |
 | `GetPileupSummaries` | locus-walker | oracle-backed | get-pileup-summaries | 1 | not measured |
 | `GetSampleName` | reporting-walker | oracle-backed | get-sample-name | 1 | not measured |
+| `GroundTruthReadsBuilder` | flow-based | golden-pending | ground-truth-reads-builder | 1 | not measured |
 | `GroundTruthScorer` | flow-based | oracle-backed | series-stats | 1 | not measured |
 | `GroupedSVCluster` | sv-caller | oracle-backed | grouped-sv-cluster | 1 | not measured |
 | `GtfToBed` | assembly-caller | oracle-backed | gtf-to-bed | 1 | not measured |
@@ -219,9 +220,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantRecalibrator` | variant-transform | oracle-backed | variant-recalibrator | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>61 not started</summary>
+<details><summary>60 not started</summary>
 
-`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `GroundTruthReadsBuilder`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
+`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6181,6 +6181,26 @@
           "why": "Eleven runs over nine read-count files: the defaults, no filtering at all, each of the four filters on its own against that baseline, the zeros left alone, two eigensample counts, a panel of one sample, and an input whose intervals do not match."
         }
       ]
+    },
+    {
+      "id": "ground-truth-reads-builder",
+      "status": "golden-pending",
+      "title": "every read scored against the haplotype its two ancestral references give it",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "GroundTruthReadsBuilder"
+      ],
+      "why": "PENDING: written once the measurement is read.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "GroundTruthReadsBuilderDump",
+          "golden": null,
+          "why": "PENDING: written once the measurement is read."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/GroundTruthReadsBuilderDump.java
+++ b/tools/readfilter-conformance/GroundTruthReadsBuilderDump.java
@@ -1,0 +1,273 @@
+/*
+ * GroundTruthReadsBuilder's CSV, taken from the reference.
+ *
+ * Every read scored against the haplotype its two ancestral references give it, written as one
+ * CSV row. The flow-based scoring engine is not what this measures: what it measures is the
+ * translation from the aligned contig to the two ancestral ones, which reads survive it, and what
+ * the row carries.
+ *
+ * Eleven behaviours this is built to catch.
+ *
+ *   - THE TOOL REFUSES ANY BUT A FLOW-BASED ENGINE outright, so every run has to name one;
+ *   - IT ALSO NEEDS THE ALIGNED REFERENCE, not only the two ancestral ones: every read is scored
+ *     against it too, and without one the haplotype is null and the engine refuses;
+ *   - THE TRANSLATION IS A TABLE OF OFFSETS, one CSV per ancestor and contig, whose first line
+ *     is IGNORED and whose rows are a position and the offset that applies from it on;
+ *   - A POSITION BETWEEN TWO ROWS TAKES THE EARLIER ROW'S OFFSET, the search falling back on the
+ *     insertion point less two;
+ *   - THE TRANSLATED CONTIG IS THE READ'S OWN NAME WITH THE ANCESTOR APPENDED, so the two
+ *     reference files have to be named for it;
+ *   - A READ WHOSE TRANSLATED END IS NOT PAST ITS TRANSLATED START IS SKIPPED AND COUNTED, not
+ *     refused: the exception is caught and the traversal carries on;
+ *   - AN HAPLOTYPE IDENTICAL TO THE REFERENCE IS NOT RESCORED, taking the reference's own score,
+ *     so a read away from either ancestral difference reports the two as equal;
+ *   - A READ BELOW --min-mq IS DROPPED;
+ *   - THE SOFT-CLIP FILTER LOOKS AT THE CLIP AT THE END OF THE READ rather than at either end,
+ *     so a read clipped only at its front is kept whatever the argument says;
+ *   - --min-haplotype-score-delta DROPS A READ WHOSE TWO HAPLOTYPES ARE TOO FAR APART, which is
+ *     every read away from both ancestral differences;
+ *   - AND THE CSV IS QUOTED: the flow keys hold commas of their own, so a reader that splits on
+ *     the comma alone reads the columns out of step.
+ *
+ * Output:
+ *
+ *     fasta\t<label>=<that reference's contig and length>
+ *     csv\t<label>=<that translation table, escaped>
+ *     sam\t<label>=<that bam as sam, without its header, escaped>
+ *     out\t<label>=<the whole output csv, escaped>
+ *     none\t<label>=<what was not written>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: GroundTruthReadsBuilderDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.tools.walkers.groundtruth.GroundTruthReadsBuilder;
+import org.broadinstitute.hellbender.utils.read.FlowBasedRead;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class GroundTruthReadsBuilderDump {
+
+    static final int LENGTH = 2400;
+    static final String FLOW_ORDER = "TGCA";
+
+    static byte referenceBase(final int position) {
+        return (byte) "TGCA".charAt((position - 1) % 4);
+    }
+
+    static String referenceBases(final int start, final int length) {
+        final StringBuilder bases = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            bases.append((char) referenceBase(start + i));
+        }
+        return bases.toString();
+    }
+
+    /** One ancestral reference: the shared sequence with a handful of bases changed. */
+    static String ancestralBases(final int[] substitutions) {
+        final char[] bases = referenceBases(1, LENGTH).toCharArray();
+        for (final int offset : substitutions) {
+            bases[offset] = bases[offset] == 'T' ? 'A' : 'T';
+        }
+        return new String(bases);
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("ground-truth-reads-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# GroundTruthReadsBuilderDump: every read scored against the "
+                + "haplotype its two ancestral references give it");
+
+        // The two ancestors differ from one another at two positions, so the haplotypes differ.
+        // The aligned reference too: the tool scores every read against it as well as against
+        // the two ancestors, and without one the haplotype is null and the engine refuses.
+        final Path reference = writeReference(dir, "reference", "chr1", referenceBases(1, LENGTH));
+        final Path maternal = writeReference(dir, "maternal", "chr1_maternal",
+                ancestralBases(new int[] {1049}));
+        final Path paternal = writeReference(dir, "paternal", "chr1_paternal",
+                ancestralBases(new int[] {1199}));
+
+        // The translation tables: an identity for the maternal one and a shift for the paternal.
+        final String maternalCsv = String.join("\n",
+                "pos,offset", "1,0", "");
+        final String paternalCsv = String.join("\n",
+                "pos,offset", "1,0", "1500,10", "");
+        write(dir, "maternal.chr1.csv", maternalCsv);
+        write(dir, "paternal.chr1.csv", paternalCsv);
+        System.out.printf("csv\tmaternal=%s%n", ReferenceQueryDump.escape(maternalCsv));
+        System.out.printf("csv\tpaternal=%s%n", ReferenceQueryDump.escape(paternalCsv));
+
+        final Path bam = dir.resolve("reads.bam").toAbsolutePath();
+        writeReads(bam);
+        System.out.printf("sam\treads=%s%n", ReferenceQueryDump.escape(asSam(bam)));
+
+        run(dir, reference, "default", bam, maternal, paternal, List.of());
+        // A mapping-quality floor, which drops the badly-mapped read.
+        run(dir, reference, "min-mq-thirty", bam, maternal, paternal, List.of("--min-mq", "30"));
+        // The soft-clipped reads kept rather than dropped.
+        run(dir, reference, "keep-softclipped", bam, maternal, paternal,
+                List.of("--discard-non-polyt-softclipped-reads", "false"));
+        // A sequence added to the haplotype at each end.
+        run(dir, reference, "prepend-append", bam, maternal, paternal,
+                List.of("--prepend-sequence", "TTTT", "--append-sequence", "CCCC"));
+        // A flow length the keys have to reach.
+        run(dir, reference, "flow-length-ten", bam, maternal, paternal,
+                List.of("--output-flow-length", "10"));
+        run(dir, reference, "flow-length-large", bam, maternal, paternal,
+                List.of("--output-flow-length", "400"));
+        // The two score filters.
+        run(dir, reference, "min-score", bam, maternal, paternal,
+                List.of("--min-haplotype-score", "-1.0"));
+        run(dir, reference, "min-score-delta", bam, maternal, paternal,
+                List.of("--min-haplotype-score-delta", "1.0"));
+        // A cap on how many reads reach the output.
+        run(dir, reference, "max-two-reads", bam, maternal, paternal, List.of("--max-output-reads", "2"));
+        // A read whose translated span collapses, which is a refusal rather than a filter.
+        final String collapsing = String.join("\n", "pos,offset", "1,0", "1010,-200", "");
+        write(dir, "paternal.chr1.csv", collapsing);
+        System.out.printf("csv\tcollapsing=%s%n", ReferenceQueryDump.escape(collapsing));
+        run(dir, reference, "collapsing-translation", bam, maternal, paternal, List.of());
+    }
+
+    /**
+     * The reads. Six over the shared contig.
+     *
+     * One is badly mapped, one is soft-clipped with a poly-T clip, one is soft-clipped with
+     * something else, and one sits past the paternal table's second row so its offset differs.
+     */
+    static void writeReads(final Path bam) {
+        final SAMFileHeader header = readHeader();
+        try (final SAMFileWriter writer = new SAMFileWriterFactory()
+                .setCreateIndex(true)
+                .makeBAMWriter(header, false, bam.toFile())) {
+            add(writer, header, "r-plain", 1000, "100M", 60, "");
+            add(writer, header, "r-second", 1100, "100M", 60, "");
+            add(writer, header, "r-low-mq", 1200, "100M", 10, "");
+            add(writer, header, "r-polyt-clip", 1300, "4S96M", 60, "TTTT");
+            add(writer, header, "r-other-clip", 1400, "4S96M", 60, "ACGT");
+            // Past the paternal table's second row, so its paternal offset is ten.
+            add(writer, header, "r-shifted", 1600, "100M", 60, "");
+        }
+    }
+
+    static void add(final SAMFileWriter writer, final SAMFileHeader header, final String name,
+                    final int start, final String cigar, final int mappingQuality,
+                    final String clip) {
+        final SAMRecord record = new SAMRecord(header);
+        record.setReadName(name);
+        record.setReferenceName("chr1");
+        record.setAlignmentStart(start);
+        record.setCigarString(cigar);
+        int aligned = 0;
+        for (final htsjdk.samtools.CigarElement element : record.getCigar()) {
+            if (element.getOperator() == htsjdk.samtools.CigarOperator.M) {
+                aligned += element.getLength();
+            }
+        }
+        final String bases = clip + referenceBases(start, aligned);
+        record.setReadString(bases);
+        final byte[] quality = new byte[bases.length()];
+        Arrays.fill(quality, (byte) 40);
+        record.setBaseQualities(quality);
+        record.setMappingQuality(mappingQuality);
+        record.setAttribute("RG", "rg1");
+        record.setAttribute(FlowBasedRead.FLOW_MATRIX_TAG_NAME, new byte[bases.length()]);
+        writer.addAlignment(record);
+    }
+
+    static SAMFileHeader readHeader() {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", LENGTH))));
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        final SAMReadGroupRecord group = new SAMReadGroupRecord("rg1");
+        group.setPlatform("ULTIMA");
+        group.setFlowOrder(FLOW_ORDER);
+        group.setSample("sample");
+        header.addReadGroup(group);
+        return header;
+    }
+
+    static Path writeReference(final Path dir, final String name, final String contig,
+                               final String bases) throws Exception {
+        final Path fasta = dir.resolve(name + ".fasta");
+        final StringBuilder text = new StringBuilder(">" + contig + "\n");
+        for (int i = 0; i < bases.length(); i += 60) {
+            text.append(bases, i, Math.min(i + 60, bases.length())).append("\n");
+        }
+        Files.writeString(fasta, text.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        new picard.sam.CreateSequenceDictionary().instanceMain(new String[] {
+                "R=" + fasta, "O=" + dir.resolve(name + ".dict")});
+        System.out.printf("fasta\t%s=%s%n", name, contig + ":" + bases.length());
+        return fasta;
+    }
+
+    static Path write(final Path dir, final String name, final String text) throws Exception {
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static String asSam(final Path bam) throws Exception {
+        final StringBuilder text = new StringBuilder();
+        try (final htsjdk.samtools.SamReader reader =
+                     htsjdk.samtools.SamReaderFactory.makeDefault().open(bam.toFile())) {
+            for (final SAMRecord record : reader) {
+                text.append(record.getSAMString());
+            }
+        }
+        return text.toString();
+    }
+
+    static void run(final Path dir, final Path reference, final String label, final Path bam,
+                    final Path maternal, final Path paternal, final List<String> extra)
+            throws Exception {
+        final Path out = dir.resolve("out-" + label + ".csv");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-I", bam.toString(),
+                "-R", reference.toString(),
+                "--maternal-ref", maternal.toString(),
+                "--paternal-ref", paternal.toString(),
+                "--ancestral-translators-base-path", dir.toString() + "/",
+                "--output-csv", out.toString(),
+                // The tool refuses any other engine outright, so every run names this one.
+                "--likelihood-calculation-engine", "FlowBased"));
+        argv.addAll(extra);
+        try {
+            new GroundTruthReadsBuilder().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            System.out.printf("none\t%s=no csv%n", label);
+            return;
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(Files.readString(out), dir)));
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
Every read scored against the haplotype its two ancestral references give it, for #622. Ten runs
over one BAM of six reads, two ancestral references and a pair of translation tables: the
defaults, a mapping-quality floor, the soft-clip filter turned off, a sequence added at each end,
two flow lengths, both score filters, a cap on the output, and a translation that collapses a
read.

The issue was parked on its fixture. Two things were in the way:

- the tool refuses any but a flow-based likelihood engine outright, so every run has to name one;
- it needs the **aligned** reference as well as the two ancestral ones. Every read is scored
  against it too, and without one the haplotype is null and the engine refuses with "Null alleles
  are not supported", which says nothing about the missing argument.

Two claims I had written were wrong:

- a read whose translated span collapses is **skipped and counted** rather than refused. The
  exception is caught and the traversal carries on, so nine of the ten runs lose one read to it
  and none of them fails;
- the soft-clip filter looks at the clip at the **end** of the read, so the fixture's two
  front-clipped reads are kept whatever the argument says.

Two commits: the dump and its manifest entry, then the mechanical generator output.

The golden is `null` and the suite is `golden-pending`, so CI produces a `candidate-goldens`
artefact rather than comparing. Freezing it is the follow-up PR, which is where #622 is
resolved.