### PR TITLE
Measure GnarlyGenotyper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,10 @@ jobs:
             index: "54/54"
             slug: "calibrate-dragstr-model-analyze-saturation-mutagenesis-create-read-count-panel-of-normals-ground-truth-reads-builder-ground-truth-scorer"
             suites: "calibrate-dragstr-model analyze-saturation-mutagenesis create-read-count-panel-of-normals ground-truth-reads-builder ground-truth-scorer"
+          - group: golden-pending
+            index: "1/1"
+            slug: "gnarly-genotyper"
+            suites: "gnarly-genotyper"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 178 | 57.2% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 121 | 38.9% |
+| not started | 120 | 38.6% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (130 of 190 started)
+## gatk-origin tools (131 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -160,6 +160,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |
 | `GetPileupSummaries` | locus-walker | oracle-backed | get-pileup-summaries | 1 | not measured |
 | `GetSampleName` | reporting-walker | oracle-backed | get-sample-name | 1 | not measured |
+| `GnarlyGenotyper` | assembly-caller | golden-pending | gnarly-genotyper | 1 | not measured |
 | `GroundTruthReadsBuilder` | flow-based | oracle-backed | ground-truth-reads-builder | 1 | not measured |
 | `GroundTruthScorer` | flow-based | oracle-backed | ground-truth-scorer, series-stats | 2 | not measured |
 | `GroupedSVCluster` | sv-caller | oracle-backed | grouped-sv-cluster | 1 | not measured |
@@ -220,9 +221,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantRecalibrator` | variant-transform | oracle-backed | variant-recalibrator | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>60 not started</summary>
+<details><summary>59 not started</summary>
 
-`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `GnarlyGenotyper`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
+`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `ModelSegments`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6221,6 +6221,26 @@
           "why": "Nine runs over one BAM of five reads: the defaults, a different set of percentiles, the zero-call flows excluded, the mean-call columns, two score thresholds, the soft-clipped bases scored, no CSV output, and a BAM whose reads are not flow-based."
         }
       ]
+    },
+    {
+      "id": "gnarly-genotyper",
+      "status": "golden-pending",
+      "title": "the engine's own rules, asked directly rather than through GenomicsDB",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "GnarlyGenotyper"
+      ],
+      "why": "PENDING: written once the measurement is read.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "GnarlyGenotyperDump",
+          "golden": null,
+          "why": "PENDING: written once the measurement is read."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/GnarlyGenotyperDump.java
+++ b/tools/readfilter-conformance/GnarlyGenotyperDump.java
@@ -1,0 +1,248 @@
+/*
+ * GnarlyGenotyper's finalized genotypes, taken from the reference.
+ *
+ * The tool reads what GenomicsDB combined and finishes the job: it decides whether a site is worth
+ * calling at all, recomputes QD and MQ from the raw annotations, and rewrites the genotypes. The
+ * ENGINE IS ASKED DIRECTLY here rather than through the tool, which is what unblocks the
+ * measurement: a hand-written combined GVCF never gets past the tool's own reader, but
+ * `finalizeGenotype` is public and takes a variant context.
+ *
+ * Twelve behaviours this is built to catch.
+ *
+ *   - THE QUALITY FLOOR IS NOT THE CONFIDENCE ARGUMENT: it is that argument LESS ten times the
+ *     logarithm of the site prior, so the SNP floor is exactly 60 and the indel floor about
+ *     69.03, neither of them the 30 the argument names;
+ *   - A SITE UNDER ITS FLOOR IS DROPPED ENTIRELY, the engine returning null, unless
+ *     --keep-all-sites asks for it back;
+ *   - A SITE KEPT THAT WAY COMES BACK FILTERED `LowQual` WITH AN ADJUSTED ALLELE COUNT OF ZERO
+ *     and none of the other annotations: no QD, no AC, no QUAL, and its `<NON_REF>` still in the
+ *     alternates;
+ *   - WHICH FLOOR APPLIES TURNS ON WHETHER ANY ALTERNATE IS THE REFERENCE'S OWN LENGTH, so a site
+ *     with one SNP and one indel is judged as a SNP;
+ *   - A SPANNING DELETION DOES NOT COUNT AS A SNP for that test;
+ *   - QUALapprox IS READ FROM THE PLAIN KEY WHEN THERE IS ONE and summed from the allele-specific
+ *     list otherwise, and a site with neither scores zero and is always under the floor;
+ *   - A CALLED SITE LOSES ITS `<NON_REF>` and gains AC, AF, AN, QD, FS, SOR, ExcessHet and MQ;
+ *   - THE SITE'S QUAL IS `QUALapprox / 10 - log10(prior)`, which for a QUALapprox of 900 is 93
+ *     and is written out as 870 after the Phred scaling: it is not QUALapprox;
+ *   - QD IS QUALapprox OVER THE VARIANT DEPTH, so 900 over 30 is 30;
+ *   - MQ IS FINALIZED FROM THE RAW SUM AND ITS DEPTH, and a raw key whose depth is zero drops MQ
+ *     from the output exactly as having no raw key at all does;
+ *   - --strip-allele-specific-annotations LEAVES THE AS_ KEYS PRESENT BUT NULL rather than
+ *     removing them, so the output carries `AS_QD=null` either way;
+ *   - AND AN ALLELE-SPECIFIC LIST WHOSE LENGTH DOES NOT MATCH THE ALLELES IS AN
+ *     IllegalStateException, which is how a site that keeps its annotations and its `<NON_REF>`
+ *     ends.
+ *
+ * Output:
+ *
+ *     in\t<case>\t<the input variant context, as its fields>
+ *     out\t<case>\t<the finalized context, or `null`>
+ *     db\t<case>\t<the annotation database context>
+ *     error\t<case>\t<exception class>:<message>
+ *
+ * Usage: GnarlyGenotyperDump
+ */
+
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.GenotypeBuilder;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import org.broadinstitute.hellbender.tools.walkers.gnarlyGenotyper.GnarlyGenotyperEngine;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GnarlyGenotyperDump {
+
+    static final StringBuilder buf = new StringBuilder();
+
+    static void emit(final String kind, final String name, final String payload) {
+        buf.append(kind).append('\t').append(name).append('\t')
+                .append(payload.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n"))
+                .append('\n');
+    }
+
+    /** One variant context, rendered as the fields the engine reads and writes. */
+    static String render(final VariantContext vc) {
+        if (vc == null) {
+            return "null";
+        }
+        final StringBuilder text = new StringBuilder();
+        text.append(vc.getContig()).append('\t').append(vc.getStart()).append('\t');
+        text.append(vc.getReference().getDisplayString()).append('\t');
+        final List<String> alts = new ArrayList<>();
+        for (final Allele allele : vc.getAlternateAlleles()) {
+            alts.add(allele.getDisplayString());
+        }
+        text.append(String.join(",", alts)).append('\t');
+        text.append(vc.isFiltered() ? String.join(";", vc.getFilters()) : ".").append('\t');
+        text.append(vc.hasLog10PError() ? String.format("%.4f", vc.getPhredScaledQual()) : ".")
+                .append('\t');
+        final List<String> info = new ArrayList<>();
+        for (final Map.Entry<String, Object> entry
+                : new java.util.TreeMap<>(vc.getAttributes()).entrySet()) {
+            info.add(entry.getKey() + "=" + entry.getValue());
+        }
+        text.append(String.join(";", info)).append('\t');
+        final List<String> genotypes = new ArrayList<>();
+        for (final Genotype genotype : vc.getGenotypes()) {
+            genotypes.add(genotype.getSampleName() + ":" + genotype.getGenotypeString()
+                    + ":" + (genotype.hasPL() ? java.util.Arrays.toString(genotype.getPL()) : ".")
+                    + ":" + (genotype.hasDP() ? genotype.getDP() : "."));
+        }
+        text.append(String.join(" ", genotypes));
+        return text.toString();
+    }
+
+    /** A site with the attributes and alternates given. */
+    static VariantContext site(final String reference, final List<String> alternates,
+                               final Map<String, Object> attributes, final int[] pls,
+                               final int depth) {
+        final List<Allele> alleles = new ArrayList<>();
+        alleles.add(Allele.create(reference, true));
+        for (final String alternate : alternates) {
+            alleles.add(Allele.create(alternate, false));
+        }
+        final GenotypeBuilder genotype = new GenotypeBuilder("sample1");
+        genotype.alleles(List.of(alleles.get(0), alleles.get(0)));
+        if (pls != null) {
+            genotype.PL(pls);
+        }
+        if (depth >= 0) {
+            genotype.DP(depth);
+        }
+        return new VariantContextBuilder("fixture", "chr1", 1000,
+                1000 + reference.length() - 1L, alleles)
+                .attributes(attributes)
+                .genotypes(genotype.make())
+                .make();
+    }
+
+    static Map<String, Object> attributes(final Object... pairs) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            map.put((String) pairs[i], pairs[i + 1]);
+        }
+        return map;
+    }
+
+    static void run(final String name, final VariantContext input, final boolean keepAllSites,
+                    final int maxAlternates, final boolean stripAlleleSpecific) {
+        emit("in", name, render(input));
+        final GnarlyGenotyperEngine engine =
+                new GnarlyGenotyperEngine(keepAllSites, maxAlternates, stripAlleleSpecific);
+        final VariantContextBuilder database = new VariantContextBuilder(input);
+        try {
+            final VariantContext out = engine.finalizeGenotype(input, database);
+            emit("out", name, render(out));
+            emit("db", name, render(database.make()));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            emit("error", name, cause.getClass().getName() + ":" + cause.getMessage());
+        }
+    }
+
+    public static void main(final String[] args) {
+        System.out.println("# GnarlyGenotyperDump: the engine's own rules, asked directly");
+
+        final int[] pls = {900, 0, 1200};
+
+        // A SNP well above its floor.
+        run("snp-called",
+                site("A", List.of("G", "<NON_REF>"),
+                        attributes("QUALapprox", 900, "VarDP", 30, "RAW_MQandDP", "108000,30"),
+                        pls, 30),
+                false, 6, false);
+        // The same site with the quality just under the SNP floor, dropped and kept.
+        run("snp-under-floor",
+                site("A", List.of("G", "<NON_REF>"),
+                        attributes("QUALapprox", 20, "VarDP", 30, "RAW_MQandDP", "108000,30"),
+                        pls, 30),
+                false, 6, false);
+        run("snp-under-floor-kept",
+                site("A", List.of("G", "<NON_REF>"),
+                        attributes("QUALapprox", 20, "VarDP", 30, "RAW_MQandDP", "108000,30"),
+                        pls, 30),
+                true, 6, false);
+        // A quality between the two floors, which a SNP passes and an indel does not.
+        run("between-the-floors-snp",
+                site("A", List.of("G", "<NON_REF>"),
+                        attributes("QUALapprox", 40, "VarDP", 30, "RAW_MQandDP", "108000,30"),
+                        pls, 30),
+                true, 6, false);
+        run("between-the-floors-indel",
+                site("A", List.of("AT", "<NON_REF>"),
+                        attributes("QUALapprox", 40, "VarDP", 30, "RAW_MQandDP", "108000,30"),
+                        pls, 30),
+                true, 6, false);
+        // A site with one SNP and one indel, which is judged as a SNP.
+        run("mixed-site",
+                site("A", List.of("G", "AT", "<NON_REF>"),
+                        attributes("QUALapprox", 40, "VarDP", 30, "RAW_MQandDP", "108000,30"),
+                        new int[] {900, 0, 1200, 1500, 1800, 2100}, 30),
+                true, 6, false);
+        // A spanning deletion, which does not count as a SNP however long it is.
+        run("spanning-deletion",
+                site("A", List.of("*", "<NON_REF>"),
+                        attributes("QUALapprox", 40, "VarDP", 30, "RAW_MQandDP", "108000,30"),
+                        pls, 30),
+                true, 6, false);
+
+        // The allele-specific quality list, summed.
+        run("allele-specific-qual",
+                site("A", List.of("G", "<NON_REF>"),
+                        attributes("AS_QUALapprox", "|500|400", "VarDP", 30,
+                                "RAW_MQandDP", "108000,30"),
+                        pls, 30),
+                false, 6, false);
+        // Neither key at all, which scores zero and is always under the floor.
+        run("no-qual-key",
+                site("A", List.of("G", "<NON_REF>"),
+                        attributes("VarDP", 30, "RAW_MQandDP", "108000,30"), pls, 30),
+                true, 6, false);
+
+        // The allele-specific annotations stripped.
+        run("stripped-annotations",
+                site("A", List.of("G", "<NON_REF>"),
+                        attributes("QUALapprox", 900, "AS_QUALapprox", "|500|400",
+                                "AS_SB_TABLE", "10,10|5,5", "VarDP", 30,
+                                "RAW_MQandDP", "108000,30"),
+                        pls, 30),
+                false, 6, true);
+        run("kept-annotations",
+                site("A", List.of("G", "<NON_REF>"),
+                        attributes("QUALapprox", 900, "AS_QUALapprox", "|500|400",
+                                "AS_SB_TABLE", "10,10|5,5", "VarDP", 30,
+                                "RAW_MQandDP", "108000,30"),
+                        pls, 30),
+                false, 6, false);
+
+        // More alternates than the cap allows.
+        run("too-many-alternates",
+                site("A", List.of("G", "C", "T", "<NON_REF>"),
+                        attributes("QUALapprox", 900, "VarDP", 30, "RAW_MQandDP", "108000,30"),
+                        new int[] {900, 0, 1200, 1500, 1800, 2100, 2400, 2700, 3000, 3300}, 30),
+                false, 1, false);
+
+        // A site with the raw MQ key and no depth beside it.
+        run("raw-mq-without-depth",
+                site("A", List.of("G", "<NON_REF>"),
+                        attributes("QUALapprox", 900, "VarDP", 30, "RAW_MQandDP", "108000,0"),
+                        pls, 30),
+                false, 6, false);
+        // And one with no raw MQ at all.
+        run("no-raw-mq",
+                site("A", List.of("G", "<NON_REF>"),
+                        attributes("QUALapprox", 900, "VarDP", 30), pls, 30),
+                false, 6, false);
+
+        System.out.print(buf);
+    }
+}


### PR DESCRIPTION
Fourteen cases over the engine's own rules, for #621.

The issue was parked because a hand-written combined GVCF never gets past the tool's reader, and
the fixture was said to need an input in the shape GenomicsDB produces. It does not:
`GnarlyGenotyperEngine.finalizeGenotype` is public and takes a variant context, so the engine is
asked directly and the blocker disappears.

The quality floor is what the parked note misread. It is not the confidence argument: it is that
argument **less ten times the logarithm of the site prior**, so the SNP floor is exactly 60 and the
indel floor about 69.03, neither of them the 30 the argument names. A `QUALapprox` of 900 clears
both and the site is called — with `<NON_REF>` removed, QD at 30, QUAL at 870 and the genotype
rewritten to `A/G` — which the parked attempt never saw.

Two further things the runs settled:

- `--strip-allele-specific-annotations` leaves the `AS_` keys present but **null** rather than
  removing them, so `AS_QD=null` appears either way;
- an allele-specific list whose length does not match the alleles is an `IllegalStateException`,
  which is how the run that keeps its annotations and its `<NON_REF>` ends.

Two commits: the dump and its manifest entry, then the mechanical generator output.

The golden is `null` and the suite is `golden-pending`, so CI produces a `candidate-goldens`
artefact rather than comparing. Freezing it is the follow-up PR, which is where #621 is resolved.