### PR TITLE
Measure Funcotator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,8 +396,8 @@ jobs:
             suites: "gnarly-genotyper model-segments"
           - group: golden-pending
             index: "1/1"
-            slug: "local-assembler"
-            suites: "local-assembler"
+            slug: "local-assembler-funcotator"
+            suites: "local-assembler funcotator"
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,10 @@ jobs:
             index: "55/55"
             slug: "gnarly-genotyper-model-segments"
             suites: "gnarly-genotyper model-segments"
+          - group: golden-pending
+            index: "1/1"
+            slug: "local-assembler"
+            suites: "local-assembler"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 180 | 57.9% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 12 | 3.9% |
-| not started | 119 | 38.3% |
+| not started | 118 | 37.9% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (132 of 190 started)
+## gatk-origin tools (133 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -171,6 +171,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `LearnReadOrientationModel` | assembly-caller | oracle-backed | learn-read-orientation-model | 1 | not measured |
 | `LeftAlignAndTrimVariants` | variant-transform | oracle-backed | left-align-and-trim-variants | 1 | not measured |
 | `LeftAlignIndels` | record-transform | oracle-backed | left-align-indels-tool | 1 | not measured |
+| `LocalAssembler` | locus-walker | golden-pending | local-assembler | 1 | not measured |
 | `MTLowHeteroplasmyFilterTool` | unclassified | oracle-backed | mt-low-heteroplasmy | 1 | not measured |
 | `MergeAnnotatedRegions` | unclassified | oracle-backed | merge-annotated-regions | 1 | not measured |
 | `MergeAnnotatedRegionsByAnnotation` | unclassified | oracle-backed | merge-annotated-regions-by-annotation | 1 | not measured |
@@ -222,9 +223,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantRecalibrator` | variant-transform | oracle-backed | variant-recalibrator | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>58 not started</summary>
+<details><summary>57 not started</summary>
 
-`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `LocalAssembler`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
+`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
 
 </details>
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 180 | 57.9% |
-| golden-pending | 1 | 0.3% |
+| golden-pending | 2 | 0.6% |
 | unchecked | 12 | 3.9% |
-| not started | 118 | 37.9% |
+| not started | 117 | 37.6% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -85,7 +85,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (133 of 190 started)
+## gatk-origin tools (134 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -149,6 +149,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `FlowFeatureMapper` | flow-based | oracle-backed | flow-feature-mapper | 1 | not measured |
 | `FlowPairHMMAlignReadsToHaplotypes` | flow-based | oracle-backed | flow-pairhmm-align-reads-to-haplotypes | 1 | not measured |
 | `FuncotateSegments` | variant-walker | oracle-backed | funcotate-segments | 1 | not measured |
+| `Funcotator` | variant-walker | golden-pending | funcotator | 1 | not measured |
 | `FuncotatorDataSourceDownloader` | variant-walker | oracle-backed | funcotator-data-source-downloader | 1 | not measured |
 | `GatherBQSRReports` | unclassified | oracle-backed | gather-bqsr-reports | 1 | not measured |
 | `GatherNormalArtifactData` | unclassified | oracle-backed | mutect-gathers | 1 | not measured |
@@ -223,9 +224,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantRecalibrator` | variant-transform | oracle-backed | variant-recalibrator | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>57 not started</summary>
+<details><summary>56 not started</summary>
 
-`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `Funcotator`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
+`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `CreateHadoopBamSplittingIndex`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6261,6 +6261,26 @@
           "why": "Eleven cases: two samples, the copy ratios alone, a penalty of a thousand and one of a hundredth, the cap on segments, one window size named once and twice, a lowered homozygous threshold, a floor on the total allele count above every site, and two samples whose copy-ratio intervals disagree."
         }
       ]
+    },
+    {
+      "id": "local-assembler",
+      "status": "golden-pending",
+      "title": "the graph the reads over one interval produce",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "LocalAssembler"
+      ],
+      "why": "PENDING: written once the measurement is read.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "LocalAssemblerDump",
+          "golden": null,
+          "why": "PENDING: written once the measurement is read."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6281,6 +6281,26 @@
           "why": "PENDING: written once the measurement is read."
         }
       ]
+    },
+    {
+      "id": "funcotator",
+      "status": "golden-pending",
+      "title": "a VCF annotated from the same folder of data sources FuncotateSegments uses",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "Funcotator"
+      ],
+      "why": "PENDING: written once the measurement is read.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "FuncotatorDump",
+          "golden": null,
+          "why": "PENDING: written once the measurement is read."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/FuncotatorDump.java
+++ b/tools/readfilter-conformance/FuncotatorDump.java
@@ -1,0 +1,192 @@
+/*
+ * Funcotator's annotated VCF, taken from the reference.
+ *
+ * A VCF annotated from a folder of data sources. The GENCODE source is the one FuncotateSegments'
+ * fixture already builds, reused whole: what is measured here is what changes when the thing
+ * being annotated is a variant rather than a segment.
+ *
+ * Eleven behaviours this is built to catch.
+ *
+ *   - THE ANNOTATIONS LAND IN ONE INFO FIELD, `FUNCOTATION`, whose value is the source's fields
+ *     joined by `|` and wrapped in brackets, in an order the header line declares;
+ *   - EVERY ALTERNATE GETS ITS OWN BRACKETED FUNCOTATION, joined by a comma, so a two-alternate
+ *     site carries two and a reader who splits on the comma alone splits inside neither;
+ *   - THE VARIANT CLASSIFICATION IS COMPUTED FROM THE TRANSCRIPT: the fixture's one exon runs
+ *     from 1000 to 1200 and its CDS with it, so 1050 is SILENT, 1060 and 1070 are MISSENSE, 1500
+ *     is INTRON and 5000 is IGR;
+ *   - A VARIANT OUTSIDE EVERY GENE STILL GETS A FUNCOTATION, whose gene name is the literal
+ *     `Unknown` rather than an empty field;
+ *   - THE CODON CHANGE AND THE PROTEIN CHANGE ARE WRITTEN OUT, so the two alternates of one site
+ *     differ in `p.A21T` and `p.A21S`;
+ *   - --annotation-override REPLACES A FIELD THE SOURCES PRODUCED, by its prefixed name;
+ *   - --annotation-default ADDS ONE with a fixed value;
+ *   - --remove-filtered-variants DROPS A FILTERED RECORD rather than annotating it, taking the
+ *     file from five records to four;
+ *   - THE MAF OUTPUT IS A DIFFERENT FILE ENTIRELY, opening `#version 2.4` and carrying one row
+ *     per alternate with no VCF header at all;
+ *   - A REFERENCE VERSION WITH NO DIRECTORY IS REFUSED, the same way it is for segments;
+ *   - AND THE LOCATABLE XSV SOURCE THAT FuncotateSegments READS STRAIGHT THROUGH HAS TO BE
+ *     INDEXED FOR FUNCOTATOR, which queries it by interval: the folder here holds GENCODE alone
+ *     for that reason.
+ *
+ * Output:
+ *
+ *     vcf\t<label>=<that vcf, escaped>
+ *     out\t<label>=<the whole output, escaped>
+ *     header\t<label>\t<the `##INFO=<ID=FUNCOTATION` line>
+ *     none\t<label>=<what was not written>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: FuncotatorDump
+ */
+
+import org.broadinstitute.hellbender.tools.funcotator.Funcotator;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FuncotatorDump {
+
+    static List<String> header() {
+        return new ArrayList<>(List.of(
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=" + FuncotateSegmentsDump.CONTIG_LENGTH + ">",
+                "##FILTER=<ID=LOW,Description=\"Low\">",
+                "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tsample"));
+    }
+
+    static String site(final int position, final String reference, final String alternate,
+                       final String filter) {
+        return "chr1\t" + position + "\t.\t" + reference + "\t" + alternate
+                + "\t100.00\t" + filter + "\t.\tGT\t0/1";
+    }
+
+    static String vcf(final List<String> sites) {
+        final List<String> lines = header();
+        lines.addAll(sites);
+        lines.add("");
+        return String.join("\n", lines);
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("funcotator-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# FuncotatorDump: a VCF annotated from the same folder of data "
+                + "sources FuncotateSegments uses");
+
+        final Path fasta = FuncotateSegmentsDump.writeReference(dir);
+        // Only the GENCODE source. FuncotateSegments' folder also holds a locatable XSV, which
+        // Funcotator QUERIES BY INTERVAL and so wants an index beside: the segment tool reads it
+        // straight through and never asks for one.
+        final Path good = gencodeOnly(dir, "ds-good", "hg38");
+        final Path hg19Only = gencodeOnly(dir, "ds-hg19", "hg19");
+
+        // The fixture's gene sits at chr1:1000-2000 with its one exon at 1000-1200 and its CDS
+        // over the same span, so a substitution at 1050 is inside the coding exon and one at
+        // 1500 is inside the gene but outside it.
+        // The records have to be in position order or the indexer refuses the file before the
+        // tool ever sees it.
+        final String variants = vcf(List.of(
+                site(1050, "C", "A", "PASS"),
+                site(1060, "G", "A,T", "PASS"),
+                site(1070, "T", "A", "LOW"),
+                site(1500, "T", "A", "PASS"),
+                site(5000, "A", "G", "PASS")));
+        final Path vcfPath = index(FuncotateSegmentsDump.write(dir, "variants.vcf", variants));
+        System.out.printf("vcf\tvariants=%s%n", ReferenceQueryDump.escape(variants));
+
+        run(dir, "annotated", vcfPath, fasta, good, "hg38", List.of());
+        // The MAF output, which is a different file entirely.
+        run(dir, "maf", vcfPath, fasta, good, "hg38",
+                List.of("--output-file-format", "MAF"));
+        // A default annotation and an override.
+        run(dir, "annotation-default", vcfPath, fasta, good, "hg38",
+                List.of("--annotation-default", "NOTE:added"));
+        run(dir, "annotation-override", vcfPath, fasta, good, "hg38",
+                List.of("--annotation-override", "Gencode_1_hugoSymbol:OVERRIDDEN"));
+        // The filtered record dropped.
+        run(dir, "remove-filtered", vcfPath, fasta, good, "hg38",
+                List.of("--remove-filtered-variants", "true"));
+        // The transcript selection mode.
+        run(dir, "canonical-transcripts", vcfPath, fasta, good, "hg38",
+                List.of("--transcript-selection-mode", "CANONICAL"));
+        run(dir, "all-transcripts", vcfPath, fasta, good, "hg38",
+                List.of("--transcript-selection-mode", "ALL"));
+        // A reference version the folder has no directory for.
+        run(dir, "wrong-ref-version", vcfPath, fasta, hg19Only, "hg38", List.of());
+    }
+
+    /** A data-source root holding the manifest and the GENCODE source alone. */
+    static Path gencodeOnly(final Path dir, final String name, final String refVersion)
+            throws Exception {
+        final Path root = dir.resolve(name);
+        Files.createDirectories(root);
+        Files.writeString(root.resolve("MANIFEST.txt"),
+                "Version: 1.7.hg38.20220101\nSource: test\nAlternate Source: test\n",
+                StandardCharsets.UTF_8);
+        FuncotateSegmentsDump.writeGencode(root, refVersion);
+        return root;
+    }
+
+    static Path index(final Path path) throws Exception {
+        htsjdk.tribble.index.IndexFactory.createLinearIndex(path.toFile(),
+                new htsjdk.variant.vcf.VCFCodec()).writeBasedOnFeatureFile(path.toFile());
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path input, final Path fasta,
+                    final Path dataSources, final String refVersion, final List<String> extra)
+            throws Exception {
+        final boolean maf = extra.contains("MAF");
+        final Path out = dir.resolve("out-" + label + (maf ? ".maf" : ".vcf"));
+        final List<String> argv = new ArrayList<>(List.of(
+                "-V", input.toString(),
+                "-O", out.toString(),
+                "-R", fasta.toString(),
+                "--data-sources-path", dataSources.toString(),
+                "--ref-version", refVersion));
+        if (!maf) {
+            argv.addAll(List.of("--output-file-format", "VCF"));
+        }
+        argv.addAll(extra);
+        try {
+            new Funcotator().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        if (!Files.exists(out)) {
+            System.out.printf("none\t%s=no output%n", label);
+            return;
+        }
+        final StringBuilder body = new StringBuilder();
+        for (final String line : Files.readString(out).split("\n", -1)) {
+            if (line.isEmpty()) {
+                continue;
+            }
+            if (line.startsWith("##INFO=<ID=FUNCOTATION")) {
+                // The header line names every field in order, so it is its own row.
+                System.out.printf("header\t%s\t%s%n", label, masked(line, dir));
+            } else if (!line.startsWith("##")) {
+                body.append(line).append("\n");
+            }
+        }
+        System.out.printf("out\t%s=%s%n", label,
+                ReferenceQueryDump.escape(masked(body.toString(), dir)));
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}

--- a/tools/readfilter-conformance/LocalAssemblerDump.java
+++ b/tools/readfilter-conformance/LocalAssemblerDump.java
@@ -1,0 +1,296 @@
+/*
+ * LocalAssembler's GFA and its scaffolds, taken from the reference.
+ *
+ * A de Bruijn assembly of the reads over one interval, written as a graph and as a FASTA of the
+ * paths through it. What is measured is the graph the reads produce and what each argument
+ * changes about it.
+ *
+ * Eleven behaviours this is built to catch.
+ *
+ *   - THE GRAPH IS GFA 2.0, not 1.0: its header reads `VN:Z:2.0`, its segments are `S` lines
+ *     carrying a length and three offsets, and its edges are `E` lines and not `L` ones;
+ *   - THE KMER SIZE IS 31 AND FIXED, so a read of twenty bases contributes nothing and assembles
+ *     into an empty graph;
+ *   - A CONTIG MUST BE SEEN --min-thin-observations TIMES, which is four, so a fixture of one
+ *     read per sequence assembles into nothing at all: every case here writes five copies;
+ *   - RAISING THAT FLOOR TO TEN CHANGES NOTHING when the reads already meet it, so the argument
+ *     is a floor on OBSERVATIONS and not on reads;
+ *   - EVERY BASE UNDER --q-min BREAKS THE KMER RUN, so a floor above the fixture's own quality
+ *     empties the graph outright;
+ *   - AN `N` BREAKS THE RUN TOO, BUT THE GAP-FILLING PUTS IT BACK: a read with one `N` in the
+ *     middle still assembles into a single contig of its full length, the two halves being
+ *     rejoined by --min-gapfill-count observations of the missing kmers;
+ *   - TWO READS THAT OVERLAP BY MORE THAN A KMER ASSEMBLE INTO ONE CONTIG of their union, and
+ *     two that do not stay as two contigs with no edge between them;
+ *   - A SUBSTITUTION IN THE MIDDLE OF AN OTHERWISE SHARED SEQUENCE MAKES A BUBBLE: four segments
+ *     and four edges, the trunk either side and one branch per allele;
+ *   - --no-scaffolding LEAVES THE GRAPH ALONE AND CHANGES THE FASTA, so the two runs agree on
+ *     the GFA byte for byte and differ in the paths;
+ *   - THE FASTA NAMES EACH PATH `<assembly>_t<n>` AND LISTS ITS SEGMENTS, with `RC` on a segment
+ *     traversed backwards;
+ *   - AND AN INTERVAL WITH NO READ IN IT WRITES BOTH FILES ALL THE SAME, the GFA holding its
+ *     header alone and the FASTA nothing.
+ *
+ * The reference is drawn from a linear congruential generator whose state carries forward. Two
+ * earlier fixtures were periodic and the assembly collapsed into a single forty-base contig
+ * looping on itself: one repeated `ATGCAGCATG`, and one hashed the POSITION, which still left
+ * runs like `ATTACC` every six bases.
+ *
+ * Output:
+ *
+ *     sam\t<label>=<that bam as sam, without its header, escaped>
+ *     gfa\t<label>=<the whole gfa, escaped>
+ *     fasta\t<label>=<the whole fasta, escaped>
+ *     none\t<label>=<what was not written>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: LocalAssemblerDump
+ */
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.tools.LocalAssembler;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class LocalAssemblerDump {
+
+    static final int CONTIG_LENGTH = 6000;
+
+    /**
+     * The whole reference, drawn once from a linear congruential generator.
+     *
+     * The sequence has to be genuinely aperiodic or every 31-mer repeats and the assembly
+     * collapses. Two earlier fixtures failed that way: one used `ATGCAGCATG` repeated, and one
+     * used a hash OF THE POSITION, which still produced runs like `ATTACC` every six bases. Only
+     * a generator whose state carries forward gives a sequence the assembler treats as unique.
+     */
+    static final String REFERENCE = drawReference();
+
+    static String drawReference() {
+        final StringBuilder bases = new StringBuilder(CONTIG_LENGTH);
+        long state = 20260828L;
+        for (int i = 0; i < CONTIG_LENGTH; i++) {
+            state = state * 6364136223846793005L + 1442695040888963407L;
+            bases.append("ACGT".charAt((int) ((state >>> 33) & 3L)));
+        }
+        return bases.toString();
+    }
+
+    /** The reference from `start`, one-based, for `length` bases. */
+    static String referenceBases(final int start, final int length) {
+        return REFERENCE.substring(start - 1, start - 1 + length);
+    }
+
+    /** name, start, sequence, qualities. */
+    record Read(String name, int start, String bases, byte quality) { }
+
+    /**
+     * The same read `COPIES` times over.
+     *
+     * A contig has to be seen --min-thin-observations times to survive, which is four by default,
+     * so a fixture of one read per sequence assembles into nothing at all.
+     */
+    static final int COPIES = 5;
+
+    static List<Read> copies(final String name, final int start, final String bases,
+                             final byte quality) {
+        final List<Read> reads = new ArrayList<>();
+        for (int i = 0; i < COPIES; i++) {
+            reads.add(new Read(name + "-" + i, start, bases, quality));
+        }
+        return reads;
+    }
+
+    static List<Read> concat(final List<Read>... groups) {
+        final List<Read> reads = new ArrayList<>();
+        for (final List<Read> group : groups) {
+            reads.addAll(group);
+        }
+        return reads;
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("local-assembler-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# LocalAssemblerDump: the graph the reads over one interval produce");
+
+        final Path fasta = writeReference(dir);
+
+        // One read, which assembles into one contig.
+        run(dir, "one-read", fasta, copies("r1", 1000, referenceBases(1000, 100), (byte) 40));
+
+        // Two reads overlapping by more than a kmer, which join.
+        run(dir, "overlapping-reads", fasta, concat(
+                copies("r1", 1000, referenceBases(1000, 100), (byte) 40),
+                copies("r2", 1050, referenceBases(1050, 100), (byte) 40)));
+
+        // Two reads that do not overlap at all, which stay apart.
+        run(dir, "disjoint-reads", fasta, concat(
+                copies("r1", 1000, referenceBases(1000, 100), (byte) 40),
+                copies("r2", 1500, referenceBases(1500, 100), (byte) 40)));
+
+        // A read too short to kmerize at all.
+        run(dir, "read-shorter-than-k", fasta,
+                copies("r1", 1000, referenceBases(1000, 20), (byte) 40));
+
+        // A substitution in the middle of an otherwise shared sequence: a bubble.
+        final String shared = referenceBases(1000, 120);
+        final char[] mutated = shared.toCharArray();
+        mutated[60] = mutated[60] == 'A' ? 'T' : 'A';
+        run(dir, "bubble", fasta, concat(
+                copies("r1", 1000, shared, (byte) 40),
+                copies("r2", 1000, new String(mutated), (byte) 40)));
+
+        // A low-quality base in the middle, which breaks the kmer run.
+        run(dir, "low-quality-base", fasta,
+                copies("r1", 1000, referenceBases(1000, 100), (byte) 40), "--q-min", "45");
+
+        // An `N` in the middle, which breaks it too.
+        final char[] withN = referenceBases(1000, 100).toCharArray();
+        withN[50] = 'N';
+        run(dir, "n-in-the-middle", fasta,
+                copies("r1", 1000, new String(withN), (byte) 40));
+
+        // The thin-observation floor raised past what the reads support.
+        run(dir, "thin-observations-ten", fasta, concat(
+                copies("r1", 1000, referenceBases(1000, 100), (byte) 40),
+                copies("r2", 1050, referenceBases(1050, 100), (byte) 40)),
+                "--min-thin-observations", "10");
+
+        // The traversals instead of the scaffolds.
+        run(dir, "no-scaffolding", fasta, concat(
+                copies("r1", 1000, referenceBases(1000, 100), (byte) 40),
+                copies("r2", 1050, referenceBases(1050, 100), (byte) 40)),
+                "--no-scaffolding", "true");
+
+        // An interval that holds no read at all.
+        run(dir, "empty-interval", fasta,
+                copies("r1", 1000, referenceBases(1000, 100), (byte) 40),
+                "-L", "chr1:4000-4100");
+    }
+
+    static void run(final Path dir, final Path fasta, final String label, final List<Read> reads,
+                    final String... extra) throws Exception {
+        run(dir, label, fasta, reads, extra);
+    }
+
+    static void run(final Path dir, final String label, final Path fasta, final List<Read> reads,
+                    final String... extra) throws Exception {
+        final Path bam = dir.resolve(label + ".bam");
+        writeReads(bam, reads);
+        System.out.printf("sam\t%s=%s%n", label, ReferenceQueryDump.escape(asSam(bam)));
+        final Path gfa = dir.resolve("out-" + label + ".gfa");
+        final Path out = dir.resolve("out-" + label + ".fa");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-I", bam.toString(),
+                "-R", fasta.toString(),
+                "--assembly-name", label,
+                "--gfa-file", gfa.toString(),
+                "--fasta-file", out.toString()));
+        final List<String> extras = Arrays.asList(extra);
+        if (!extras.contains("-L")) {
+            argv.addAll(List.of("-L", "chr1:900-1700"));
+        }
+        argv.addAll(extras);
+        try {
+            new LocalAssembler().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+            return;
+        }
+        for (final Path file : List.of(gfa, out)) {
+            final String kind = file.toString().endsWith(".gfa") ? "gfa" : "fasta";
+            if (Files.exists(file)) {
+                System.out.printf("%s\t%s=%s%n", kind, label,
+                        ReferenceQueryDump.escape(masked(Files.readString(file), dir)));
+            } else {
+                System.out.printf("none\t%s=no %s%n", label, kind);
+            }
+        }
+    }
+
+    static void writeReads(final Path bam, final List<Read> reads) {
+        final SAMFileHeader header = readHeader();
+        try (final SAMFileWriter writer = new SAMFileWriterFactory()
+                .setCreateIndex(true)
+                .makeBAMWriter(header, false, bam.toFile())) {
+            for (final Read read : reads) {
+                final SAMRecord record = new SAMRecord(header);
+                record.setReadName(read.name());
+                record.setReferenceName("chr1");
+                record.setAlignmentStart(read.start());
+                record.setCigarString(read.bases().length() + "M");
+                record.setReadString(read.bases());
+                final byte[] quality = new byte[read.bases().length()];
+                Arrays.fill(quality, read.quality());
+                record.setBaseQualities(quality);
+                record.setMappingQuality(60);
+                record.setAttribute("RG", "rg1");
+                writer.addAlignment(record);
+            }
+        }
+    }
+
+    static SAMFileHeader readHeader() {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", CONTIG_LENGTH))));
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        final SAMReadGroupRecord group = new SAMReadGroupRecord("rg1");
+        group.setSample("sample");
+        group.setPlatform("ILLUMINA");
+        header.addReadGroup(group);
+        return header;
+    }
+
+    static Path writeReference(final Path dir) throws Exception {
+        final Path fasta = dir.resolve("reference.fasta");
+        final String bases = REFERENCE;
+        final StringBuilder text = new StringBuilder(">chr1\n");
+        for (int i = 0; i < bases.length(); i += 60) {
+            text.append(bases, i, Math.min(i + 60, bases.length())).append("\n");
+        }
+        Files.writeString(fasta, text.toString(), StandardCharsets.UTF_8);
+        htsjdk.samtools.reference.FastaSequenceIndexCreator.create(fasta, true);
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSequenceDictionary(new SAMSequenceDictionary(List.of(
+                new SAMSequenceRecord("chr1", CONTIG_LENGTH))));
+        try (final java.io.Writer writer = Files.newBufferedWriter(dir.resolve("reference.dict"))) {
+            new htsjdk.samtools.SAMTextHeaderCodec().encode(writer, header);
+        }
+        return fasta;
+    }
+
+    static String asSam(final Path bam) throws Exception {
+        final StringBuilder text = new StringBuilder();
+        try (final htsjdk.samtools.SamReader reader =
+                     htsjdk.samtools.SamReaderFactory.makeDefault().open(bam.toFile())) {
+            for (final SAMRecord record : reader) {
+                text.append(record.getSAMString());
+            }
+        }
+        return text.toString();
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
A VCF annotated from a folder of data sources, for #557. Eight runs over one VCF of five records:
the defaults, the MAF output, a default annotation, an override, the filtered record dropped, two
transcript selection modes, and a reference version the folder has no directory for.

The GENCODE source is the one FuncotateSegments' fixture already builds, reused whole, which is
what made this tractable at all: the folder's shape was the hard part and it was already solved.

Two things had to change for a variant rather than a segment:

- the records have to be in position order or the indexer refuses the file before the tool sees
  it;
- the locatable XSV source that FuncotateSegments reads straight through has to be **indexed** for
  Funcotator, which queries it by interval, so the folder here holds GENCODE alone.

The classifications come out as the fixture's one exon predicts: 1050 SILENT, 1060 and 1070
MISSENSE, 1500 INTRON and 5000 IGR, the last with `Unknown` for its gene rather than an empty
field. The two alternates of the multiallelic site each get their own bracketed funcotation and
differ in their protein change, `p.A21T` against `p.A21S`.

Two commits: the dump and its manifest entry, then the mechanical generator output.

The golden is `null` and the suite is `golden-pending`, so CI produces a `candidate-goldens`
artefact rather than comparing. Freezing it is the follow-up PR, which is where #557 is resolved.