### PR TITLE
Make CreateReadCountPanelOfNormals' measurement reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,10 @@ jobs:
             index: "55/55"
             slug: "gnarly-genotyper-model-segments-local-assembler-funcotator-main-dispatch"
             suites: "gnarly-genotyper model-segments local-assembler funcotator main-dispatch"
+          - group: golden-pending
+            index: "1/1"
+            slug: "main-catalogue"
+            suites: "main-catalogue"
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,16 +388,16 @@ jobs:
             suites: "extract-variant-annotations variant-recalibrator haplotype-based-variant-recaller flow-feature-mapper flow-pairhmm-align-reads-to-haplotypes"
           - group: oracle-backed
             index: "54/55"
-            slug: "calibrate-dragstr-model-analyze-saturation-mutagenesis-create-read-count-panel-of-normals-ground-truth-reads-builder-ground-truth-scorer"
-            suites: "calibrate-dragstr-model analyze-saturation-mutagenesis create-read-count-panel-of-normals ground-truth-reads-builder ground-truth-scorer"
+            slug: "calibrate-dragstr-model-analyze-saturation-mutagenesis-ground-truth-reads-builder-ground-truth-scorer-gnarly-genotyper"
+            suites: "calibrate-dragstr-model analyze-saturation-mutagenesis ground-truth-reads-builder ground-truth-scorer gnarly-genotyper"
           - group: oracle-backed
             index: "55/55"
-            slug: "gnarly-genotyper-model-segments-local-assembler-funcotator-main-dispatch"
-            suites: "gnarly-genotyper model-segments local-assembler funcotator main-dispatch"
+            slug: "model-segments-local-assembler-funcotator-main-dispatch"
+            suites: "model-segments local-assembler funcotator main-dispatch"
           - group: golden-pending
             index: "1/1"
-            slug: "main-catalogue"
-            suites: "main-catalogue"
+            slug: "create-read-count-panel-of-normals-main-catalogue"
+            suites: "create-read-count-panel-of-normals main-catalogue"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -6,8 +6,8 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 | state | tools | share |
 |---|---:|---:|
-| oracle-backed | 202 | 65.0% |
-| golden-pending | 0 | 0.0% |
+| oracle-backed | 201 | 64.6% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 0 | 0.0% |
 | not started | 109 | 35.0% |
 | **total** | **311** | |
@@ -136,7 +136,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
 | `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
 | `CountVariants` | variant-walker | oracle-backed | count-variants | 1 | not measured |
-| `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |
+| `CreateReadCountPanelOfNormals` | cnv-segmentation | golden-pending | create-read-count-panel-of-normals | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |
 | `DenoiseReadCounts` | cnv-segmentation | oracle-backed | denoise-read-counts | 1 | not measured |
 | `DepthOfCoverage` | locus-walker | oracle-backed | depth-of-coverage | 1 | not measured |

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6164,13 +6164,13 @@
     },
     {
       "id": "create-read-count-panel-of-normals",
-      "status": "oracle-backed",
+      "status": "golden-pending",
       "title": "which intervals and which samples reach the panel",
       "harness": "tools/readfilter-conformance",
       "tools": [
         "CreateReadCountPanelOfNormals"
       ],
-      "why": "The singular value decomposition is a distributed solver's and is not measured: only the count of its values is. What is measured is everything that decides which intervals and which samples reach it, and the harsher of the two interval filters turned out to be the zeros one, which leaves two intervals where the median filter leaves most of them.",
+      "why": "PENDING a fresh candidate: the fixture has been rebuilt so its samples' median coverages are separated by fourteen per cent or more. The committed golden is the old fixture's and is left in place only so the Rust comparison keeps building; it is replaced by the follow-up PR.",
       "compare": {
         "mode": "lines"
       },
@@ -6178,7 +6178,7 @@
         {
           "dump": "CreateReadCountPanelOfNormalsDump",
           "golden": "crates/gatk-tools/tests/data/create_read_count_panel_of_normals.txt.gz",
-          "why": "Eleven runs over nine read-count files: the defaults, no filtering at all, each of the four filters on its own against that baseline, the zeros left alone, two eigensample counts, a panel of one sample, and an input whose intervals do not match."
+          "why": "Eleven runs over nine read-count files: the defaults, no filtering at all, each of the four filters on its own against that baseline, the zeros left alone, two eigensample counts, a panel of one sample, and an input whose intervals do not match. PENDING: re-measured against the rebuilt fixture."
         }
       ]
     },

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6321,6 +6321,26 @@
           "why": "Twenty cases over a fixed catalogue of five classes, so what is pinned is the search and not the reference's own class path: the six deprecation notices, prefixes and substrings of several lengths, one character too many and too few and one substituted, two too many and two too few, a name far from everything, the empty name, a prefix that beats a neighbour, a substring that ties two tools, a one-tool catalogue, and a name that resolves."
         }
       ]
+    },
+    {
+      "id": "main-catalogue",
+      "status": "golden-pending",
+      "title": "the set of tool names `gatk <Tool>` resolves, discovered the way Main discovers it",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "Main"
+      ],
+      "why": "PENDING: written once the measurement is read.",
+      "compare": {
+        "mode": "lines"
+      },
+      "cases": [
+        {
+          "dump": "MainCatalogueDump",
+          "golden": null,
+          "why": "PENDING: written once the measurement is read."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/CreateReadCountPanelOfNormalsDump.java
+++ b/tools/readfilter-conformance/CreateReadCountPanelOfNormalsDump.java
@@ -10,21 +10,26 @@
  *
  *   - THE TOOL IS A SPARK ONE, so it needs a master even with nothing to distribute, and it
  *     needs a JVM that exports `sun.nio.ch` to it;
- *   - THE COUNTS BECOME FRACTIONAL COVERAGE FIRST, each sample divided by its own total, so a
- *     sample sequenced twice as deeply as another contributes the same and is not an outlier;
+ *   - THE COUNTS BECOME FRACTIONAL COVERAGE FIRST, each sample divided by its own total, so the
+ *     sample that is exactly twice another has exactly that other's median coverage and is not an
+ *     outlier;
  *   - AN INTERVAL WHOSE MEDIAN FRACTIONAL COVERAGE IS UNDER THE PERCENTILE IS DROPPED, which is
  *     what takes out the two intervals every sample reads near zero;
  *   - AN INTERVAL WITH TOO MANY ZEROS ACROSS THE SAMPLES IS DROPPED TOO, and that filter is much
- *     the harsher of the two: on this panel it leaves two intervals where the median filter
+ *     the harsher of the two: on this panel it leaves so few intervals that the decomposition
+ *     finds no non-zero singular value at all and the run is REFUSED, where the median filter
  *     leaves most of them;
  *   - A SAMPLE WITH TOO MANY ZEROS IS DROPPED, which is what takes out the nearly-empty one;
  *   - A SAMPLE WHOSE MEDIAN IS EXTREME IS DROPPED FROM BOTH ENDS, the percentile being applied
- *     twice, so a percentile of twenty takes two samples of nine;
+ *     twice, so a percentile of twenty takes two samples of nine. The medians are separated by
+ *     fourteen per cent or more for exactly this reason: a fixture that varied only the depth put
+ *     the top two within two parts in a hundred thousand of each other, and which one the filter
+ *     called the maximum flipped on CI;
  *   - THE PANEL KEEPS BOTH THE ORIGINAL INTERVALS AND THE SURVIVING ONES, so the file says what
  *     was dropped as well as what was kept, and the ORIGINAL count is the input's whatever the
  *     filters did;
  *   - THE NUMBER OF EIGENSAMPLES IS CAPPED AT THE NUMBER OF SAMPLES THAT SURVIVED, so asking for
- *     a hundred over nine samples with one filtered out gives eight;
+ *     a hundred over nine samples with two filtered out gives seven;
  *   - A PANEL OF ONE SAMPLE IS ACCEPTED, has no eigensamples, and REFUSES to hand over its
  *     singular values rather than handing over an empty array;
  *   - AND THE INPUTS MUST AGREE ON THEIR INTERVALS, one that does not being refused by name.
@@ -35,7 +40,7 @@
  *     panel\t<label>\t<field>=<value>
  *     matrix\t<label>\t<name>=<one value per line, escaped>
  *     none\t<label>=<what was not written>
- *     error\t<label>\t<the tool's own message>
+ *     error\t<label>\t<the tool's own message, its leading wall clock removed>
  *     error\t<label>\t<field>\t<exception class>:<message>
  *
  * Usage: CreateReadCountPanelOfNormalsDump
@@ -82,26 +87,35 @@ public class CreateReadCountPanelOfNormalsDump {
     }
 
     /**
+     * A captured line with its leading wall clock removed.
+     *
+     * The message this dump keeps is whichever log line named the exception, and log4j opens every
+     * line with `HH:mm:ss.SSS`. That is a clock, not a behaviour, and no byte comparison should be
+     * asked to reproduce it.
+     */
+    static String withoutTheClock(final String line) {
+        return line.replaceFirst("^\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d ", "");
+    }
+
+    /**
      * The panel's samples.
      *
-     * Six ordinary ones, one sequenced twice as deeply, one that is nearly all zeros, and one
-     * whose median is far above the rest.
+     * Six of a shape of their own, one that is exactly twice another, one nearly all zeros, and
+     * one whose coverage is piled into its first quarter.
+     *
+     * The per-sample shape is what matters. The first version of this fixture varied only the
+     * DEPTH, and fractional coverage divides depth out again: the nine samples' median coverages
+     * then agreed to five decimal places, and which of them the extreme-median filter called the
+     * maximum could flip on a reordering. It did, once, on CI. Here the medians are separated by
+     * fourteen per cent or more, except for the one pair that is deliberately identical.
      */
     static int[] sampleCounts(final int sample) {
         final int[] values = new int[INTERVALS];
         for (int i = 0; i < INTERVALS; i++) {
-            // A repeating profile so the intervals differ from one another, plus a per-sample
-            // offset so the samples differ too.
-            final int base = 100 + (i * 7) % 23 + (sample * 3) % 11;
-            switch (sample) {
-                case 6 -> values[i] = base * 2;              // twice as deep
-                case 7 -> values[i] = i < 4 ? base : 0;      // nearly all zeros
-                case 8 -> values[i] = base * 20;             // an extreme median
-                default -> values[i] = base;
-            }
+            values[i] = shape(sample, i) * (sample == 6 ? 2 : 1);
             // The first two intervals are near zero in every sample, so their median is low.
             if (i < 2) {
-                values[i] = sample == 7 ? 0 : 1;
+                values[i] = sample == 7 ? 0 : (sample == 6 ? 2 : 1);
             }
             // One interval is zero in three samples, which is over the interval percentage.
             if (i == 20 && sample < 3) {
@@ -109,6 +123,25 @@ public class CreateReadCountPanelOfNormalsDump {
             }
         }
         return values;
+    }
+
+    /**
+     * One sample's profile before the shared clamps.
+     *
+     * Sample 6 borrows sample 3's, so that doubling it leaves its fractional coverage EXACTLY
+     * equal: that is the pair the coverage normalisation has to make indistinguishable, and it
+     * sits in the middle of the ranking where no percentile filter reaches for it.
+     */
+    static int shape(final int sample, final int i) {
+        final int base = 100 + (i * 7) % 23;
+        if (sample == 7) {
+            return i < 4 ? base : 0;        // nearly all zeros
+        }
+        if (sample == 8) {
+            return i < 10 ? base * 40 : base;   // piled into the first quarter
+        }
+        final int weight = 1 + (sample == 6 ? 3 : sample);
+        return i < 20 ? base * weight : base;
     }
 
     public static void main(final String[] args) throws Exception {
@@ -233,7 +266,7 @@ public class CreateReadCountPanelOfNormalsDump {
                 }
             }
             System.out.printf("error\t%s\t%s%n", label,
-                    ReferenceQueryDump.escape(masked(message, dir)));
+                    ReferenceQueryDump.escape(masked(withoutTheClock(message), dir)));
             return;
         }
         if (!Files.exists(out)) {

--- a/tools/readfilter-conformance/MainCatalogueDump.java
+++ b/tools/readfilter-conformance/MainCatalogueDump.java
@@ -1,0 +1,191 @@
+/*
+ * Main's own tool catalogue and the suggestions it makes over it, taken from the reference.
+ *
+ * MainDispatchDump measured the SEARCH over a catalogue of five named classes. This measures the
+ * CATALOGUE: the set of tool names `gatk <Tool>` will resolve, discovered exactly the way Main
+ * discovers it, and what the suggestion search answers when a near miss is asked of the whole set
+ * rather than of a handful.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - THE CATALOGUE IS THE TWO PACKAGES `org.broadinstitute.hellbender` AND `picard`, scanned for
+ *     both flavours of CommandLineProgram, so the Picard tools GATK dispatches to are in it and
+ *     `SortVcf` resolves;
+ *   - THE CATALOGUE IS BIGGER THAN THE DOCUMENTED TOOL LIST: the scan finds 331 classes where the
+ *     CLI reports 311 tools, so twenty names resolve that no inventory of the documentation names;
+ *   - A CLASS WITHOUT THE ANNOTATION IS NOT IN IT, and PicardCommandLineProgramExecutor and
+ *     CommandLineArgumentValidator are excluded by name whatever their annotation says;
+ *   - THE KEY IS THE SIMPLE CLASS NAME, so two tools of the same simple name in different
+ *     packages would be a collision the reference refuses to start with;
+ *   - A DEPRECATED TOOL IS NOT IN THE CATALOGUE AT ALL. CNNScoreVariants has been taken out of the
+ *     code, so its name falls through to the search, and the deprecation registry answering before
+ *     the search is the ONLY reason the notice is ever seen;
+ *   - THE SPARK TOOLS ARE IN IT, so `PrintReadsSpark` resolves as `PrintReads` does;
+ *   - A NAME ONE CHARACTER OFF A REAL TOOL FINDS IT AND ONLY IT, over three hundred tools and not
+ *     only over a handful;
+ *   - A PREFIX OF SEVERAL TOOLS FINDS ALL OF THEM at distance zero, and a substring of five
+ *     characters or more does the same wherever it sits: `Fingerprint` finds five;
+ *   - AND A NAME FAR FROM EVERYTHING FINDS NOTHING even against the whole catalogue.
+ *
+ * The suggestion names are emitted SORTED and the raw message only where there is nothing to
+ * suggest. The reference walks its class set in hash order, which is not something a byte
+ * comparison should be asked to reproduce; what is being pinned here is WHICH tools a query
+ * finds, not the order the message lists them in.
+ *
+ * Output:
+ *
+ *     count\tcatalogue\t<how many tools the scan found>
+ *     catalogue\t<n>\t<the names, sorted, comma-separated, one line per hundred>
+ *     suggests\t<query>\t<the names it suggests, sorted, comma-separated>
+ *     message\t<query>\t<the whole message, where nothing is suggested>
+ *     holds\t names\t<name>=<whether the catalogue holds it>, comma-separated>
+ *     error\t<query>\t<exception class>:<message>
+ *
+ * Usage: MainCatalogueDump
+ */
+
+import org.broadinstitute.barclay.argparser.ClassFinder;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.Main;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.utils.ClassUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class MainCatalogueDump {
+
+    static final StringBuilder buf = new StringBuilder();
+
+    static void emit(final String kind, final String name, final String payload) {
+        buf.append(kind).append('\t').append(name).append('\t')
+                .append(payload.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n"))
+                .append('\n');
+    }
+
+    /** Main's own package list, which is protected and therefore reachable from a subclass. */
+    static final class Reachable extends Main {
+        List<String> packages() {
+            return getPackageList();
+        }
+
+        List<Class<? extends CommandLineProgram>> classes() {
+            return getClassList();
+        }
+    }
+
+    /**
+     * `extractCommandLineProgram`'s scan, transcribed: both flavours of CommandLineProgram in
+     * every package, keeping the instantiable classes that carry the annotation and dropping the
+     * two the reference names.
+     */
+    static Set<Class<?>> catalogue(final Reachable main) {
+        final ClassFinder finder = new ClassFinder();
+        for (final String pkg : main.packages()) {
+            finder.find(pkg, picard.cmdline.CommandLineProgram.class);
+            finder.find(pkg, CommandLineProgram.class);
+        }
+        final Set<Class<?>> toCheck = new LinkedHashSet<>(finder.getClasses());
+        toCheck.addAll(main.classes());
+        final Set<Class<?>> kept = new LinkedHashSet<>();
+        for (final Class<?> clazz : toCheck) {
+            if (clazz.getSimpleName().equals("PicardCommandLineProgramExecutor")
+                    || clazz.getSimpleName().equals("CommandLineArgumentValidator")) {
+                continue;
+            }
+            if (!ClassUtils.canMakeInstances(clazz)) {
+                continue;
+            }
+            final CommandLineProgramProperties property = Main.getProgramProperty(clazz);
+            if (property == null) {
+                continue;
+            }
+            kept.add(clazz);
+        }
+        return kept;
+    }
+
+    /** The names a message suggests, sorted, or nothing where it suggests none. */
+    static List<String> suggestions(final String message) {
+        final int mean = message.indexOf("Did you mean");
+        if (mean < 0) {
+            return List.of();
+        }
+        final int newline = message.indexOf('\n', mean);
+        final String tail = message.substring(newline + 1);
+        final List<String> names = new ArrayList<>();
+        for (final String part : tail.split(" {8}")) {
+            if (!part.isEmpty()) {
+                names.add(part);
+            }
+        }
+        return new ArrayList<>(new TreeSet<>(names));
+    }
+
+    static void query(final Main main, final Set<Class<?>> classes, final String name) {
+        final String message;
+        try {
+            message = main.getUnknownCommandMessage(classes, name);
+        } catch (final Exception e) {
+            emit("error", name, e.getClass().getName() + ":" + String.valueOf(e.getMessage()));
+            return;
+        }
+        final List<String> names = suggestions(message);
+        if (names.isEmpty()) {
+            emit("message", name, message);
+        } else {
+            emit("suggests", name, String.join(",", names));
+        }
+    }
+
+    public static void main(final String[] args) {
+        final Reachable main = new Reachable();
+        final Set<Class<?>> classes = catalogue(main);
+
+        final List<String> names = new ArrayList<>();
+        for (final Class<?> clazz : classes) {
+            names.add(clazz.getSimpleName());
+        }
+        final List<String> sorted = new ArrayList<>(new TreeSet<>(names));
+        emit("count", "catalogue", Integer.toString(sorted.size()));
+        for (int i = 0; i < sorted.size(); i += 100) {
+            emit("catalogue", Integer.toString(i / 100),
+                    String.join(",", sorted.subList(i, Math.min(i + 100, sorted.size()))));
+        }
+
+        // A name one character off a real tool, over the whole catalogue.
+        query(main, classes, "PrintRead");
+        query(main, classes, "PrintReadz");
+        query(main, classes, "HaplotypeCallr");
+        query(main, classes, "MarkDuplicate");
+        // A prefix several tools share.
+        query(main, classes, "CollectQuality");
+        query(main, classes, "PathSeq");
+        // A substring of many, five characters or more.
+        query(main, classes, "Fingerprint");
+        // A name far from everything.
+        query(main, classes, "Zzzzzzzzzzzzzzzzzzzz");
+        // A deprecated name. It is not in the catalogue at all, so it reaches the search, and the
+        // registry answering first is the only reason the notice is seen.
+        query(main, classes, "IndelRealigner");
+        // A Picard tool, to show the second package is scanned.
+        query(main, classes, "SortVcf");
+
+        // The names the two guards drop, and a handful the catalogue must hold.
+        final List<String> expected = Arrays.asList(
+                "PrintReads", "HaplotypeCaller", "MarkDuplicates", "SortSam", "SortVcfs",
+                "CNNScoreVariants", "PrintReadsSpark", "PicardCommandLineProgramExecutor",
+                "CommandLineArgumentValidator");
+        final List<String> present = new ArrayList<>();
+        for (final String name : expected) {
+            present.add(name + "=" + sorted.contains(name));
+        }
+        emit("holds", "names", String.join(",", present));
+
+        System.out.print(buf);
+    }
+}


### PR DESCRIPTION
The golden failed once on CI with `eigensamples=7` against the committed `8`, and passed on the
three runs either side of it. The fixture is what was wrong, not the tool.

The samples varied only in **depth**, and the first thing the tool does is divide depth out again.
The nine samples' median fractional coverages then agreed to five decimal places:

```
sample 4: 0.0262911895
sample 5: 0.0262918279
sample 3: 0.0262928213
sample 6: 0.0262982690
sample 8: 0.0263029825      <- the top two are 2 parts in 100 000 apart
sample 0: 0.0269388741
sample 1: 0.0269411765
sample 2: 0.0269433616
```

The extreme-median filter drops the sample with the highest median, so which sample that was could
flip on any reordering, and once it did.

The samples now vary in **shape**. Their median coverages are separated by fourteen per cent or
more, except for one pair that is deliberately identical: sample 6 is exactly twice sample 3, which
is the pair the coverage normalisation has to make indistinguishable, and it sits mid-ranking where
no percentile filter reaches for it. Three local runs of the rebuilt fixture are byte-identical.

The captured log line also carried log4j's `HH:mm:ss.SSS`, which differed between all three runs.
That is a clock and not a behaviour, and it is stripped.

Two header claims move with the fixture:

- the zeros-in-interval filter now leaves so few intervals that the decomposition finds no non-zero
  singular value and the run is **refused**, which shows its harshness more sharply than the two
  intervals it used to leave;
- asking for a hundred eigensamples over nine samples with **two** filtered out gives seven.

The suite goes back to `golden-pending`. The committed golden is the old fixture's and is left in
place only so the Rust comparison keeps building; the follow-up PR replaces it with a candidate the
oracle produced, and that is where the suite returns to `oracle-backed`.

Stacked on #953.