### PR TITLE
Update the measured state in the README and the roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ All three ports in this program use those exact pins, so they are mutually coher
 construction.
 
 GATK 4.7.0.0 (htsjdk 5.0.0, Picard 3.5.0) was released on 2026-08-18, and the target deliberately
-stays at 4.6.2.0: 216 suites are oracle-backed against it, and the three ports move together or
+stays at 4.6.2.0: 414 conformance suites are oracle-backed against it across the three
+repositories (278 here, 66 in picard-rs, 70 in htsjdk-rs), and the three ports move together or
 not at all. The delta, and the order the move has to happen in, are recorded in ROADMAP.md.
 
 ## Origin

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,13 +12,16 @@ golden stays `[~]`.
 
 ---
 
-## Where we are (measured 2026-07-30)
+## Where we are (measured 2026-08-28)
 
 | Repo | Scope | State |
 |---|---|---|
-| **htsjdk-rs** | the I/O and math foundation | substantially built; CRAM, GKL-exact deflate, full VCF and the jmath conformance corpus remain |
-| **picard-rs** | 121 tools | ~50 tools have a first slice, ~43 with an oracle-backed conformance suite; many are partial (default paths only). The harness is generated from a manifest, the fuzzer and the determinism gate run in CI, and argument coverage is measured for 2 tools |
-| **gatk-rs** | 190 tools | 6 crates, **58 conformance suites, all oracle-backed**; 3 tools byte-identical, and the annotation archetype opened with 53 of 54 annotations measured. **No performance number exists yet for any of it** — see Milestone S |
+| **htsjdk-rs** | the I/O and math foundation | 71 conformance suites, 70 oracle-backed; the one exception is `format`, whose 41,678 formatted doubles have a harness and a Rust test but have never been regenerated against the oracle in CI. CRAM, GKL-exact deflate and full VCF remain |
+| **picard-rs** | 121 tools | 68 tools carry a suite, 66 oracle-backed and 2 waiting on a candidate; 83 cases. Many are partial (default paths only). The harness is generated from a manifest, the fuzzer and the determinism gate run in CI, and argument coverage is measured for 2 tools |
+| **gatk-rs** | 190 tools | 6 crates, **279 conformance suites over 154 tools, 278 oracle-backed**; 3 tools byte-identical, and 53 of 54 annotations measured. **No performance number exists yet for any of it**: see Milestone S |
+
+Across the three repositories that is **414 oracle-backed suites**, and the generated dashboard
+([docs/STATUS.md](docs/STATUS.md)) puts 203 of the 311 tools in an oracle-backed state, 65.3%.
 
 Totals from the generated inventory (`tools/inventory`): **311 tools** (190 GATK-origin,
 121 Picard-origin), **39 Spark**, ~13,130 arguments. Non-Spark: 151 GATK + 121 Picard.


### PR DESCRIPTION
The roadmap's "Where we are" table was measured on 2026-07-30 and says 58 conformance suites for gatk-rs and "~43 with an oracle-backed suite" for picard-rs. Counted from the three manifests today:

| repo | suites | oracle-backed | not yet |
|---|---:|---:|---|
| gatk-rs | 279 over 154 tools | 278 | 1 waiting on a candidate |
| picard-rs | 68 | 66 | 2 waiting on a candidate |
| htsjdk-rs | 71 | 70 | `format`, never regenerated against the oracle in CI |

That is 414 oracle-backed suites across the three repositories, against the README's 216. The generated dashboard puts 203 of the 311 tools in an oracle-backed state, 65.3%.

The exceptions are named rather than rounded away, since a suite waiting on a candidate and a suite nothing has ever checked are two different kinds of not-yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)