### PR TITLE
Measure AlleleFrequencyQC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,10 @@ jobs:
             index: "56/56"
             slug: "main-catalogue-main-entry-splitting-index"
             suites: "main-catalogue main-entry splitting-index"
+          - group: golden-pending
+            index: "1/1"
+            slug: "allele-frequency-qc"
+            suites: "allele-frequency-qc"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 203 | 65.3% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 0 | 0.0% |
-| not started | 108 | 34.7% |
+| not started | 107 | 34.4% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -93,7 +93,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (135 of 190 started)
+## gatk-origin tools (136 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -101,6 +101,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `AddFlowBaseQuality` | unclassified | oracle-backed | add-flow-base-quality | 1 | not measured |
 | `AddFlowSNVQuality` | flow-based | oracle-backed | add-flow-snv-quality | 1 | not measured |
 | `AddOriginalAlignmentTags` | unclassified | oracle-backed | add-oa-tags | 1 | not measured |
+| `AlleleFrequencyQC` | unclassified | golden-pending | allele-frequency-qc | 1 | not measured |
 | `AnalyzeCovariates` | reporting-walker | oracle-backed | analyze-covariates | 1 | not measured |
 | `AnalyzeSaturationMutagenesis` | locus-walker | oracle-backed | analyze-saturation-mutagenesis | 1 | not measured |
 | `AnnotateIntervals` | cnv-segmentation | oracle-backed | annotate-intervals | 1 | not measured |
@@ -233,9 +234,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantRecalibrator` | variant-transform | oracle-backed | variant-recalibrator | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>55 not started</summary>
+<details><summary>54 not started</summary>
 
-`AlleleFrequencyQC`, `ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
+`ApplyBQSRSpark`, `ApplyVQSR`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6381,6 +6381,26 @@
           "why": "Fourteen cases: four granularities including the default and one above the record count, the default output name, the .bai companion, a queryname-sorted file with and without it, an empty BAM on both paths, a granularity of zero and of minus one, and a file that is not a BAM."
         }
       ]
+    },
+    {
+      "id": "allele-frequency-qc",
+      "status": "golden-pending",
+      "title": "the chi-squared statistic over the allele frequency bins, and the p-value it gives",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "AlleleFrequencyQC"
+      ],
+      "compare": {
+        "mode": "lines"
+      },
+      "why": "The statistic is not Pearson's: the expected count in the denominator is replaced by a constant variance, SQUARED, so raising --allowed-variance from a hundredth to a tenth divides the statistic by a hundred rather than by ten. The comparison set has to be given TWICE, once as --comp and once as a second eval track, or every allele-frequency bin holds a single row and the sum is nought whatever the data says.",
+      "cases": [
+        {
+          "dump": "AlleleFrequencyQCDump",
+          "golden": null,
+          "why": "Nine cases: het calls against the comparison frequencies, one bin called homozygous, two other variances, a threshold above the p-value, a filtered variant, a comparison bin the call set has nothing in, a single bin, and a VCF with no alias header."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6393,12 +6393,12 @@
       "compare": {
         "mode": "lines"
       },
-      "why": "The statistic is not Pearson's: the expected count in the denominator is replaced by a constant variance, SQUARED, so raising --allowed-variance from a hundredth to a tenth divides the statistic by a hundred rather than by ten. The comparison set has to be given TWICE, once as --comp and once as a second eval track, or every allele-frequency bin holds a single row and the sum is nought whatever the data says.",
+      "why": "The statistic is not Pearson's: the expected count in the denominator is replaced by a constant variance, SQUARED, so raising --allowed-variance from a hundredth to a tenth divides the statistic by a hundred rather than by ten. The comparison set has to be given TWICE, once as --comp and once as a second eval track, or every bin holds a single row and the sum is nought whatever the data says. The bin ladder is fixed at sixty-one, so the degrees of freedom are sixty in every run and a bin no variant reached contributes a term of nought.",
       "cases": [
         {
           "dump": "AlleleFrequencyQCDump",
           "golden": null,
-          "why": "Nine cases: het calls against the comparison frequencies, one bin called homozygous, two other variances, a threshold above the p-value, a filtered variant, a comparison bin the call set has nothing in, a single bin, and a VCF with no alias header."
+          "why": "Nine cases: het calls against the comparison frequencies, one bin called homozygous, two other variances, a threshold above the p-value, a filtered variant, a comparison site the call set has nothing at, a file with one variant in it, and a VCF with no alias header."
         }
       ]
     }

--- a/tools/readfilter-conformance/AlleleFrequencyQCDump.java
+++ b/tools/readfilter-conformance/AlleleFrequencyQCDump.java
@@ -14,11 +14,14 @@
  *     CONSTANT variance, squared, so the same difference costs the same wherever it happens;
  *   - THE VARIANCE IS SQUARED AND DIVIDES THE WHOLE SUM, so raising --allowed-variance from a
  *     hundredth to a tenth divides the statistic by a HUNDRED and not by ten;
- *   - A BIN WITH FEWER THAN TWO ENTRIES CONTRIBUTES NOTHING, so an allele frequency the comparison
- *     set has and the call set has not is silently dropped from the sum while still counting
- *     towards the degrees of freedom;
- *   - THE DEGREES OF FREEDOM ARE THE BIN COUNT LESS ONE, counted over the bins that survived the
- *     `called` filter;
+ *   - THE BIN LADDER IS FIXED AND NOT THE DATA'S: the logarithmic scale emits SIXTY-ONE bins
+ *     whatever the file holds, each with one row per eval track, so the degrees of freedom are
+ *     sixty in every run here and a bin no variant reached contributes a term of nought;
+ *   - WHICH MAKES THE `fewer than two entries` GUARD UNREACHABLE ON THIS PATH: every bin has
+ *     exactly the two rows, so the guard is carried in the port and never fires against the
+ *     reference;
+ *   - A COMPARISON SITE THE CALL SET HAS NOTHING AT STILL CONTRIBUTES, its bin holding the
+ *     comparison frequency against a nought, which moves the statistic by that square alone;
  *   - THE P-VALUE IS THE UPPER TAIL, so a perfect match is one and a large statistic is nought;
  *   - THE ROWS ARE FILTERED TO `called` BEFORE THE GROUPING, so the filtered variants' own rows
  *     never reach the statistic;
@@ -28,7 +31,9 @@
  *     written to a temporary file and deleted;
  *   - THE METRICS ARE WRITTEN BEFORE THE PLOT IS ATTEMPTED, so a run whose R script fails has
  *     already answered, which is why this dump reads the file rather than the exit status;
- *   - AND A SINGLE SURVIVING BIN LEAVES ZERO DEGREES OF FREEDOM, which the distribution refuses.
+ *   - AND A FILE WITH ONE VARIANT IN IT IS NOT A DEGENERATE CASE: the ladder is the same
+ *     sixty-one bins, the two tracks agree in the one bin they reach, and the statistic is nought
+ *     against a p-value of one.
  *
  * Output:
  *
@@ -145,12 +150,13 @@ public class AlleleFrequencyQCDump {
                 "comp-with-an-extra-bin");
         run(dir, "a-bin-with-one-entry", fasta, diverging, lonely, List.of());
 
-        // One bin alone, which leaves no degrees of freedom.
+        // A single variant, whose bin is the only one either track reaches. The ladder is still
+        // sixty-one bins wide, so the statistic is nought rather than undefined.
         final Path oneComp = VariantEvalDump.writeIndexed(dir, "one-comp.vcf",
                 compVcf(List.of(site(1000, "0.5"))), "comp-one-bin");
         final Path oneEval = VariantEvalDump.writeIndexed(dir, "one-eval.vcf",
                 evalVcf(List.of(called(1000, "0/1")), true), "eval-one-bin");
-        run(dir, "one-bin", fasta, oneEval, oneComp, List.of());
+        run(dir, "one-variant", fasta, oneEval, oneComp, List.of());
 
         // A VCF with no alias header at all.
         final Path noAlias = VariantEvalDump.writeIndexed(dir, "no-alias.vcf",

--- a/tools/readfilter-conformance/AlleleFrequencyQCDump.java
+++ b/tools/readfilter-conformance/AlleleFrequencyQCDump.java
@@ -1,0 +1,220 @@
+/*
+ * AlleleFrequencyQC's verdict, taken from the reference.
+ *
+ * The tool is VariantEval with every knob preset: one module, two stratifiers, and a logarithmic
+ * allele-frequency scale. What it adds is a chi-squared statistic over the AF bins and the
+ * p-value that statistic gives, which is the whole of the tool's own arithmetic.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - THE COMPARISON SET IS GIVEN TWICE, once as `--comp` and once as a second eval track, which
+ *     is what puts two rows in each bin: with one eval track every bin holds a single row and the
+ *     statistic is nought whatever the data says;
+ *   - THE STATISTIC IS NOT PEARSON'S: the expected count in the denominator is replaced by a
+ *     CONSTANT variance, squared, so the same difference costs the same wherever it happens;
+ *   - THE VARIANCE IS SQUARED AND DIVIDES THE WHOLE SUM, so raising --allowed-variance from a
+ *     hundredth to a tenth divides the statistic by a HUNDRED and not by ten;
+ *   - A BIN WITH FEWER THAN TWO ENTRIES CONTRIBUTES NOTHING, so an allele frequency the comparison
+ *     set has and the call set has not is silently dropped from the sum while still counting
+ *     towards the degrees of freedom;
+ *   - THE DEGREES OF FREEDOM ARE THE BIN COUNT LESS ONE, counted over the bins that survived the
+ *     `called` filter;
+ *   - THE P-VALUE IS THE UPPER TAIL, so a perfect match is one and a large statistic is nought;
+ *   - THE ROWS ARE FILTERED TO `called` BEFORE THE GROUPING, so the filtered variants' own rows
+ *     never reach the statistic;
+ *   - THE SAMPLE NAME COMES FROM A `##sampleAlias` HEADER LINE and not from the genotype columns,
+ *     so a VCF without one fails on a null rather than falling back;
+ *   - --debug-file KEEPS THE VARIANT EVAL REPORT the statistic was read out of, which is otherwise
+ *     written to a temporary file and deleted;
+ *   - THE METRICS ARE WRITTEN BEFORE THE PLOT IS ATTEMPTED, so a run whose R script fails has
+ *     already answered, which is why this dump reads the file rather than the exit status;
+ *   - AND A SINGLE SURVIVING BIN LEAVES ZERO DEGREES OF FREEDOM, which the distribution refuses.
+ *
+ * Output:
+ *
+ *     vcf\t<label>=<that input file, escaped>
+ *     metrics\t<label>\t<the metrics table without its comments, escaped>
+ *     report\t<label>\t<the debug file's own table, escaped>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: AlleleFrequencyQCDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.varianteval.AlleleFrequencyQC;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AlleleFrequencyQCDump {
+
+    /** The eval set carries genotypes and the alias; the comparison set is sites only. */
+    static String evalVcf(final List<String> sites, final boolean withAlias) {
+        final List<String> lines = new ArrayList<>(List.of(
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=" + VariantEvalDump.CONTIG_LENGTH + ">",
+                "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+                "##FILTER=<ID=LowQual,Description=\"Low quality\">"));
+        if (withAlias) {
+            lines.add("##sampleAlias=NA12878");
+        }
+        lines.add("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts1");
+        lines.addAll(sites);
+        lines.add("");
+        return String.join("\n", lines);
+    }
+
+    static String compVcf(final List<String> sites) {
+        final List<String> lines = new ArrayList<>(List.of(
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=" + VariantEvalDump.CONTIG_LENGTH + ">",
+                "##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele frequency\">",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"));
+        lines.addAll(sites);
+        lines.add("");
+        return String.join("\n", lines);
+    }
+
+    /** One eval site, whose genotype is the allele fraction the evaluator sums. */
+    static String called(final int position, final String genotype) {
+        return "chr1\t" + position + "\t.\tA\tG\t100.00\tPASS\t.\tGT\t" + genotype;
+    }
+
+    static String filtered(final int position, final String genotype) {
+        return "chr1\t" + position + "\t.\tA\tG\t100.00\tLowQual\t.\tGT\t" + genotype;
+    }
+
+    /** One comparison site, whose AF is the bin the pair is stratified into. */
+    static String site(final int position, final String frequency) {
+        return "chr1\t" + position + "\t.\tA\tG\t100.00\tPASS\tAF=" + frequency;
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("allele-frequency-qc-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# AlleleFrequencyQCDump: the chi-squared statistic over the allele "
+                + "frequency bins, and the p-value it gives");
+
+        final Path fasta = VariantEvalDump.writeReference(dir);
+
+        // Four allele frequencies an order of magnitude apart, so the logarithmic scale puts each
+        // in a bin of its own, and the eval genotypes that match them.
+        final List<String> frequencies = List.of("0.005", "0.05", "0.25", "0.5");
+        final List<String> compSites = new ArrayList<>();
+        final List<String> matchingSites = new ArrayList<>();
+        final List<String> divergingSites = new ArrayList<>();
+        for (int i = 0; i < frequencies.size(); i++) {
+            final int position = 1000 * (i + 1);
+            compSites.add(site(position, frequencies.get(i)));
+            matchingSites.add(called(position, "0/1"));
+            // The last bin's call disagrees: a homozygous variant where the others are het.
+            divergingSites.add(called(position, i == frequencies.size() - 1 ? "1/1" : "0/1"));
+        }
+        final Path comp = VariantEvalDump.writeIndexed(dir, "comp.vcf", compVcf(compSites), "comp");
+        final Path matching = VariantEvalDump.writeIndexed(dir, "matching.vcf",
+                evalVcf(matchingSites, true), "matching");
+        final Path diverging = VariantEvalDump.writeIndexed(dir, "diverging.vcf",
+                evalVcf(divergingSites, true), "diverging");
+
+        run(dir, "het-calls", fasta, matching, comp, List.of());
+        run(dir, "one-bin-homozygous", fasta, diverging, comp, List.of());
+        // The variance, which is squared and divides the whole sum.
+        run(dir, "variance-tenth", fasta, diverging, comp,
+                List.of("-allowed-variance", "0.1"));
+        run(dir, "variance-hundredth", fasta, diverging, comp,
+                List.of("-allowed-variance", "0.001"));
+        // The threshold, which decides whether the tool complains and nothing else.
+        run(dir, "threshold-above-the-pvalue", fasta, matching, comp,
+                List.of("-pvalue-threshold", "0.99"));
+
+        // A filtered variant, whose rows never reach the statistic.
+        final List<String> withFiltered = new ArrayList<>(divergingSites);
+        withFiltered.add(filtered(5000, "1/1"));
+        final Path filteredEval = VariantEvalDump.writeIndexed(dir, "filtered.vcf",
+                evalVcf(withFiltered, true), "filtered");
+        run(dir, "a-filtered-variant", fasta, filteredEval, comp, List.of());
+
+        // A comparison site the call set has nothing at, whose bin has one entry and not two.
+        final List<String> extraComp = new ArrayList<>(compSites);
+        extraComp.add(site(9000, "0.001"));
+        final Path lonely = VariantEvalDump.writeIndexed(dir, "lonely.vcf", compVcf(extraComp),
+                "comp-with-an-extra-bin");
+        run(dir, "a-bin-with-one-entry", fasta, diverging, lonely, List.of());
+
+        // One bin alone, which leaves no degrees of freedom.
+        final Path oneComp = VariantEvalDump.writeIndexed(dir, "one-comp.vcf",
+                compVcf(List.of(site(1000, "0.5"))), "comp-one-bin");
+        final Path oneEval = VariantEvalDump.writeIndexed(dir, "one-eval.vcf",
+                evalVcf(List.of(called(1000, "0/1")), true), "eval-one-bin");
+        run(dir, "one-bin", fasta, oneEval, oneComp, List.of());
+
+        // A VCF with no alias header at all.
+        final Path noAlias = VariantEvalDump.writeIndexed(dir, "no-alias.vcf",
+                evalVcf(matchingSites, false), "no-alias");
+        run(dir, "no-sample-alias", fasta, noAlias, comp, List.of());
+    }
+
+    /** One run, with the metrics it wrote and the report it was read out of. */
+    static void run(final Path dir, final String label, final Path fasta, final Path eval,
+                    final Path comp, final List<String> extra) throws Exception {
+        final Path out = dir.resolve("out-" + label + ".txt");
+        final Path debug = dir.resolve("debug-" + label + ".txt");
+        final List<String> argv = new ArrayList<>(List.of(
+                "-O", out.toString(),
+                "-R", fasta.toString(),
+                "--eval", eval.toString(),
+                "--comp", comp.toString(),
+                // The comparison set is given AGAIN as a second, tagged eval track. That is what
+                // puts two rows in each allele-frequency bin, one from the call set's genotypes
+                // and one from the comparison set's own AF field, and the statistic is the
+                // difference between them: with one eval track every bin holds a single row and
+                // the sum is nought whatever the data says.
+                "-eval:thousand_genomes", comp.toString(),
+                "-L", comp.toString(),
+                "-debug-file", debug.toString()));
+        argv.addAll(extra);
+        try {
+            new AlleleFrequencyQC().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null && cause.getCause() != cause) {
+                cause = cause.getCause();
+            }
+            // The plot is the LAST thing the tool does, and it wants R packages no oracle image
+            // here carries. The metrics and the report are both written before it, so a run that
+            // got that far is measured and the plot's own fate is left out: the golden then says
+            // the same thing whether or not the image has R, which is what keeps it a measurement
+            // of the tool rather than of the container.
+            if (!Files.exists(out)) {
+                System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                        ReferenceQueryDump.escape(masked(String.valueOf(cause.getMessage()), dir)));
+                return;
+            }
+        }
+        System.out.printf("metrics\t%s\t%s%n", label,
+                ReferenceQueryDump.escape(withoutComments(Files.readString(out,
+                        StandardCharsets.UTF_8), dir)));
+        System.out.printf("report\t%s\t%s%n", label,
+                ReferenceQueryDump.escape(withoutComments(Files.readString(debug,
+                        StandardCharsets.UTF_8), dir)));
+    }
+
+    /** The comment lines carry the command line and the run's own clock. */
+    static String withoutComments(final String text, final Path dir) {
+        final List<String> kept = new ArrayList<>();
+        for (final String line : text.split("\n", -1)) {
+            if (!line.startsWith("#") && !line.isEmpty()) {
+                kept.add(masked(line, dir));
+            }
+        }
+        return String.join("\n", kept);
+    }
+
+    static String masked(final String text, final Path dir) {
+        return text.replace(dir.toString(), "<dir>");
+    }
+}


### PR DESCRIPTION
`AlleleFrequencyQC` is `VariantEval` with every knob preset: one module, two stratifiers, a logarithmic allele-frequency scale. What it adds is a chi-squared statistic over the AF bins and the p-value that statistic gives, and that is what this measures.

Three facts the fixture had to be built around, each of which cost a round to find:

* **the comparison set is given twice**, once as `--comp` and once as a second, tagged eval track (`-eval:thousand_genomes`), which is what puts two rows in each bin: one from the call set's genotypes and one from the comparison set's own `AF` field. With a single eval track every bin holds one row, every list is of length one, and the statistic is nought whatever the data says. The reference's own integration test does the same thing;
* **the bin ladder is fixed, not the data's**: the logarithmic scale emits 61 bins whatever the file holds, so the degrees of freedom are 60 in every run here, and a bin no variant reached contributes a term of nought. The `fewer than two entries` guard in the reference is therefore unreachable on this path: it is carried in the port and never fires;
* **the metrics are written before the plot is attempted.** A run whose R script fails has already answered, so the dump reads the file rather than the exit status, and the golden says the same thing whether or not the oracle image carries R or the packages the script wants.

Nine cases. What they show:

* the statistic is not Pearson's: the expected count in the denominator is replaced by a constant variance, **squared**, so `--allowed-variance` 0.1 gives 76.0025 where 0.01 gives 7600.25 and 0.001 gives 760025, a factor of a hundred each step;
* the p-value is the upper tail, so those three read 0.079611, 0 and 0;
* a comparison site the call set has nothing at still contributes: its bin holds the comparison frequency against a nought, moving the statistic from 7600.25 to 7600.26 by that square alone;
* the rows are filtered to `called` before the grouping, so a filtered variant changes nothing;
* a file with one variant in it is not a degenerate case: the same 61 bins, the two tracks agreeing in the one they reach, a statistic of nought and a p-value of one;
* `--pvalue-threshold` decides whether the tool complains and nothing else;
* and the sample name comes from a `##sampleAlias` header line, so a VCF without one dies on a null rather than falling back to the genotype columns.

The second commit is a correction to the first: the initial reading credited the degrees of freedom for a change the sum had made, and named a case `one-bin` that is one variant across the full ladder.

The suite lands `golden-pending`: this laptop is arm64, so the golden comes from the candidate this PR's own CI run produces.

Part of #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)