### PR TITLE
Measure CalculateContamination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,10 @@ jobs:
             index: "56/56"
             slug: "main-catalogue-main-entry-splitting-index-allele-frequency-qc"
             suites: "main-catalogue main-entry splitting-index allele-frequency-qc"
+          - group: golden-pending
+            index: "1/1"
+            slug: "calculate-contamination"
+            suites: "calculate-contamination"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 205 | 65.9% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 0 | 0.0% |
-| not started | 106 | 34.1% |
+| not started | 105 | 33.8% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -93,7 +93,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (137 of 190 started)
+## gatk-origin tools (138 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -112,6 +112,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `BaseRecalibrator` | record-transform | oracle-backed | base-recalibrator | 1 | not measured |
 | `CRAMIssue8768Detector` | unclassified | oracle-backed | cram-issue-8768-detector | 1 | not measured |
 | `CalculateAverageCombinedAnnotations` | unclassified | oracle-backed | calculate-average-combined-annotations | 1 | not measured |
+| `CalculateContamination` | reporting-walker | golden-pending | calculate-contamination | 1 | not measured |
 | `CalculateGenotypePosteriors` | variant-walker | oracle-backed | calculate-genotype-posteriors, family-priors | 2 | not measured |
 | `CalculateMixingFractions` | variant-walker | oracle-backed | calculate-mixing-fractions | 1 | not measured |
 | `CalibrateDragstrModel` | assembly-caller | oracle-backed | calibrate-dragstr-model | 1 | not measured |
@@ -235,9 +236,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantRecalibrator` | variant-transform | oracle-backed | variant-recalibrator | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>53 not started</summary>
+<details><summary>52 not started</summary>
 
-`ApplyBQSRSpark`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CalculateContamination`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
+`ApplyBQSRSpark`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
 
 </details>
 

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6409,6 +6409,26 @@
           "why": "Nine cases: het calls against the comparison frequencies, one bin called homozygous, two other variances, a threshold above the p-value, a filtered variant, a comparison site the call set has nothing at, a file with one variant in it, and a VCF with no alias header."
         }
       ]
+    },
+    {
+      "id": "calculate-contamination",
+      "status": "golden-pending",
+      "title": "the coverage filter, the table the genotyping is done from, and the two files",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "CalculateContamination"
+      ],
+      "compare": {
+        "mode": "lines"
+      },
+      "why": "The two ratio arguments are accepted and ignored: both fields are `private final double` initialised from a constant expression, which makes their one read a compile-time constant, so a low ratio of ten that would drop every site changes nothing. The filter itself still cuts at three times the mean, which the golden shows by keeping the same six homozygous-alternate sites at a lower depth and watching the answer move. And a matched normal decides WHICH sites are homozygous while the tumour's own counts are read there: 0.915 against 0.044 on the same tumour table.",
+      "cases": [
+        {
+          "dump": "CalculateContaminationDump",
+          "golden": null,
+          "why": "Eleven cases: a plain run, one asking for the segmentation, a table with sites under the minimum coverage, a deep hom-alt tail the ceiling cuts and the same tail at a depth it keeps, four ratio settings including one that would drop every site, a matched normal whose hom-alt sites sit elsewhere, one with no hom-alt site at all, and a matched normal with the segmentation."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/CalculateContaminationDump.java
+++ b/tools/readfilter-conformance/CalculateContaminationDump.java
@@ -1,0 +1,258 @@
+/*
+ * CalculateContamination's two files, taken from the reference.
+ *
+ * The model underneath is measured already (`contamination-model`); what this dump is for is the
+ * tool around it: which sites survive the coverage filter, which table the genotyping is done
+ * from, and what reaches the two output files.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - --low-coverage-ratio-threshold AND --high-coverage-ratio-threshold ARE ACCEPTED AND IGNORED.
+ *     Barclay does set the fields, and a probe reading them back after the parse shows the value
+ *     that was asked for; the filter never sees it, because both fields are `private final double`
+ *     initialised from a constant expression, which makes them constant variables under JLS 4.12.4
+ *     and their one read a compile-time constant. A low ratio of ten, which would drop every site
+ *     in the table, changes nothing;
+ *   - THE COVERAGE FILTER STILL CUTS, at a ceiling of three times the MEAN: six homozygous-
+ *     alternate sites at depth four hundred are dropped, and the same six at depth sixty are kept
+ *     and move the answer, which is how the golden shows the cut happened rather than assuming it;
+ *   - A SITE AT OR UNDER `MIN_COVERAGE` IS DROPPED BEFORE EITHER STATISTIC IS TAKEN, so it moves
+ *     neither the median nor the mean;
+ *   - WITHOUT A MATCHED NORMAL THE TUMOUR IS GENOTYPED FROM ITSELF;
+ *   - WITH ONE THE NORMAL SAYS WHICH SITES ARE HOMOZYGOUS AND THE TUMOUR'S OWN COUNTS ARE READ
+ *     THERE: a normal whose homozygous-alternate sites sit at other positions answers 0.915 where
+ *     the tumour alone answers 0.044;
+ *   - A NORMAL WITH NO HOMOZYGOUS-ALTERNATE SITE AT ALL FALLS THROUGH to the hom-ref strategies,
+ *     which read the tumour and not the model, so the answer returns to the tumour-only one;
+ *   - --tumor-segmentation IS OPTIONAL and changes neither number in the contamination table;
+ *   - THE SEGMENTATION IS THE TUMOUR'S OWN even when a matched normal did the genotyping, which is
+ *     the one place the two models are built from different site lists;
+ *   - AND THE SAMPLE NAME IS THE TUMOUR TABLE'S METADATA LINE, copied into both outputs, while the
+ *     tool returns the string `SUCCESS`.
+ *
+ * Output:
+ *
+ *     table\t<label>=<that input file, escaped>
+ *     contamination\t<label>\t<the contamination table, escaped>
+ *     segments\t<label>\t<the segmentation table, escaped, or `absent`>
+ *     returned\t<label>\t<what doWork returned>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: CalculateContaminationDump
+ */
+
+import org.broadinstitute.hellbender.tools.walkers.contamination.CalculateContamination;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CalculateContaminationDump {
+
+    /** One row of a pileup summary table. */
+    record Site(int position, int ref, int alt, int other, double frequency) {}
+
+    static String table(final String sample, final List<Site> sites) {
+        final StringBuilder text = new StringBuilder("#<METADATA>SAMPLE=" + sample + "\n"
+                + "contig\tposition\tref_count\talt_count\tother_alt_count\tallele_frequency\n");
+        for (final Site site : sites) {
+            text.append("chr1\t").append(site.position()).append('\t').append(site.ref())
+                    .append('\t').append(site.alt()).append('\t').append(site.other())
+                    .append('\t').append(String.format("%.6f", site.frequency())).append('\n');
+        }
+        return text.toString();
+    }
+
+    /**
+     * A stretch of sites in the shape the model can fit.
+     *
+     * Every fifth site is homozygous reference with a little error, every fifth homozygous
+     * alternate, and the rest heterozygous, which is what `ContaminationModel` needs to fit an
+     * allele fraction before it can read a contamination off the homozygous-alternate ones. The
+     * shape is `ContaminationModelDump`'s own, so the two suites are looking at the same fixture
+     * from either side of the tool.
+     */
+    static List<Site> sites(final int count, final int depthOffset, final boolean loh,
+                            final int shift) {
+        final List<Site> sites = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            final int position = 1000 + 100 * i;
+            final double frequency = 0.05 + (i % 19) * 0.05;
+            final int depth = 50 + depthOffset + (i % 7) * 5;
+            final int other = i % 4 == 0 ? 1 : 0;
+            final int alt;
+            switch ((i + shift) % 5) {
+                case 0:
+                    alt = 1 + i % 2;
+                    break;
+                case 3:
+                    alt = depth - other - (i % 2);
+                    break;
+                default:
+                    alt = (loh && i >= count / 2) ? (depth - other) / 4 : (depth - other) / 2;
+                    break;
+            }
+            sites.add(new Site(position, depth - alt - other, alt, other, frequency));
+        }
+        return sites;
+    }
+
+    /** A stretch of sites at ONE depth, which is what moves the coverage statistics. */
+    static List<Site> flat(final int from, final int count, final int depth) {
+        final List<Site> sites = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            sites.add(new Site(from + i * 100, depth / 2, depth / 2, 0, 0.5));
+        }
+        return sites;
+    }
+
+    /**
+     * A stretch of homozygous-alternate sites carrying a fifth of their reads as reference.
+     *
+     * A hom-alt site is what the contamination is read off, so these WOULD move the answer if the
+     * coverage filter kept them: putting them at a depth the high threshold cuts is how the golden
+     * shows the cut happened at all.
+     */
+    static List<Site> deepHomAlt(final int from, final int count, final int depth) {
+        final List<Site> sites = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            sites.add(new Site(from + i * 100, depth / 5, depth - depth / 5, 0, 0.5));
+        }
+        return sites;
+    }
+
+    static List<Site> concat(final List<Site>... parts) {
+        final List<Site> all = new ArrayList<>();
+        for (final List<Site> part : parts) {
+            all.addAll(part);
+        }
+        return all;
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("calculate-contamination-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# CalculateContaminationDump: the coverage filter, the genotyping "
+                + "table, and the two files");
+
+        // A hundred sites in the shape the model fits: hom ref, hom alt and het in turn.
+        final List<Site> tumour = sites(100, 0, false, 0);
+        final Path tumourPath = write(dir, "tumour.table", table("tumour", tumour), "tumour");
+
+        // The same sites with a handful under the minimum coverage, which the filter drops before
+        // it computes either statistic.
+        final List<Site> withUncovered = concat(tumour, flat(90000, 5, 8));
+        final Path uncoveredPath = write(dir, "uncovered.table",
+                table("tumour", withUncovered), "with-uncovered-sites");
+
+        // The same sites with a tail of very deep ones, which moves the mean and so the top.
+        final List<Site> withDeep = concat(tumour, deepHomAlt(95000, 6, 400));
+        final Path deepPath = write(dir, "deep.table", table("tumour", withDeep),
+                "with-a-deep-tail");
+
+        // The same six sites at a depth the filter keeps, which is what says the answer moves when
+        // they are not cut.
+        final List<Site> withShallow = concat(tumour, deepHomAlt(95000, 6, 60));
+        final Path shallowPath = write(dir, "shallow.table", table("tumour", withShallow),
+                "with-a-shallow-tail");
+
+        // A matched normal, deeper than the tumour and with a loss of heterozygosity in its second
+        // half, so the two models see different site lists.
+        // Its homozygous-alternate sites sit at DIFFERENT positions, which is what makes the
+        // genotyping source visible: the contamination is still read off the tumour's counts, but
+        // at the positions the normal called homozygous.
+        final List<Site> normal = sites(100, 10, true, 2);
+        final Path normalPath = write(dir, "normal.table", table("normal", normal), "normal");
+
+        // A normal in which nothing is homozygous alternate, so the genotyping model has nothing
+        // to read a contamination off.
+        final List<Site> homRef = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            homRef.add(new Site(1000 + 100 * i, 59, 1, 0, 0.05 + (i % 19) * 0.05));
+        }
+        final Path homRefPath = write(dir, "homref.table", table("normal", homRef),
+                "normal-all-hom-ref");
+
+        run(dir, "plain", tumourPath, null, false, List.of());
+        run(dir, "with-segmentation", tumourPath, null, true, List.of());
+        run(dir, "uncovered-sites", uncoveredPath, null, false, List.of());
+        run(dir, "a-deep-tail", deepPath, null, false, List.of());
+        run(dir, "a-shallow-tail", shallowPath, null, false, List.of());
+        // The two ratios, including a low one of nought.
+        run(dir, "low-ratio-zero", deepPath, null, false,
+                List.of("--low-coverage-ratio-threshold", "0.0"));
+        run(dir, "high-ratio-one", tumourPath, null, false,
+                List.of("--high-coverage-ratio-threshold", "1.0"));
+        run(dir, "low-ratio-one", tumourPath, null, false,
+                List.of("--low-coverage-ratio-threshold", "1.0"));
+        run(dir, "low-ratio-ten", tumourPath, null, false,
+                List.of("--low-coverage-ratio-threshold", "10.0"));
+        // The matched normal, with and without the segmentation the tumour's own model writes.
+        run(dir, "matched-normal", tumourPath, normalPath, false, List.of());
+        run(dir, "matched-normal-homref", tumourPath, homRefPath, false, List.of());
+        run(dir, "matched-normal-segmented", tumourPath, normalPath, true, List.of());
+    }
+
+    static Path write(final Path dir, final String name, final String text, final String label)
+            throws Exception {
+        System.out.printf("table\t%s=%s%n", label, ReferenceQueryDump.escape(text));
+        final Path path = dir.resolve(name);
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    static void run(final Path dir, final String label, final Path input, final Path matched,
+                    final boolean segmentation, final List<String> extra) throws Exception {
+        final Path out = dir.resolve("contamination-" + label + ".table");
+        final Path segments = dir.resolve("segments-" + label + ".table");
+        final List<String> argv = new ArrayList<>(List.of("-I", input.toString(),
+                "-O", out.toString()));
+        if (matched != null) {
+            argv.add("--matched-normal");
+            argv.add(matched.toString());
+        }
+        if (segmentation) {
+            argv.add("--tumor-segmentation");
+            argv.add(segments.toString());
+        }
+        argv.addAll(extra);
+        final Object returned;
+        try {
+            returned = new CalculateContamination().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null && cause.getCause() != cause) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", label, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(cause.getMessage())
+                            .replace(dir.toString(), "<dir>")));
+            return;
+        }
+        System.out.printf("returned\t%s\t%s%n", label, returned);
+        System.out.printf("contamination\t%s\t%s%n", label,
+                ReferenceQueryDump.escape(withoutComments(Files.readString(out,
+                        StandardCharsets.UTF_8))));
+        System.out.printf("segments\t%s\t%s%n", label, Files.exists(segments)
+                ? ReferenceQueryDump.escape(withoutComments(Files.readString(segments,
+                        StandardCharsets.UTF_8)))
+                : "absent");
+    }
+
+    /** The comment lines carry the command line and the run's own clock. */
+    static String withoutComments(final String text) {
+        final List<String> kept = new ArrayList<>();
+        for (final String line : text.split("\n", -1)) {
+            if (!line.startsWith("#") || line.startsWith("#<METADATA>")) {
+                if (!line.isEmpty()) {
+                    kept.add(line);
+                }
+            }
+        }
+        return String.join("\n", kept);
+    }
+}


### PR DESCRIPTION
The contamination model underneath is measured already (`contamination-model`, `contamination-tables`, `pileup-summary`). This is the tool around it, and two of its arguments turn out to do nothing.

**`--low-coverage-ratio-threshold` and `--high-coverage-ratio-threshold` are accepted and ignored.** Barclay does set the fields: a throwaway probe reading them back after the parse shows the value that was asked for. The filter never sees it, because both are `private final double` initialised from a constant expression, which makes them constant variables under JLS 4.12.4 and their one read a compile-time constant. A low ratio of ten, which would drop every site in the table, changes nothing. The golden pins that, since the port has to reproduce it.

The filter itself still cuts, and the golden shows it rather than assuming it: six homozygous-alternate sites at depth four hundred are dropped by the ceiling of three times the mean, and the same six at depth sixty are kept and move the answer from 0.04388 to 0.04551. Sites at or under `MIN_COVERAGE` are dropped before either statistic is taken.

Eleven cases in all. The rest of what they show:

* without a matched normal the tumour is genotyped from itself;
* with one, the normal says which sites are homozygous and the tumour's own counts are read at those positions: a normal whose hom-alt sites sit at other positions answers **0.915** where the tumour alone answers **0.044**;
* a normal with no hom-alt site at all falls through to the hom-ref strategies, which read the tumour and not the model, so the answer returns to the tumour-only one;
* `--tumor-segmentation` is optional and changes neither number in the contamination table;
* the segmentation is the tumour's own even when a matched normal did the genotyping, which is the one place the two models are built from different site lists;
* and the sample name is the tumour table's metadata line, copied into both outputs, while the tool returns the string `SUCCESS`.

The suite lands `golden-pending`: this laptop is arm64, so the golden comes from the candidate this PR's own CI run produces.

Part of #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)