### PR TITLE
Measure what one tool declares

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,10 @@ jobs:
             index: "56/56"
             slug: "main-catalogue-main-entry-splitting-index-allele-frequency-qc-calculate-contamination"
             suites: "main-catalogue main-entry splitting-index allele-frequency-qc calculate-contamination"
+          - group: golden-pending
+            index: "1/1"
+            slug: "tool-argument-declarations"
+            suites: "tool-argument-declarations"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -137,8 +137,8 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountBases` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
 | `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
-| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
-| `CountVariants` | variant-walker | oracle-backed | count-variants | 1 | not measured |
+| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers, tool-argument-declarations | 3 | not measured |
+| `CountVariants` | variant-walker | oracle-backed | count-variants, tool-argument-declarations | 2 | not measured |
 | `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | not measured |
 | `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |
@@ -202,7 +202,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `PrintDistantMates` | record-transform | oracle-backed | print-distant-mates | 1 | not measured |
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |
 | `PrintReadCounts` | sv-caller | oracle-backed | print-read-counts | 1 | not measured |
-| `PrintReads` | record-transform | oracle-backed | printreads | 1 | not measured |
+| `PrintReads` | record-transform | oracle-backed | printreads, tool-argument-declarations | 2 | not measured |
 | `PrintReadsHeader` | record-transform | oracle-backed | print-reads-header | 1 | not measured |
 | `PrintSVEvidence` | unclassified | oracle-backed | print-sv-evidence | 1 | not measured |
 | `RampedHaplotypeCaller` | assembly-caller | oracle-backed | ramped-haplotype-caller | 1 | not measured |

--- a/tools/argument-conformance/ToolArgumentDeclarationDump.java
+++ b/tools/argument-conformance/ToolArgumentDeclarationDump.java
@@ -1,0 +1,123 @@
+/*
+ * The argument declarations of three ported tools, taken from the reference.
+ *
+ * The Barclay parser is measured already, argument by argument and mechanism by mechanism. What is
+ * not measured is what any ONE tool declares: the flattened namespace its own fields and its
+ * inherited collections produce, and therefore which command lines it accepts. That is the layer
+ * Milestone C's per-tool declarations have to reproduce, and it cannot be read off the parser.
+ *
+ * Nine behaviours this is built to catch.
+ *
+ *   - THE NAMESPACE IS FLAT AND INHERITED: a read walker declares four arguments of its own and
+ *     ends up with dozens, the rest coming from the collections its superclasses hold;
+ *   - THE ORDER IS THE PARSER'S OWN, subclass first, and it is what the usage prints in;
+ *   - A REQUIRED ARGUMENT IS REQUIRED BY ITS DECLARATION AND NOT BY THE TOOL, and the two
+ *     archetypes do not mirror each other: a read walker REQUIRES `--input` and has no `--variant`
+ *     at all, while a variant walker requires `--variant` and takes `--input` as an OPTIONAL
+ *     argument, so `-V` on the first is "not a recognized option" and `-I` on the second parses;
+ *   - THE SHORT NAME IS PART OF THE DECLARATION, and several arguments have none;
+ *   - A COLLECTION ARGUMENT IS DECLARED AS ONE, which is what lets it be repeated;
+ *   - THE DEFAULT IS THE FIELD'S OWN VALUE at construction time, so it is read off an instance and
+ *     not off the annotation;
+ *   - AN ARGUMENT NAMED TWICE IS AN ERROR ONLY IF IT IS A SCALAR: `--input` is declared as a
+ *     collection, so naming it twice parses, while `--output` is a scalar and naming it twice is
+ *     refused;
+ *   - AN UNKNOWN ARGUMENT IS REFUSED BY THE PARSER AND NOT BY THE TOOL, with a message that names
+ *     it;
+ *   - AND A MISSING REQUIRED ARGUMENT IS REFUSED THE SAME WAY, before the tool runs at all.
+ *
+ * Output:
+ *
+ *     count\t<tool>\t<how many named arguments it declares>
+ *     def\t<tool>\t<index>\t<longName>|<shortName>|<required>|<collection>|<default>
+ *     parse\t<tool>\t<case>\tok|E:<exception class>:<message>
+ *
+ * Usage: ToolArgumentDeclarationDump
+ */
+
+import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
+import org.broadinstitute.barclay.argparser.NamedArgumentDefinition;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ToolArgumentDeclarationDump {
+
+    public static void main(final String[] args) {
+        declarations("CountReads",
+                new org.broadinstitute.hellbender.tools.CountReads());
+        declarations("CountVariants",
+                new org.broadinstitute.hellbender.tools.walkers.CountVariants());
+        declarations("PrintReads",
+                new org.broadinstitute.hellbender.tools.PrintReads());
+
+        // A read walker: its own input, and the arguments it inherits.
+        parse("CountReads", "no-arguments", new String[]{});
+        parse("CountReads", "input-only", new String[]{"-I", "/dev/null"});
+        parse("CountReads", "long-input", new String[]{"--input", "/dev/null"});
+        parse("CountReads", "input-twice",
+                new String[]{"-I", "/dev/null", "-I", "/dev/null"});
+        parse("CountReads", "unknown-argument", new String[]{"--no-such-argument", "1"});
+        parse("CountReads", "an-interval", new String[]{"-I", "/dev/null", "-L", "chr1"});
+        parse("CountReads", "two-intervals",
+                new String[]{"-I", "/dev/null", "-L", "chr1", "-L", "chr2"});
+        parse("CountReads", "a-variant-argument",
+                new String[]{"-I", "/dev/null", "-V", "/dev/null"});
+
+        // A variant walker, which has no `--input` at all.
+        parse("CountVariants", "variant-only", new String[]{"-V", "/dev/null"});
+        parse("CountVariants", "an-input", new String[]{"-V", "/dev/null", "-I", "/dev/null"});
+        parse("CountVariants", "no-arguments", new String[]{});
+
+        // The output argument a print tool requires on top of its input.
+        parse("PrintReads", "input-only", new String[]{"-I", "/dev/null"});
+        parse("PrintReads", "input-and-output",
+                new String[]{"-I", "/dev/null", "-O", "/dev/null"});
+        // The output is a scalar where the input is a collection, so naming it twice is refused.
+        parse("PrintReads", "output-twice", new String[]{
+            "-I", "/dev/null", "-O", "/dev/null", "-O", "/dev/null"});
+    }
+
+    /** Every named argument the tool declares, in the parser's own order. */
+    static void declarations(final String tool, final Object target) {
+        final List<NamedArgumentDefinition> definitions =
+                new CommandLineArgumentParser(target).getNamedArgumentDefinitions();
+        System.out.printf("count\t%s\t%d%n", tool, definitions.size());
+        for (int i = 0; i < definitions.size(); i++) {
+            final NamedArgumentDefinition definition = definitions.get(i);
+            final List<String> shorts = new ArrayList<>(definition.getArgumentAliases());
+            System.out.printf("def\t%s\t%d\t%s|%s|%s|%s|%s%n", tool, i,
+                    definition.getLongName(),
+                    String.join(",", shorts),
+                    definition.isOptional() ? "optional" : "required",
+                    definition.isCollection() ? "collection" : "scalar",
+                    escape(String.valueOf(definition.getDefaultValueAsString())));
+        }
+    }
+
+    /** The dump's own escaping, since this harness has no shared helper. */
+    static String escape(final String text) {
+        return text.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n");
+    }
+
+    /** What the parser makes of one command line, before the tool runs at all. */
+    static void parse(final String tool, final String label, final String[] argv) {
+        final Object target = switch (tool) {
+            case "CountReads" -> new org.broadinstitute.hellbender.tools.CountReads();
+            case "CountVariants" -> new org.broadinstitute.hellbender.tools.walkers.CountVariants();
+            default -> new org.broadinstitute.hellbender.tools.PrintReads();
+        };
+        String result;
+        try {
+            final PrintStream sink = new PrintStream(new ByteArrayOutputStream());
+            result = new CommandLineArgumentParser(target).parseArguments(sink, argv)
+                    ? "ok" : "not-parsed";
+        } catch (final Exception | AssertionError e) {
+            result = "E:" + e.getClass().getName() + ":" + e.getMessage();
+        }
+        System.out.printf("parse\t%s\t%s\t%s%n", tool, label,
+                escape(result));
+    }
+}

--- a/tools/argument-conformance/ToolArgumentDeclarationDump.java
+++ b/tools/argument-conformance/ToolArgumentDeclarationDump.java
@@ -8,8 +8,13 @@
  *
  * Nine behaviours this is built to catch.
  *
- *   - THE NAMESPACE IS FLAT AND INHERITED: a read walker declares four arguments of its own and
- *     ends up with dozens, the rest coming from the collections its superclasses hold;
+ *   - THE NAMESPACE IS FLAT AND INHERITED: a read walker declares a handful of arguments of its
+ *     own and ends up with dozens, the rest coming from the collections its superclasses hold;
+ *   - AND WHICH PARSER IS ASKED DECIDES HOW MANY THERE ARE: a parser built straight from the
+ *     instance sees 38 where the one the tool hands out sees 70, the gap being the plugin
+ *     descriptors' four read-filter arguments and the standard collections the tool adds when it
+ *     builds its own. Every one of the 38 is in the 70, so the instance list is a subset and not
+ *     a different reading;
  *   - THE ORDER IS THE PARSER'S OWN, subclass first, and it is what the usage prints in;
  *   - A REQUIRED ARGUMENT IS REQUIRED BY ITS DECLARATION AND NOT BY THE TOOL, and the two
  *     archetypes do not mirror each other: a read walker REQUIRES `--input` and has no `--variant`
@@ -80,11 +85,29 @@ public class ToolArgumentDeclarationDump {
             "-I", "/dev/null", "-O", "/dev/null", "-O", "/dev/null"});
     }
 
-    /** Every named argument the tool declares, in the parser's own order. */
+    /**
+     * Every named argument the tool declares, in the parser's own order, and how many a parser
+     * built straight from the instance would have seen instead.
+     *
+     * The two are not the same list. A parser constructed from the instance knows nothing about
+     * the plugin descriptors or the standard argument collections the tool adds when it builds its
+     * own, so it sees 38 arguments where the tool's parser sees 70. The four read-filter arguments
+     * are the visible half of that gap; the rest are the common and advanced ones the usage text
+     * does not print either.
+     */
     static void declarations(final String tool, final Object target) {
-        final List<NamedArgumentDefinition> definitions =
+        final List<NamedArgumentDefinition> instance =
                 new CommandLineArgumentParser(target).getNamedArgumentDefinitions();
-        System.out.printf("count\t%s\t%d%n", tool, definitions.size());
+        final List<NamedArgumentDefinition> definitions =
+                ((CommandLineArgumentParser) ((org.broadinstitute.hellbender.cmdline
+                        .CommandLineProgram) target).getCommandLineParser())
+                        .getNamedArgumentDefinitions();
+        System.out.printf("count\t%s\tinstance=%d tool=%d%n", tool, instance.size(),
+                definitions.size());
+        final List<String> seen = new ArrayList<>();
+        for (final NamedArgumentDefinition definition : instance) {
+            seen.add(definition.getLongName());
+        }
         for (int i = 0; i < definitions.size(); i++) {
             final NamedArgumentDefinition definition = definitions.get(i);
             final List<String> shorts = new ArrayList<>(definition.getArgumentAliases());
@@ -94,6 +117,10 @@ public class ToolArgumentDeclarationDump {
                     definition.isOptional() ? "optional" : "required",
                     definition.isCollection() ? "collection" : "scalar",
                     escape(String.valueOf(definition.getDefaultValueAsString())));
+            if (!seen.contains(definition.getLongName())) {
+                System.out.printf("only-on-the-tool\t%s\t%s%n", tool,
+                        definition.getLongName());
+            }
         }
     }
 
@@ -112,8 +139,8 @@ public class ToolArgumentDeclarationDump {
         String result;
         try {
             final PrintStream sink = new PrintStream(new ByteArrayOutputStream());
-            result = new CommandLineArgumentParser(target).parseArguments(sink, argv)
-                    ? "ok" : "not-parsed";
+            result = ((org.broadinstitute.hellbender.cmdline.CommandLineProgram) target)
+                    .getCommandLineParser().parseArguments(sink, argv) ? "ok" : "not-parsed";
         } catch (final Exception | AssertionError e) {
             result = "E:" + e.getClass().getName() + ":" + e.getMessage();
         }

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6429,6 +6429,28 @@
           "why": "Eleven cases: a plain run, one asking for the segmentation, a table with sites under the minimum coverage, a deep hom-alt tail the ceiling cuts and the same tail at a depth it keeps, four ratio settings including one that would drop every site, a matched normal whose hom-alt sites sit elsewhere, one with no hom-alt site at all, and a matched normal with the segmentation."
         }
       ]
+    },
+    {
+      "id": "tool-argument-declarations",
+      "status": "golden-pending",
+      "title": "what one tool declares, and therefore which command lines it accepts",
+      "harness": "tools/argument-conformance",
+      "tools": [
+        "CountReads",
+        "CountVariants",
+        "PrintReads"
+      ],
+      "compare": {
+        "mode": "lines"
+      },
+      "why": "The parser is measured mechanism by mechanism; what no suite holds is what any ONE tool declares. A read walker declares a handful of arguments of its own and ends up with dozens, the rest inherited from the collections its superclasses hold, in an order that is the parser's and not the source's. That flattened namespace is what Milestone C's per-tool declarations have to reproduce, and a variant walker having no `--input` at all is the cheapest proof that it cannot be guessed from the archetype.",
+      "cases": [
+        {
+          "dump": "ToolArgumentDeclarationDump",
+          "golden": null,
+          "why": "Three tools' full declaration lists, and fourteen command lines over them: the empty one, the input alone under each spelling, the input twice, an unknown argument, one and two intervals, a variant argument given to a read walker and an input given to a variant walker, and a print tool with and without its output."
+        }
+      ]
     }
   ],
   "probes": []


### PR DESCRIPTION
The Barclay parser is measured mechanism by mechanism: the value model, tagged arguments, argument collections, the arguments file, plugin descriptors. What no suite held is what any **one tool** declares: the flattened namespace its own fields and its inherited collections produce, and therefore which command lines it accepts.

That is the layer #819's per-tool declarations have to reproduce, and it cannot be read off the parser or guessed from the archetype.

**Which parser is asked decides the answer.** A parser built straight from the tool instance sees **38** named arguments for `CountReads`; the parser the tool hands out sees **70**. The gap is the plugin descriptors' four read-filter arguments and the standard collections the tool adds when it builds its own. The golden holds both counts, every definition the tool's parser carries, and a row naming each of the 32 arguments only that parser has. A declaration that reproduced the instance list would be short by half; the second commit is that correction.

Three tools and fifteen command lines over them:

* `CountReads` declares 70 named arguments, `CountVariants` 72, `PrintReads` 70;
* the two archetypes do not mirror each other: a read walker **requires** `--input` and has no `--variant` at all, while a variant walker requires `--variant` and takes `--input` as an **optional** argument. `-V` on the first is "not a recognized option"; `-I` on the second parses;
* `--input` is declared as a **collection** and `--output` as a **scalar**, so naming the first twice parses and naming the second twice is refused as an illegal argument value;
* an unknown argument is refused by the parser, with a message that names it, before the tool runs;
* and a missing required argument is refused the same way, naming what was missing.

Each definition is held as `longName|aliases|required|collection|default`, the default read off a constructed instance rather than off the annotation.

The suite lands `golden-pending`: this laptop is arm64, so the golden comes from the candidate this PR's own CI run produces.

Part of #819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)