### PR TITLE
Name the GATK tool GatherVcfsCloud, which is what it is

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -107,7 +107,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `AnnotateIntervals` | cnv-segmentation | oracle-backed | annotate-intervals | 1 | not measured |
 | `AnnotateVcfWithBamDepth` | variant-walker | oracle-backed | annotate-vcf-with-bam-depth | 1 | not measured |
 | `AnnotateVcfWithExpectedAlleleFraction` | variant-walker | oracle-backed | annotate-vcf-with-expected-allele-fraction | 1 | not measured |
-| `ApplyBQSR` | record-transform | oracle-backed | apply-bqsr | 1 | not measured |
+| `ApplyBQSR` | record-transform | oracle-backed | apply-bqsr, tool-argument-declarations | 2 | not measured |
 | `ApplyVQSR` | variant-transform | oracle-backed | apply-vqsr-allele-specific, apply-vqsr-site-filtering, apply-vqsr-tranches, apply-vqsr-two-modes | 4 | not measured |
 | `BaseRecalibrator` | record-transform | oracle-backed | base-recalibrator | 1 | not measured |
 | `CRAMIssue8768Detector` | unclassified | oracle-backed | cram-issue-8768-detector | 1 | not measured |
@@ -167,7 +167,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GatherNormalArtifactData` | unclassified | oracle-backed | mutect-gathers | 1 | not measured |
 | `GatherPileupSummaries` | unclassified | oracle-backed | mutect-gathers | 1 | not measured |
 | `GatherTranches` | unclassified | oracle-backed | gather-tranches | 1 | not measured |
-| `GatherVcfsCloud` | variant-transform | oracle-backed | gather-vcfs | 1 | not measured |
+| `GatherVcfsCloud` | variant-transform | oracle-backed | gather-vcfs, tool-argument-declarations | 2 | not measured |
 | `GeneExpressionEvaluation` | locus-walker | oracle-backed | gene-expression-evaluation | 1 | not measured |
 | `GenotypeGVCFs` | assembly-caller | oracle-backed | genotype-gvcfs | 1 | not measured |
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |
@@ -179,7 +179,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GroupedSVCluster` | sv-caller | oracle-backed | grouped-sv-cluster | 1 | not measured |
 | `GtfToBed` | assembly-caller | oracle-backed | gtf-to-bed | 1 | not measured |
 | `HaplotypeBasedVariantRecaller` | assembly-caller | oracle-backed | haplotype-based-variant-recaller | 1 | not measured |
-| `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file | 1 | not measured |
+| `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file, tool-argument-declarations | 2 | not measured |
 | `JointGermlineCNVSegmentation` | sv-caller | oracle-backed | joint-germline-cnv-segmentation | 1 | not measured |
 | `LearnReadOrientationModel` | assembly-caller | oracle-backed | learn-read-orientation-model | 1 | not measured |
 | `LeftAlignAndTrimVariants` | variant-transform | oracle-backed | left-align-and-trim-variants | 1 | not measured |
@@ -215,7 +215,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `SVCluster` | sv-caller | oracle-backed | sv-cluster | 1 | not measured |
 | `SVConcordance` | sv-caller | oracle-backed | sv-concordance | 1 | not measured |
 | `SVStratify` | sv-caller | oracle-backed | sv-stratify | 1 | not measured |
-| `SelectVariants` | variant-transform | oracle-backed | select-variants-concordance, select-variants-filters, select-variants-output, select-variants-samples, select-variants-subset | 5 | not measured |
+| `SelectVariants` | variant-transform | oracle-backed | select-variants-concordance, select-variants-filters, select-variants-output, select-variants-samples, select-variants-subset, tool-argument-declarations | 6 | not measured |
 | `ShiftFasta` | reference-utility | oracle-backed | shift-fasta | 1 | not measured |
 | `SiteDepthtoBAF` | sv-caller | oracle-backed | site-depth-to-baf | 1 | not measured |
 | `SplitCRAM` | unclassified | oracle-backed | split-cram | 1 | not measured |

--- a/tools/argument-conformance/ToolArgumentDeclarationDump.java
+++ b/tools/argument-conformance/ToolArgumentDeclarationDump.java
@@ -66,7 +66,11 @@ public class ToolArgumentDeclarationDump {
                 new org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants());
         declarations("IndexFeatureFile",
                 new org.broadinstitute.hellbender.tools.IndexFeatureFile());
-        declarations("GatherVcfs",
+        // `GatherVcfs` is Picard's tool of that name, which GATK dispatches to; the GATK one is
+        // GatherVcfsCloud, and the two declare different arguments. Naming it wrongly here made
+        // the generator's cross-check report a `--COMMENT` the parser did not declare, which is
+        // Picard's argument and not this tool's.
+        declarations("GatherVcfsCloud",
                 new org.broadinstitute.hellbender.tools.GatherVcfsCloud());
 
         // A read walker: its own input, and the arguments it inherits.

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6438,12 +6438,16 @@
       "tools": [
         "CountReads",
         "CountVariants",
-        "PrintReads"
+        "PrintReads",
+        "ApplyBQSR",
+        "SelectVariants",
+        "IndexFeatureFile",
+        "GatherVcfsCloud"
       ],
       "compare": {
         "mode": "lines"
       },
-      "why": "The parser is measured mechanism by mechanism; what no suite holds is what any ONE tool declares. A read walker declares a handful of arguments of its own and ends up with dozens, the rest inherited from the collections its superclasses hold, in an order that is the parser's and not the source's. That flattened namespace is what Milestone C's per-tool declarations have to reproduce, and a variant walker having no `--input` at all is the cheapest proof that it cannot be guessed from the archetype. The golden here is the PREVIOUS one: four more tools have been added to the dump, so the file this suite regenerates no longer matches it. It stays declared and committed only so the Rust comparison and the declarations generator keep working; the follow-up PR replaces it with the candidate this run produces.",
+      "why": "The parser is measured mechanism by mechanism; what no suite holds is what any ONE tool declares. A read walker declares a handful of arguments of its own and ends up with dozens, the rest inherited from the collections its superclasses hold, in an order that is the parser's and not the source's. That flattened namespace is what Milestone C's per-tool declarations have to reproduce, and a variant walker having no `--input` at all is the cheapest proof that it cannot be guessed from the archetype.",
       "cases": [
         {
           "dump": "ToolArgumentDeclarationDump",

--- a/tools/declarations/generate.py
+++ b/tools/declarations/generate.py
@@ -107,7 +107,10 @@ def cross_check(tool, entries):
         sys.exit(
             f"{tool}: --{name} defaults to {ours!r} in the parser and {written!r} in the usage text"
         )
-    if len(documented) >= len(entries):
+    # The usage text never prints MORE than the parser declares. It prints fewer for a walker,
+    # whose plugin descriptors and standard collections it leaves out, and exactly as many for a
+    # tool that has neither: IndexFeatureFile is 14 of 14.
+    if len(documented) > len(entries):
         sys.exit(f"{tool}: the usage text prints {len(documented)} of {len(entries)} declarations")
     return len(documented)
 


### PR DESCRIPTION
The dump declared `org.broadinstitute.hellbender.tools.GatherVcfsCloud` under the name `GatherVcfs`. That name belongs to `picard.vcf.GatherVcfs`, a different tool with different arguments that GATK dispatches to, and the inventory carries both.

**The generator's cross-check caught it**: regenerating the module reported a `--COMMENT` that the parser did not declare, which is Picard's argument and not this tool's. That is the check doing exactly what #970 added it for, so the fix is the name, not the check.

One rule is relaxed with it. The cross-check refused a tool whose usage text prints as many arguments as the parser declares, on the assumption that the usage always prints fewer. That holds for a walker, whose plugin descriptors and standard collections the usage leaves out; it does not hold for a tool that has neither, and `IndexFeatureFile` is 14 of 14. The check now refuses only a usage text that prints **more** than the parser declares.

The suite stays `golden-pending`: the dump's tool label has changed, so the candidate comes round again and the freeze is the next PR.

Part of #819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)