### PR TITLE
Measure BwaMemIndexImageCreator, and find pointers in its output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,10 @@ jobs:
             index: "57/57"
             slug: "tool-argument-declarations-usage-text"
             suites: "tool-argument-declarations usage-text"
+          - group: golden-pending
+            index: "1/1"
+            slug: "bwa-index-image"
+            suites: "bwa-index-image"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,9 +7,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | state | tools | share |
 |---|---:|---:|
 | oracle-backed | 206 | 66.2% |
-| golden-pending | 0 | 0.0% |
+| golden-pending | 1 | 0.3% |
 | unchecked | 0 | 0.0% |
-| not started | 105 | 33.8% |
+| not started | 104 | 33.4% |
 | **total** | **311** | |
 
 `oracle-backed` means CI re-derives the tool's goldens in the pinned container on every run and compares them. It does **not** mean the tool is byte-identical over its whole argument surface: that is what the argument-coverage column is for. A t-wise array (`tools/coverage/covering.py`, sized in [what-pairwise-coverage-costs.md](what-pairwise-coverage-costs.md)) is run against the reference and the port, and the column reports the fraction of its rows on which the two answered identically, rejections included. `not measured` means the array has never been run against a port binary, which is still true of most tools here.
@@ -93,7 +93,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 </details>
 
-## gatk-origin tools (138 of 190 started)
+## gatk-origin tools (139 of 190 started)
 
 | tool | archetype | state | suites | cases | argument coverage |
 |---|---|---|---|---:|---|
@@ -110,6 +110,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ApplyBQSR` | record-transform | oracle-backed | apply-bqsr, tool-argument-declarations | 2 | not measured |
 | `ApplyVQSR` | variant-transform | oracle-backed | apply-vqsr-allele-specific, apply-vqsr-site-filtering, apply-vqsr-tranches, apply-vqsr-two-modes | 4 | not measured |
 | `BaseRecalibrator` | record-transform | oracle-backed | base-recalibrator | 1 | not measured |
+| `BwaMemIndexImageCreator` | reference-utility | golden-pending | bwa-index-image | 1 | not measured |
 | `CRAMIssue8768Detector` | unclassified | oracle-backed | cram-issue-8768-detector | 1 | not measured |
 | `CalculateAverageCombinedAnnotations` | unclassified | oracle-backed | calculate-average-combined-annotations | 1 | not measured |
 | `CalculateContamination` | reporting-walker | oracle-backed | calculate-contamination | 1 | not measured |
@@ -236,9 +237,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `VariantRecalibrator` | variant-transform | oracle-backed | variant-recalibrator | 1 | not measured |
 | `VariantsToTable` | variant-walker | oracle-backed | variants-to-table | 1 | not measured |
 
-<details><summary>52 not started</summary>
+<details><summary>51 not started</summary>
 
-`ApplyBQSRSpark`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaMemIndexImageCreator`, `BwaSpark`, `CalcMetadataSpark`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
+`ApplyBQSRSpark`, `BQSRPipelineSpark`, `BaseRecalibratorSpark`, `BwaAndMarkDuplicatesPipelineSpark`, `BwaSpark`, `CalcMetadataSpark`, `CollectAllelicCountsSpark`, `CollectBaseDistributionByCycleSpark`, `CollectInsertSizeMetricsSpark`, `CollectMultipleMetricsSpark`, `CollectQualityYieldMetricsSpark`, `CompareDuplicatesSpark`, `CountBasesSpark`, `CountReadsSpark`, `CountVariantsSpark`, `CpxVariantReInterpreterSpark`, `DetermineGermlineContigPloidy`, `DiscoverVariantsFromContigAlignmentsSAMSpark`, `ExtractOriginalAlignmentRecordsByNameSpark`, `ExtractSVEvidenceSpark`, `FindBadGenomicKmersSpark`, `FindBreakpointEvidenceSpark`, `FlagStatSpark`, `GenomicsDBImport`, `GermlineCNVCaller`, `HaplotypeCaller`, `HaplotypeCallerSpark`, `HtsgetReader`, `MarkDuplicatesSpark`, `MeanQualityByCycleSpark`, `Mutect2`, `NVScoreVariants`, `ParallelCopyGCSDirectoryIntoHDFSSpark`, `PathSeqBwaSpark`, `PathSeqFilterSpark`, `PathSeqPipelineSpark`, `PathSeqScoreSpark`, `PileupSpark`, `PlotDenoisedCopyRatios`, `PlotModeledSegments`, `PostprocessGermlineCNVCalls`, `PrintReadsSpark`, `PrintVariantsSpark`, `QualityScoreDistributionSpark`, `ReadsPipelineSpark`, `RevertSamSpark`, `ScoreVariantAnnotations`, `SortSamSpark`, `StructuralVariationDiscoveryPipelineSpark`, `SvDiscoverFromLocalAssemblyContigAlignmentsSpark`, `TrainVariantAnnotationsModel`
 
 </details>
 

--- a/docs/pointers-that-reach-the-output.md
+++ b/docs/pointers-that-reach-the-output.md
@@ -1,0 +1,35 @@
+# Pointers that reach the output
+
+`BwaMemIndexImageCreator` writes a file whose bytes are not a function of its input. Building one
+reference twice in a single process gives two images of the same length that differ in nine bytes,
+and those bytes read `70 1a 79 f8 ff 7f 00 00`: an address on the JVM's heap, written into the file
+by BWA's own serialiser through JNI.
+
+That is a different animal from the two hazards already written down here:
+
+  * [an unspecified order that reaches the output](an-unspecified-order-that-reaches-the-output.md)
+    is deterministic for a given JDK and a given key set; it is unspecified, not unstable;
+  * a log4j timestamp is stripped by the dump because it is a clock, and a clock is not an answer.
+
+A pointer cannot be stripped by masking, because which bytes carry one is not knowable from the
+file alone, and it cannot be pinned by a golden, because address-space layout randomisation moves
+it on every run. A golden holding those bytes would go red on a run that changed nothing.
+
+## What the suite holds instead
+
+  * the SIZE, which is a function of the reference: 1333 bytes for five repeats of eight bases,
+    1551 for twenty, 1334 for the same sequence under a longer contig name;
+  * the file the tool wrote, which is what `--OUTPUT` and its default decide;
+  * the refusal, when the reference cannot be read;
+  * and the instability itself, as a `stable` row that reads `false` for every case, so a future
+    run that starts producing identical images fails this suite rather than passing it quietly.
+
+## What that means for the port
+
+The port cannot claim byte-identity for this tool and the dashboard must not imply one. What it can
+reproduce is the naming, the refusal and the size, and the size only if the port builds the index
+the same way, which it does not: the index is BWA's.
+
+The honest position is the one [the ML surface](the-ml-surface-cannot-be-bit-identical.md) already
+takes for a different reason: the claim is scoped to what is a function of the input, and the rest
+is named rather than quietly dropped.

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6477,6 +6477,26 @@
           "why": "Three tools' whole usage text, its line count, and whether -h and --help agree."
         }
       ]
+    },
+    {
+      "id": "bwa-index-image",
+      "status": "golden-pending",
+      "title": "the BWA index image a reference produces, and where it lands",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "BwaMemIndexImageCreator"
+      ],
+      "compare": {
+        "mode": "lines"
+      },
+      "why": "The image is NOT byte-comparable: building one reference twice in a single process gives two files of the same length whose differing bytes are in-process POINTERS. The golden therefore holds the size, the landing name, the refusal and the fact of that instability, and says why the bytes are not a claim.",
+      "cases": [
+        {
+          "dump": "BwaMemIndexImageCreatorDump",
+          "golden": null,
+          "why": "Ten cases: one reference indexed twice, the same bases in lower case, a longer sequence, two contigs, a renamed contig, a run of Ns, a reference of one base, the default output name, and a fasta that is not there. Every case is built twice, and the golden records that no two builds agree."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/readfilter-conformance/BwaMemIndexImageCreatorDump.java
+++ b/tools/readfilter-conformance/BwaMemIndexImageCreatorDump.java
@@ -1,0 +1,151 @@
+/*
+ * BwaMemIndexImageCreator's image, taken from the reference.
+ *
+ * The tool hands a FASTA to BWA's own index builder through JNI and writes the result. The image
+ * is NOT byte-comparable and this dump is what establishes that: building the same reference twice
+ * in one process gives two files of the same length that differ in a handful of bytes, and those
+ * bytes are in-process POINTERS. `\x70\x1a\x79\xf8\xff\x7f\x00\x00` is an address, not data.
+ *
+ * So the golden holds what is stable and says so: the size, where the file landed, whether two
+ * builds of one reference agree, and the refusal. The bytes are not a claim this repository can
+ * make, and a golden that held them would fail on the next run under a different address layout.
+ *
+ * Eight behaviours this is built to catch.
+ *
+ *   - THE DEFAULT OUTPUT IS THE INPUT'S WHOLE NAME PLUS `.img`, so `default-output.fasta` becomes
+ *     `default-output.fasta.img` and not `default-output.img`;
+ *   - THE IMAGE IS NOT DETERMINISTIC: two builds of one reference differ in a few bytes;
+ *   - THE SIZE IS, so it is what the golden compares;
+ *   - THE SIZE GROWS WITH THE SEQUENCE: five repeats of eight bases give 1333 bytes and twenty
+ *     give 1551;
+ *   - THE BASES ARE UPPER-CASED BEFORE INDEXING, so a reference in lower case gives an image of
+ *     the same size;
+ *   - THE CONTIG NAME IS IN THE IMAGE, so renaming `chr1` to `other` moves the size by one byte;
+ *   - A RUN OF Ns ADDS TO THE SIZE without adding to the indexed bases, and a reference of one
+ *     base still produces an image;
+ *   - AND A MISSING FASTA IS A CouldNotReadReferenceException from the native side, whose message
+ *     names the file and the reason.
+ *
+ * Output:
+ *
+ *     fasta\t<name>\t<that reference, escaped>
+ *     wrote\t<case>\t<the file name the image landed on>
+ *     size\t<case>\t<its size in bytes>
+ *     stable\t<case>\t<whether two builds of this reference are byte-identical>
+ *     error\t<case>\t<exception class>:<message>
+ *
+ * Usage: BwaMemIndexImageCreatorDump
+ */
+
+import org.broadinstitute.hellbender.tools.BwaMemIndexImageCreator;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BwaMemIndexImageCreatorDump {
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("bwa-index-image-dump").toAbsolutePath();
+        PrintReadsDump.emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# BwaMemIndexImageCreatorDump: the image BWA's own builder returns");
+
+        final String plain = fasta(List.of("chr1"), List.of(repeat("ACGTTGCA", 5)));
+        run(dir, "plain", plain, false);
+        // The same reference again, to show the bytes do not move between runs.
+        run(dir, "plain-again", plain, false);
+        // The same bases in lower case.
+        run(dir, "lower-case", fasta(List.of("chr1"), List.of(repeat("acgttgca", 5))), false);
+        // A longer sequence, and a second contig.
+        run(dir, "longer", fasta(List.of("chr1"), List.of(repeat("ACGTTGCA", 20))), false);
+        run(dir, "two-contigs", fasta(
+                List.of("chr1", "chr2"),
+                List.of(repeat("ACGTTGCA", 5), repeat("TTAACCGG", 5))), false);
+        // The same sequence under another contig name.
+        run(dir, "renamed-contig", fasta(List.of("other"), List.of(repeat("ACGTTGCA", 5))), false);
+        // Ns, which BWA holds apart from the bases it indexes.
+        run(dir, "with-ns", fasta(List.of("chr1"),
+                List.of(repeat("ACGTTGCA", 2) + "NNNNNNNN" + repeat("ACGTTGCA", 2))), false);
+        // One base.
+        run(dir, "one-base", fasta(List.of("chr1"), List.of("A")), false);
+        // The default output name.
+        run(dir, "default-output", plain, true);
+        // A reference that is not there.
+        missing(dir);
+    }
+
+    static String repeat(final String unit, final int times) {
+        return unit.repeat(times);
+    }
+
+    static String fasta(final List<String> names, final List<String> sequences) {
+        final StringBuilder text = new StringBuilder();
+        for (int i = 0; i < names.size(); i++) {
+            text.append('>').append(names.get(i)).append('\n');
+            final String sequence = sequences.get(i);
+            for (int at = 0; at < sequence.length(); at += 60) {
+                text.append(sequence, at, Math.min(at + 60, sequence.length())).append('\n');
+            }
+        }
+        return text.toString();
+    }
+
+    static void run(final Path dir, final String name, final String fasta,
+                    final boolean defaultOutput) throws Exception {
+        final Path reference = dir.resolve(name + ".fasta");
+        Files.writeString(reference, fasta, StandardCharsets.UTF_8);
+        System.out.printf("fasta\t%s\t%s%n", name, ReferenceQueryDump.escape(fasta));
+        final Path image = dir.resolve(name + ".img");
+        final List<String> argv = new ArrayList<>(List.of("-I", reference.toString()));
+        if (!defaultOutput) {
+            argv.add("-O");
+            argv.add(image.toString());
+        }
+        try {
+            new BwaMemIndexImageCreator().instanceMain(argv.toArray(new String[0]));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null && cause.getCause() != cause) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\t%s\t%s:%s%n", name, cause.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(cause.getMessage())
+                            .replace(dir.toString(), "<dir>")));
+            return;
+        }
+        final Path landed = defaultOutput ? Path.of(reference + ".img") : image;
+        System.out.printf("wrote\t%s\t%s%n", name, landed.getFileName());
+        System.out.printf("size\t%s\t%d%n", name, Files.size(landed));
+
+        // The same reference again, into another file: the two differ in their pointer fields, so
+        // the answer is `false` and the bytes stay out of the golden.
+        final Path second = dir.resolve(name + "-second.img");
+        new BwaMemIndexImageCreator().instanceMain(new String[]{
+            "-I", reference.toString(), "-O", second.toString()});
+        final byte[] first = Files.readAllBytes(landed);
+        final byte[] again = Files.readAllBytes(second);
+        System.out.printf("stable\t%s\t%s%n", name, java.util.Arrays.equals(first, again));
+    }
+
+    /** A reference that is not there, which fails on the native side. */
+    static void missing(final Path dir) {
+        try {
+            new BwaMemIndexImageCreator().instanceMain(new String[]{
+                "-I", dir.resolve("no-such.fasta").toString(),
+                "-O", dir.resolve("no-such.img").toString()});
+            System.out.printf("error\tmissing-fasta\tno failure%n");
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null && cause.getCause() != cause) {
+                cause = cause.getCause();
+            }
+            System.out.printf("error\tmissing-fasta\t%s:%s%n", cause.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(cause.getMessage())
+                            .replace(dir.toString(), "<dir>")));
+        }
+    }
+}


### PR DESCRIPTION
The tool hands a FASTA to BWA's own index builder through JNI. **The image it writes is not byte-comparable**, and this suite is what establishes that rather than assuming either way: building one reference twice in a single process gives two files of the same length that differ in nine bytes, and those bytes read `70 1a 79 f8 ff 7f 00 00` — an address on the JVM's heap, written into the file by BWA's serialiser.

A pointer cannot be masked, because which bytes carry one is not knowable from the file, and it cannot be pinned, because ASLR moves it on every run. A golden holding those bytes would go red on a run that changed nothing, which is a flake this repository has already paid for once.

So the golden holds what **is** a function of the input:

* the size: 1333 bytes for five repeats of eight bases, 1551 for twenty, 1334 for the same sequence under a longer contig name, 1349 with a run of Ns, 1291 for a single base;
* the file the tool wrote, which is where the default `--OUTPUT` lands: `default-output.fasta.img`, the whole name plus `.img`;
* the refusal, a `CouldNotReadReferenceException` naming the file and the reason;
* and the instability itself, as a `stable` row that reads `false` for every case. A future run that starts producing identical images fails this suite rather than passing it quietly.

`docs/pointers-that-reach-the-output.md` writes down why this hazard is not the same as the unspecified-order one already documented, and what the port can and cannot claim here.

The suite lands `golden-pending`: this laptop is arm64, so the golden comes from the candidate this PR's own CI run produces.

Part of #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)