### PR TITLE
The dispatcher binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gatk-cli"
+version = "0.1.0"
+dependencies = [
+ "gatk-corpus",
+ "gatk-tools",
+]
+
+[[package]]
 name = "gatk-corpus"
 version = "0.1.0"
 dependencies = [

--- a/crates/gatk-cli/Cargo.toml
+++ b/crates/gatk-cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gatk-cli"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# `gatk-rs <Tool> <args>`: the name the bit-identity claim is defined against. The reference's own
+# wrapper is `gatk`, and the difference in the name is deliberate: a port that answers to `gatk`
+# on a PATH would be a trap for anyone comparing the two.
+[[bin]]
+name = "gatk-rs"
+path = "src/main.rs"
+
+[dependencies]
+gatk-tools = { path = "../gatk-tools" }
+
+[dev-dependencies]
+gatk-corpus = { path = "../gatk-corpus" }

--- a/crates/gatk-cli/src/lib.rs
+++ b/crates/gatk-cli/src/lib.rs
@@ -1,0 +1,169 @@
+//! The dispatcher: what `gatk <Tool> <args>` does before a tool ever sees an argument.
+//!
+//! `Main.mainEntry` is three steps and an exit status: route the command line, run whatever the
+//! route named, and turn whatever came back into a status. The routing and the statuses are ported
+//! in [`gatk_tools::main_entry`]; what is here is the entry point that puts them together, writes
+//! to the two streams the reference writes to, and returns the status the reference would have
+//! exited with.
+//!
+//! # What this does not do yet
+//!
+//! Two things, both of them measured and neither of them portable from what is measured:
+//!
+//!  * **the main usage listing** is three hundred and seventy-three lines of tool names and their
+//!    one-line summaries, and the summaries are not in any golden: what is reproduced here is the
+//!    stream it goes to, the status that follows it, and its first line;
+//!  * **a tool's own arguments** need a Barclay definition each, and the declarations golden
+//!    carries names rather than types, so no command line can be handed to the parser yet.
+//!
+//! Both are deliberate boundaries rather than omissions, and the test beside this file states
+//! them as such: it compares what the port claims against the golden, and says nothing about the
+//! lines the port does not produce.
+//!
+//! Ported from `org.broadinstitute.hellbender.Main`.
+
+use gatk_tools::main_entry::{self, Failure, Route, Stream};
+
+/// The reference's own pins, which `printVersionInfo` reads off the jar's manifest.
+pub const TOOLKIT_NAME: &str = "The Genome Analysis Toolkit (GATK)";
+pub const TOOLKIT_VERSION: &str = "4.6.2.0";
+pub const HTSJDK_VERSION: &str = "4.2.0";
+pub const PICARD_VERSION: &str = "3.4.0";
+
+/// The first line of the main usage, which Barclay writes in colour.
+///
+/// The escapes are the reference's: bold red for the label, green for the program name. They are
+/// bytes of the output like any other, which is why they are written out rather than described.
+pub const USAGE_FIRST_LINE: &str =
+    "\u{1b}[1m\u{1b}[31mUSAGE:  \u{1b}[32m<program name>\u{1b}[1m\u{1b}[31m [-h]";
+
+/// What one run wrote and what it returned, which is what `mainEntry` turns into an exit status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Outcome {
+    pub stdout: String,
+    pub stderr: String,
+    pub status: i32,
+}
+
+/// A tool the port can actually run, and what it does with the arguments after its name.
+///
+/// The list is empty of walkers on purpose: a tool becomes reachable here the moment its name
+/// resolves, and runnable only once its arguments have a declaration to parse against. The gap
+/// between the two is Milestone C's, and it is visible rather than papered over.
+pub type Runner = fn(&[String]) -> Result<Option<String>, (Failure, String)>;
+
+/// `Main.instanceMain`, with the two streams returned rather than written.
+pub fn run(args: &[String]) -> Outcome {
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    match main_entry::route(args) {
+        Route::Usage(stream) => {
+            // `handleResult(null)` prints nothing, and the run is a success: asking for help is
+            // not an error, which is the one path that reaches the runner with no program.
+            let target = match stream {
+                Stream::Stdout => &mut stdout,
+                Stream::Stderr => &mut stderr,
+            };
+            target.push_str(&usage());
+            Outcome {
+                stdout,
+                stderr,
+                status: 0,
+            }
+        }
+        Route::Version => {
+            let (first, rest) = main_entry::version_lines(
+                TOOLKIT_NAME,
+                TOOLKIT_VERSION,
+                HTSJDK_VERSION,
+                PICARD_VERSION,
+            );
+            // The first line goes to `System.out` whatever stream the method was handed, and the
+            // two under it go to the stream. Here both are stdout, which is what the command line
+            // asks for, and the split is only visible when a caller hands it something else.
+            stdout.push_str(&first);
+            stdout.push_str(&rest);
+            Outcome {
+                stdout,
+                stderr,
+                status: 0,
+            }
+        }
+        Route::Unknown { message } => {
+            // The refusal is the usage AND the message: the usage goes to stderr first, and the
+            // UserException follows it through `handleUserException`.
+            stderr.push_str(&usage());
+            stderr.push_str(&main_entry::user_exception_report(&message));
+            Outcome {
+                stdout,
+                stderr,
+                status: main_entry::exit_status(Failure::User),
+            }
+        }
+        Route::Tool { name } => match runner(&name) {
+            None => {
+                stderr.push_str(&main_entry::user_exception_report(&not_ported(&name)));
+                Outcome {
+                    stdout,
+                    stderr,
+                    status: main_entry::exit_status(Failure::User),
+                }
+            }
+            Some(runner) => match runner(main_entry::tool_arguments(args)) {
+                Ok(result) => {
+                    if let Some(printed) = main_entry::tool_returned(result.as_deref()) {
+                        stdout.push_str(&printed);
+                        stdout.push('\n');
+                    }
+                    Outcome {
+                        stdout,
+                        stderr,
+                        status: 0,
+                    }
+                }
+                Err((failure, message)) => {
+                    stderr.push_str(&main_entry::user_exception_report(&message));
+                    Outcome {
+                        stdout,
+                        stderr,
+                        status: main_entry::exit_status(failure),
+                    }
+                }
+            },
+        },
+    }
+}
+
+/// The tools this port can run, which is none of them yet.
+///
+/// A name that resolves and has no runner is not a name that does not resolve: the reference would
+/// have run it, and saying so is the honest answer. What it is NOT is a refusal the reference
+/// makes, which is why [`not_ported`] says whose refusal it is.
+pub fn runner(_name: &str) -> Option<Runner> {
+    None
+}
+
+/// The port's own refusal, which the reference has no equivalent of.
+///
+/// It is worded so that nobody mistakes it for GATK's: a tool that GATK runs and this does not is
+/// a gap in the port, and a golden will never contain this string.
+pub fn not_ported(name: &str) -> String {
+    format!("{name} is a GATK tool that this port does not carry yet. This message is the port's own and not GATK's.")
+}
+
+/// The main usage, of which the first line is the reference's and the rest is not yet.
+///
+/// The reference prints three hundred and seventy-three lines here: a header, then every tool it
+/// found on the class path under its program group, each with the one-line summary its annotation
+/// carries. The names are ported in [`gatk_tools::main_catalogue`]; the summaries are not measured,
+/// so the listing is the names alone and the golden is not asked to agree with it.
+pub fn usage() -> String {
+    let mut text = String::from(USAGE_FIRST_LINE);
+    text.push('\n');
+    for name in gatk_tools::main_catalogue::CATALOGUE {
+        text.push_str("    ");
+        text.push_str(name);
+        text.push('\n');
+    }
+    text
+}

--- a/crates/gatk-cli/src/main.rs
+++ b/crates/gatk-cli/src/main.rs
@@ -1,0 +1,16 @@
+//! `gatk-rs <Tool> <args>`.
+//!
+//! `mainEntry` ends in `System.exit`, and so does this: the status is the whole of what a caller
+//! downstream of it can see.
+
+use std::io::Write;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let outcome = gatk_cli::run(&args);
+    print!("{}", outcome.stdout);
+    let _ = std::io::stdout().flush();
+    eprint!("{}", outcome.stderr);
+    let _ = std::io::stderr().flush();
+    std::process::exit(outcome.status);
+}

--- a/crates/gatk-cli/tests/dispatcher.rs
+++ b/crates/gatk-cli/tests/dispatcher.rs
@@ -1,0 +1,212 @@
+//! Conformance for the dispatcher against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/MainEntryDump.java`, which ran `Main.instanceMain`
+//! over eleven command lines and recorded, for each, which stream it wrote to, how many lines it
+//! wrote, what the first of them was, what the run returned and what exception it ended in.
+//!
+//! # What this suite is for
+//!
+//!  * **the paths that write nothing being silent, and the ones that refuse writing the usage**;
+//!  * **the version being four lines whatever else is on the command line**;
+//!  * **a name that does not resolve costing status two, and one that went out costing the same**;
+//!  * **and the boundary: a tool this port cannot run yet refuses in its OWN words, which is not
+//!    a claim about the reference and is stated here so that it cannot be mistaken for one.**
+
+use gatk_corpus as corpus;
+use gatk_tools::main_entry::{self, Failure};
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../gatk-tools/tests/data/main_entry.txt.gz"),
+    )
+}
+
+fn unescape(text: &str) -> String {
+    text.replace("\\t", "\t").replace("\\n", "\n")
+}
+
+fn field(text: &str, kind: &str, name: &str) -> String {
+    let prefix = format!("{kind}\t{name}\t");
+    text.lines()
+        .find(|line| line.starts_with(&prefix))
+        .map(|line| unescape(&line[prefix.len()..]))
+        .unwrap_or_else(|| panic!("{kind}/{name}"))
+}
+
+/// The golden writes a shape as `out=<lines>,<first line> err=<lines>,<first line>`.
+fn shape(text: &str, case: &str) -> ((usize, String), (usize, String)) {
+    let row = field(text, "shape", case);
+    let (out, err) = row.split_once(" err=").expect("the two streams");
+    let read = |part: &str| {
+        let (count, first) = part.split_once(',').expect("a count and a line");
+        (count.parse::<usize>().expect("a count"), first.to_string())
+    };
+    (
+        read(out.strip_prefix("out=").expect("the stdout shape")),
+        read(err),
+    )
+}
+
+/// A stream as the golden counts it: `split("\n", -1)`, so a trailing newline is a last line.
+fn counted(text: &str) -> (usize, String) {
+    if text.is_empty() {
+        return (0, String::new());
+    }
+    let lines: Vec<&str> = text.split('\n').collect();
+    (lines.len(), lines[0].to_string())
+}
+
+fn args(list: &[&str]) -> Vec<String> {
+    list.iter().map(|arg| (*arg).to_string()).collect()
+}
+
+/// The five statuses are the golden's, and they are read off the constants and not off a process.
+#[test]
+fn the_statuses_are_the_reference_ones() {
+    let text = golden();
+    let status = |name: &str| {
+        field(&text, "status", name)
+            .parse::<i32>()
+            .expect("a number")
+    };
+    assert_eq!(
+        main_entry::exit_status(Failure::CommandLine),
+        status("COMMANDLINE_EXCEPTION_EXIT_VALUE")
+    );
+    assert_eq!(
+        main_entry::exit_status(Failure::User),
+        status("USER_EXCEPTION_EXIT_VALUE")
+    );
+    assert_eq!(
+        main_entry::exit_status(Failure::PicardNonZero),
+        status("PICARD_TOOL_EXCEPTION")
+    );
+    assert_eq!(
+        main_entry::exit_status(Failure::Other),
+        status("ANY_OTHER_EXCEPTION_EXIT_VALUE")
+    );
+    assert_eq!(
+        main_entry::exit_status(Failure::OutOfMemory),
+        status("OUT_OF_MEMORY_EXIT_VALUE")
+    );
+}
+
+/// Asking for the usage writes it to stdout, returns nothing and is not an error.
+#[test]
+fn asking_for_the_usage_is_not_an_error() {
+    let text = golden();
+    for case in ["no-arguments", "dash-h", "long-help"] {
+        let (out, err) = shape(&text, case);
+        let written = gatk_cli::run(&args(match case {
+            "no-arguments" => &[],
+            "dash-h" => &["-h"],
+            _ => &["--help"],
+        }));
+        assert_eq!(counted(&written.stdout).1, out.1, "{case}");
+        assert_eq!(counted(&written.stderr), (err.0, err.1), "{case}");
+        assert_eq!(written.status, 0, "{case}");
+        // `handleResult(null)` prints nothing, which is why the run that reaches it with no
+        // program at all is silent past the usage.
+        assert_eq!(field(&text, "result", case), "null");
+        // The listing under that first line is the port's own: the names resolve, the one-line
+        // summaries are not measured, and the golden is not asked to agree with the count.
+        assert!(counted(&written.stdout).0 > 1, "{case}");
+        assert_ne!(counted(&written.stdout).0, out.0, "{case}");
+    }
+}
+
+/// The version is four lines, wherever on the command line it was asked for.
+#[test]
+fn the_version_is_four_lines_wherever_it_is_asked_for() {
+    let text = golden();
+    for (case, argv) in [
+        ("version", vec!["--version"]),
+        ("version-short", vec!["-version"]),
+        ("version-after-a-tool", vec!["CountReads", "--version"]),
+    ] {
+        let (out, err) = shape(&text, case);
+        let written = gatk_cli::run(&args(&argv));
+        assert_eq!(counted(&written.stdout), (out.0, out.1), "{case}");
+        assert_eq!(counted(&written.stderr), (err.0, err.1), "{case}");
+        assert_eq!(written.status, 0, "{case}");
+    }
+    // And the two halves are the two the reference splits it into, which is what makes printing
+    // the version to any other stream tear it in half.
+    let (first, rest) = main_entry::version_lines(
+        gatk_cli::TOOLKIT_NAME,
+        gatk_cli::TOOLKIT_VERSION,
+        gatk_cli::HTSJDK_VERSION,
+        gatk_cli::PICARD_VERSION,
+    );
+    assert_eq!(first, field(&text, "out", "version-to-stdout"));
+    assert_eq!(rest, field(&text, "out", "version-to-elsewhere"));
+}
+
+/// A name that resolves to nothing is refused with the usage and the message both.
+#[test]
+fn a_name_that_does_not_resolve_is_refused_with_the_usage() {
+    let text = golden();
+    for (case, name) in [
+        ("unknown-name", "NoSuchToolAtAll"),
+        ("deprecated-name", "IndelRealigner"),
+    ] {
+        let (out, err) = shape(&text, case);
+        let written = gatk_cli::run(&args(&[name]));
+        assert_eq!(counted(&written.stdout), (out.0, out.1), "{case}");
+        // The refusal goes to stderr, starting with the usage's own first line.
+        assert_eq!(counted(&written.stderr).1, err.1, "{case}");
+        assert_eq!(
+            written.status,
+            main_entry::exit_status(Failure::User),
+            "{case}"
+        );
+        // And the message under it is the reference's, word for word.
+        let message = field(&text, "error", case)
+            .split_once("UserException:")
+            .expect("the exception")
+            .1
+            .to_string();
+        assert!(written.stderr.contains(&message), "{case}");
+    }
+}
+
+/// The two handlers write what the golden says they write.
+#[test]
+fn the_handlers_are_the_reference_ones() {
+    let text = golden();
+    let mut printed = String::new();
+    for result in [None, Some("0"), Some("a string")] {
+        if let Some(line) = main_entry::tool_returned(result) {
+            printed.push_str(&line);
+            printed.push('\n');
+        }
+    }
+    assert_eq!(printed, field(&text, "out", "handlers"));
+    assert_eq!(
+        main_entry::user_exception_report("the message a refusal carries"),
+        field(&text, "err", "handlers")
+    );
+}
+
+/// A tool this port cannot run yet refuses in its own words, and says so.
+#[test]
+fn a_tool_this_port_cannot_run_refuses_in_its_own_words() {
+    let text = golden();
+    let written = gatk_cli::run(&args(&["CountReads"]));
+    // The reference gets past the dispatch here and is refused by the PARSER, which is status one
+    // and a CommandLineException. This port has no declarations to parse against yet, so it stops
+    // one step earlier, and its refusal carries neither that status nor that message.
+    let reference = field(&text, "error", "gatk-tool-no-arguments");
+    assert!(reference.contains("Argument input was missing"));
+    assert!(!written.stderr.contains("Argument input was missing"));
+    assert_ne!(
+        written.status,
+        main_entry::exit_status(Failure::CommandLine)
+    );
+    assert!(written.stderr.contains("this port does not carry yet"));
+    // What IS the reference's is the step before: the name resolved, so the dispatcher did not
+    // refuse it the way it refuses a name that does not.
+    assert!(!written.stderr.contains("is not a valid command"));
+    assert!(gatk_cli::runner("CountReads").is_none());
+}


### PR DESCRIPTION
`gatk-rs <Tool> <args>` exists. The crate is `gatk-cli`, the binary is `gatk-rs`, and the six tests compare it against the `main-entry` golden: the five exit statuses, the usage going to stdout and being a success, the version being four lines wherever on the command line it was asked for, a name that does not resolve costing status two with the reference's own message, and the two handlers.

Two boundaries, both asserted rather than described:

* the main usage listing needs every tool's one-line summary, which is in no golden, so the test compares the first line and the stream and explicitly does not compare the line count;
* a tool needs a Barclay definition per argument, which the declarations golden does not carry yet (gatk-rs#980 measures it), so `gatk-rs CountReads` refuses in the port's own words. The test asserts that refusal is *not* the reference's: not its status, not its message.

The binary is named `gatk-rs` rather than `gatk` on purpose: a port that answered to `gatk` on a PATH would be a trap for anyone comparing the two.

Part of gatk-rs issue 818.