### PR TITLE
Measure the enum-valued arguments and their constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,10 @@ jobs:
             index: "57/57"
             slug: "tool-argument-declarations-usage-text-bwa-index-image"
             suites: "tool-argument-declarations usage-text bwa-index-image"
+          - group: golden-pending
+            index: "1/1"
+            slug: "tool-argument-enums"
+            suites: "tool-argument-enums"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -128,7 +128,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `AnnotateIntervals` | cnv-segmentation | oracle-backed | annotate-intervals | 1 | not measured |
 | `AnnotateVcfWithBamDepth` | variant-walker | oracle-backed | annotate-vcf-with-bam-depth | 1 | not measured |
 | `AnnotateVcfWithExpectedAlleleFraction` | variant-walker | oracle-backed | annotate-vcf-with-expected-allele-fraction | 1 | not measured |
-| `ApplyBQSR` | record-transform | oracle-backed | apply-bqsr, tool-argument-declarations | 2 | not measured |
+| `ApplyBQSR` | record-transform | oracle-backed | apply-bqsr, tool-argument-declarations, tool-argument-enums | 3 | not measured |
 | `ApplyVQSR` | variant-transform | oracle-backed | apply-vqsr-allele-specific, apply-vqsr-site-filtering, apply-vqsr-tranches, apply-vqsr-two-modes | 4 | not measured |
 | `BaseRecalibrator` | record-transform | oracle-backed | base-recalibrator | 1 | not measured |
 | `BwaMemIndexImageCreator` | reference-utility | oracle-backed | bwa-index-image | 1 | not measured |
@@ -159,8 +159,8 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountBases` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
 | `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
-| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers, tool-argument-declarations, usage-text | 4 | not measured |
-| `CountVariants` | variant-walker | oracle-backed | count-variants, tool-argument-declarations | 2 | not measured |
+| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers, tool-argument-declarations, tool-argument-enums, usage-text | 5 | not measured |
+| `CountVariants` | variant-walker | oracle-backed | count-variants, tool-argument-declarations, tool-argument-enums | 3 | not measured |
 | `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | not measured |
 | `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |
@@ -189,7 +189,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GatherNormalArtifactData` | unclassified | oracle-backed | mutect-gathers | 1 | not measured |
 | `GatherPileupSummaries` | unclassified | oracle-backed | mutect-gathers | 1 | not measured |
 | `GatherTranches` | unclassified | oracle-backed | gather-tranches | 1 | not measured |
-| `GatherVcfsCloud` | variant-transform | oracle-backed | gather-vcfs, tool-argument-declarations, usage-text | 3 | not measured |
+| `GatherVcfsCloud` | variant-transform | oracle-backed | gather-vcfs, tool-argument-declarations, tool-argument-enums, usage-text | 4 | not measured |
 | `GeneExpressionEvaluation` | locus-walker | oracle-backed | gene-expression-evaluation | 1 | not measured |
 | `GenotypeGVCFs` | assembly-caller | oracle-backed | genotype-gvcfs | 1 | not measured |
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |
@@ -201,7 +201,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GroupedSVCluster` | sv-caller | oracle-backed | grouped-sv-cluster | 1 | not measured |
 | `GtfToBed` | assembly-caller | oracle-backed | gtf-to-bed | 1 | not measured |
 | `HaplotypeBasedVariantRecaller` | assembly-caller | oracle-backed | haplotype-based-variant-recaller | 1 | not measured |
-| `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file, tool-argument-declarations, usage-text | 3 | not measured |
+| `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file, tool-argument-declarations, tool-argument-enums, usage-text | 4 | not measured |
 | `JointGermlineCNVSegmentation` | sv-caller | oracle-backed | joint-germline-cnv-segmentation | 1 | not measured |
 | `LearnReadOrientationModel` | assembly-caller | oracle-backed | learn-read-orientation-model | 1 | not measured |
 | `LeftAlignAndTrimVariants` | variant-transform | oracle-backed | left-align-and-trim-variants | 1 | not measured |
@@ -224,7 +224,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `PrintDistantMates` | record-transform | oracle-backed | print-distant-mates | 1 | not measured |
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |
 | `PrintReadCounts` | sv-caller | oracle-backed | print-read-counts | 1 | not measured |
-| `PrintReads` | record-transform | oracle-backed | printreads, tool-argument-declarations | 2 | not measured |
+| `PrintReads` | record-transform | oracle-backed | printreads, tool-argument-declarations, tool-argument-enums | 3 | not measured |
 | `PrintReadsHeader` | record-transform | oracle-backed | print-reads-header | 1 | not measured |
 | `PrintSVEvidence` | unclassified | oracle-backed | print-sv-evidence | 1 | not measured |
 | `RampedHaplotypeCaller` | assembly-caller | oracle-backed | ramped-haplotype-caller | 1 | not measured |
@@ -237,7 +237,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `SVCluster` | sv-caller | oracle-backed | sv-cluster | 1 | not measured |
 | `SVConcordance` | sv-caller | oracle-backed | sv-concordance | 1 | not measured |
 | `SVStratify` | sv-caller | oracle-backed | sv-stratify | 1 | not measured |
-| `SelectVariants` | variant-transform | oracle-backed | select-variants-concordance, select-variants-filters, select-variants-output, select-variants-samples, select-variants-subset, tool-argument-declarations | 6 | not measured |
+| `SelectVariants` | variant-transform | oracle-backed | select-variants-concordance, select-variants-filters, select-variants-output, select-variants-samples, select-variants-subset, tool-argument-declarations, tool-argument-enums | 7 | not measured |
 | `ShiftFasta` | reference-utility | oracle-backed | shift-fasta | 1 | not measured |
 | `SiteDepthtoBAF` | sv-caller | oracle-backed | site-depth-to-baf | 1 | not measured |
 | `SplitCRAM` | unclassified | oracle-backed | split-cram | 1 | not measured |

--- a/tools/argument-conformance/ToolArgumentEnumDump.java
+++ b/tools/argument-conformance/ToolArgumentEnumDump.java
@@ -1,0 +1,132 @@
+/*
+ * The enum-valued arguments of the ported tools, and the constants they accept, from the reference.
+ *
+ * The declarations golden says an argument's type is `IntervalSetRule`. What it cannot say is what
+ * an `IntervalSetRule` is, and a parser needs that twice: to convert a value at all, and to write
+ * the message a bad one produces, which lists every constant in declaration order.
+ *
+ * Six behaviours this is built to catch.
+ *
+ *   - THE CONSTANTS ARE IN DECLARATION ORDER and not in any sorted one, which is what the message
+ *     prints and what `values()` returns;
+ *   - THE CONVERSION IS `Enum.valueOf` AND IS THEREFORE CASE SENSITIVE, so `union` is not `UNION`
+ *     and the refusal names both the value and the type;
+ *   - THE MESSAGE LISTS EVERY CONSTANT, which is why the list is measured rather than the count;
+ *   - AN ENUM THAT IMPLEMENTS `ClpEnum` DOCUMENTS ITS CONSTANTS, and that documentation is part of
+ *     the usage text rather than of the refusal, so the two are measured apart;
+ *   - THE SAME TYPE APPEARS UNDER MORE THAN ONE TOOL and is one type, so the table is by type and
+ *     the arguments point into it;
+ *   - AND A DEFAULT IS ONE OF THE CONSTANTS, which is what makes an unset enum argument optional.
+ *
+ * Output:
+ *
+ *     enum\t<type>\t<constants, comma separated, in declaration order>
+ *     clp\t<type>\t<constant>=<the documentation ClpEnum gives it, escaped>
+ *     arg\t<tool>\t<long name>\t<type>|<default>
+ *     parse\t<tool>\t<case>\tok|E:<exception class>:<message>
+ *
+ * Usage: ToolArgumentEnumDump
+ */
+
+import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
+import org.broadinstitute.barclay.argparser.CommandLineParser;
+import org.broadinstitute.barclay.argparser.NamedArgumentDefinition;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ToolArgumentEnumDump {
+
+    /** One entry per enum type, in the order the tools first mention it. */
+    static final Map<String, Class<?>> types = new LinkedHashMap<>();
+    static final StringBuilder args = new StringBuilder();
+
+    public static void main(final String[] args) {
+        declarations("CountReads", new org.broadinstitute.hellbender.tools.CountReads());
+        declarations("CountVariants",
+                new org.broadinstitute.hellbender.tools.walkers.CountVariants());
+        declarations("PrintReads", new org.broadinstitute.hellbender.tools.PrintReads());
+        declarations("ApplyBQSR",
+                new org.broadinstitute.hellbender.tools.walkers.bqsr.ApplyBQSR());
+        declarations("SelectVariants",
+                new org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants());
+        declarations("IndexFeatureFile",
+                new org.broadinstitute.hellbender.tools.IndexFeatureFile());
+        declarations("GatherVcfsCloud",
+                new org.broadinstitute.hellbender.tools.GatherVcfsCloud());
+
+        // The table first, then the arguments that point into it.
+        final List<String> names = new ArrayList<>(types.keySet());
+        java.util.Collections.sort(names);
+        for (final String name : names) {
+            final Class<?> type = types.get(name);
+            final List<String> constants = new ArrayList<>();
+            for (final Object constant : type.getEnumConstants()) {
+                constants.add(((Enum<?>) constant).name());
+            }
+            System.out.printf("enum\t%s\t%s%n", name, String.join(",", constants));
+            // A `ClpEnum` documents each of its constants, and that documentation is the usage
+            // text's rather than the refusal's.
+            if (CommandLineParser.ClpEnum.class.isAssignableFrom(type)) {
+                for (final Object constant : type.getEnumConstants()) {
+                    System.out.printf("clp\t%s\t%s=%s%n", name, ((Enum<?>) constant).name(),
+                            escape(((CommandLineParser.ClpEnum) constant).getHelpDoc()));
+                }
+            }
+        }
+        System.out.print(ToolArgumentEnumDump.args);
+
+        // What a value the enum does not carry costs, which is where the constants are printed.
+        parse("CountReads", "a-constant", new String[]{"-I", "/dev/null", "-isr", "UNION"});
+        parse("CountReads", "the-other-constant",
+                new String[]{"-I", "/dev/null", "-isr", "INTERSECTION"});
+        parse("CountReads", "lower-case", new String[]{"-I", "/dev/null", "-isr", "union"});
+        parse("CountReads", "not-a-constant", new String[]{"-I", "/dev/null", "-isr", "NEITHER"});
+        parse("CountReads", "an-empty-value", new String[]{"-I", "/dev/null", "-isr", ""});
+        // A second type, so the message is not one type's own shape.
+        parse("CountReads", "a-stringency",
+                new String[]{"-I", "/dev/null", "-VS", "LENIENT"});
+        parse("CountReads", "not-a-stringency",
+                new String[]{"-I", "/dev/null", "-VS", "PERMISSIVE"});
+    }
+
+    /** Every enum-valued argument of one tool, and the type it points at. */
+    static void declarations(final String tool, final Object target) {
+        final List<NamedArgumentDefinition> definitions =
+                ((CommandLineArgumentParser) ((org.broadinstitute.hellbender.cmdline
+                        .CommandLineProgram) target).getCommandLineParser())
+                        .getNamedArgumentDefinitions();
+        for (final NamedArgumentDefinition definition : definitions) {
+            final Class<?> type = definition.getUnderlyingFieldClass();
+            if (!type.isEnum()) {
+                continue;
+            }
+            types.putIfAbsent(type.getSimpleName(), type);
+            args.append(String.format("arg\t%s\t%s\t%s|%s%n", tool, definition.getLongName(),
+                    type.getSimpleName(),
+                    escape(String.valueOf(definition.getDefaultValueAsString()))));
+        }
+    }
+
+    static String escape(final String text) {
+        return text.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n");
+    }
+
+    /** What the parser makes of one command line, before the tool runs at all. */
+    static void parse(final String tool, final String label, final String[] argv) {
+        final Object target = new org.broadinstitute.hellbender.tools.CountReads();
+        String result;
+        try {
+            final PrintStream sink = new PrintStream(new ByteArrayOutputStream());
+            result = ((org.broadinstitute.hellbender.cmdline.CommandLineProgram) target)
+                    .getCommandLineParser().parseArguments(sink, argv) ? "ok" : "not-parsed";
+        } catch (final Exception | AssertionError e) {
+            result = "E:" + e.getClass().getName() + ":" + e.getMessage();
+        }
+        System.out.printf("parse\t%s\t%s\t%s%n", tool, label, escape(result));
+    }
+}

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6497,6 +6497,32 @@
           "why": "Ten cases: one reference indexed twice, the same bases in lower case, a longer sequence, two contigs, a renamed contig, a run of Ns, a reference of one base, the default output name, and a fasta that is not there. Every case is built twice, and the golden records that no two builds agree."
         }
       ]
+    },
+    {
+      "id": "tool-argument-enums",
+      "status": "golden-pending",
+      "title": "the constants an enum-valued argument accepts, and what a value outside them costs",
+      "harness": "tools/argument-conformance",
+      "tools": [
+        "CountReads",
+        "CountVariants",
+        "PrintReads",
+        "ApplyBQSR",
+        "SelectVariants",
+        "IndexFeatureFile",
+        "GatherVcfsCloud"
+      ],
+      "compare": {
+        "mode": "keyed"
+      },
+      "why": "The declarations golden says an argument's type is IntervalSetRule and cannot say what one is. A parser needs the constants twice: to convert a value at all, and to write the message a bad one produces, which lists every constant in declaration order.",
+      "cases": [
+        {
+          "dump": "ToolArgumentEnumDump",
+          "golden": null,
+          "why": "One table of enum types with their constants in declaration order, the ClpEnum documentation where there is any, every enum-valued argument of the seven tools with its default, and seven command lines: two constants, a lower-case one, a value the type does not carry, an empty one, and the same pair on a second type."
+        }
+      ]
     }
   ],
   "probes": []


### PR DESCRIPTION
The declarations golden now carries an argument's type. It cannot carry what the type *is*, and a Barclay `ValueClass::Enum` needs the constants in declaration order: the conversion is `Enum.valueOf`, and the message a bad value produces lists every constant.

Nine enum types across the seven ported tools, `GatherType` through `ValidationStringency`, each with its constants in declaration order; the `ClpEnum` documentation where there is any, kept apart because it belongs to the usage text and not to the refusal; every enum-valued argument with its default; and seven command lines, including the one that says the conversion is case sensitive:

```
parse  CountReads  lower-case  E:...BadArgumentValue:Argument interval-set-rule has a bad value: union. 'union' is not a valid value for IntervalSetRule...
```

The suite is `golden-pending`: the candidate must come from the oracle job on a real x86-64 runner.

Part of gatk-rs issue 819.