### PR TITLE
Build Barclay definitions from the declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
 name = "gatk-cli"
 version = "0.1.0"
 dependencies = [
+ "gatk-barclay",
  "gatk-corpus",
  "gatk-tools",
 ]

--- a/crates/gatk-cli/Cargo.toml
+++ b/crates/gatk-cli/Cargo.toml
@@ -13,6 +13,7 @@ name = "gatk-rs"
 path = "src/main.rs"
 
 [dependencies]
+gatk-barclay = { path = "../gatk-barclay" }
 gatk-tools = { path = "../gatk-tools" }
 
 [dev-dependencies]

--- a/crates/gatk-cli/src/definitions.rs
+++ b/crates/gatk-cli/src/definitions.rs
@@ -1,0 +1,131 @@
+//! A tool's declarations, as Barclay definitions the parser can be built from.
+//!
+//! [`gatk_tools::tool_declarations`] is what the reference's own parser reports: a long name, its
+//! aliases, whether it is required, whether it is a collection, its default as the parser renders
+//! it, its type, its bounds and its documentation. [`gatk_barclay::Definition`] is what the ported
+//! parser consumes. This module is the map between them, and it is deliberately partial.
+//!
+//! # Which types convert, and which do not
+//!
+//! `ValueClass` carries the classes whose CONVERSION is measured: an integer, a double, a string,
+//! a boolean, an enum and a taggable path. The declarations name four more, and each of them
+//! converts through a constructor or a `valueOf` whose refusal names the class:
+//!
+//!  * `Float`, whose message would say `Float` where a double's says `Double`;
+//!  * `File` and `GATKPath`, which are two different classes with two different messages, one of
+//!    them taggable and the other not;
+//!  * `FeatureInput`, which is taggable and carries a feature name.
+//!
+//! None of those four is measured, so none of them is converted here: a definition this module
+//! declines to build is an argument the port cannot yet parse, which is a smaller claim than a
+//! definition built on a guessed message. [`unconvertible`] names them, and the test beside this
+//! file counts them against the declarations rather than against a number written down here.
+
+use gatk_barclay::{Annotation, Definition, Value, ValueClass};
+use gatk_tools::tool_declarations::{enum_type, Declaration};
+
+/// The classes the declarations name and this module does not convert.
+pub const UNCONVERTIBLE_CLASSES: [&str; 4] = ["FeatureInput", "File", "Float", "GATKPath"];
+
+/// Whether an argument's type is one of those.
+pub fn unconvertible(declaration: &Declaration) -> bool {
+    UNCONVERTIBLE_CLASSES.contains(&declaration.type_name)
+}
+
+/// The `ValueClass` a declared type converts through, if it is one this port has measured.
+pub fn value_class(type_name: &str) -> Option<ValueClass> {
+    match type_name {
+        "Integer" => Some(ValueClass::Integer),
+        "Double" => Some(ValueClass::Double),
+        "String" => Some(ValueClass::Text),
+        "Boolean" => Some(ValueClass::Boolean),
+        name => enum_type(name).map(|type_| ValueClass::Enum {
+            simple_name: type_.name,
+            constants: type_.constants,
+        }),
+    }
+}
+
+/// The value a constructed instance holds, rebuilt from the rendering the golden carries.
+///
+/// The rendering is `String.valueOf` on the field, so it is lossy in exactly one direction: it
+/// cannot say whether a collection was empty or null, both of which render as `null`. The
+/// reference's own `convertDefaultValueToString` collapses them the same way, so a rebuilt empty
+/// list and a rebuilt null render identically and the definition is not changed by the choice.
+pub fn initial_value(declaration: &Declaration, class: &ValueClass) -> Value {
+    if declaration.collection {
+        return Value::List(Vec::new());
+    }
+    let Some(default) = declaration.default else {
+        return Value::Null;
+    };
+    match class {
+        ValueClass::Integer => default
+            .parse::<i32>()
+            .map(Value::Int)
+            .unwrap_or(Value::Null),
+        ValueClass::Double => default
+            .parse::<f64>()
+            .map(Value::Double)
+            .unwrap_or(Value::Null),
+        ValueClass::Boolean => match default {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            _ => Value::Null,
+        },
+        ValueClass::Enum { .. } => Value::Enum(default.to_string()),
+        ValueClass::Text | ValueClass::Tagged => Value::Str(default.to_string()),
+    }
+}
+
+/// One declaration as a definition, or nothing when its class is not one this port converts.
+pub fn definition(declaration: &Declaration) -> Option<Definition> {
+    let class = value_class(declaration.type_name)?;
+    // `getArgumentAliases()` is the short name first and then the long one, so an argument with
+    // two aliases has a short name and one with a single alias does not.
+    let short_name = match declaration.aliases {
+        [short, long] if *long == declaration.long_name => *short,
+        _ => "",
+    };
+    let annotation = Annotation {
+        full_name: declaration.long_name,
+        short_name,
+        doc: declaration.doc,
+        // `isOptional()` is the annotation OR an initialised field, and what the golden carries is
+        // the answer to that question rather than the annotation's own flag. Handing the answer
+        // back as the flag reproduces the answer, which is what the parser reads.
+        optional: !declaration.required,
+        mutex: declaration.mutex,
+        min_value: declaration.min_value,
+        max_value: declaration.max_value,
+        min_recommended_value: declaration.min_recommended_value,
+        max_recommended_value: declaration.max_recommended_value,
+        suppress_file_expansion: false,
+    };
+    let initial = initial_value(declaration, &class);
+    Some(Definition::new(
+        annotation,
+        declaration.long_name,
+        class,
+        declaration.collection,
+        declaration.primitive,
+        initial,
+    ))
+}
+
+/// Every definition a tool's declarations produce, in the parser's own order.
+///
+/// The list is shorter than the declarations by the arguments whose class is not converted, and
+/// [`missing`] says which those are for a given tool.
+pub fn definitions(declarations: &[Declaration]) -> Vec<Definition> {
+    declarations.iter().filter_map(definition).collect()
+}
+
+/// The long names a tool declares that this module cannot build a definition for.
+pub fn missing(declarations: &[Declaration]) -> Vec<&'static str> {
+    declarations
+        .iter()
+        .filter(|declaration| definition(declaration).is_none())
+        .map(|declaration| declaration.long_name)
+        .collect()
+}

--- a/crates/gatk-cli/src/lib.rs
+++ b/crates/gatk-cli/src/lib.rs
@@ -22,6 +22,8 @@
 //!
 //! Ported from `org.broadinstitute.hellbender.Main`.
 
+pub mod definitions;
+
 use gatk_tools::main_entry::{self, Failure, Route, Stream};
 
 /// The reference's own pins, which `printVersionInfo` reads off the jar's manifest.
@@ -100,38 +102,76 @@ pub fn run(args: &[String]) -> Outcome {
                 status: main_entry::exit_status(Failure::User),
             }
         }
-        Route::Tool { name } => match runner(&name) {
-            None => {
-                stderr.push_str(&main_entry::user_exception_report(&not_ported(&name)));
-                Outcome {
+        Route::Tool { name } => {
+            // The parse comes before the run, and it only happens for a tool whose whole argument
+            // surface converts: a parser missing a third of its arguments would refuse a command
+            // line the reference accepts, which is a worse answer than refusing to parse at all.
+            if let Some(error) = parse_failure(&name, main_entry::tool_arguments(args)) {
+                stderr.push_str(&main_entry::user_exception_report(&error));
+                return Outcome {
                     stdout,
                     stderr,
-                    status: main_entry::exit_status(Failure::User),
-                }
+                    status: main_entry::exit_status(Failure::CommandLine),
+                };
             }
-            Some(runner) => match runner(main_entry::tool_arguments(args)) {
-                Ok(result) => {
-                    if let Some(printed) = main_entry::tool_returned(result.as_deref()) {
-                        stdout.push_str(&printed);
-                        stdout.push('\n');
-                    }
+            match runner(&name) {
+                None => {
+                    stderr.push_str(&main_entry::user_exception_report(&not_ported(&name)));
                     Outcome {
                         stdout,
                         stderr,
-                        status: 0,
+                        status: main_entry::exit_status(Failure::User),
                     }
                 }
-                Err((failure, message)) => {
-                    stderr.push_str(&main_entry::user_exception_report(&message));
-                    Outcome {
-                        stdout,
-                        stderr,
-                        status: main_entry::exit_status(failure),
+                Some(runner) => match runner(main_entry::tool_arguments(args)) {
+                    Ok(result) => {
+                        if let Some(printed) = main_entry::tool_returned(result.as_deref()) {
+                            stdout.push_str(&printed);
+                            stdout.push('\n');
+                        }
+                        Outcome {
+                            stdout,
+                            stderr,
+                            status: 0,
+                        }
                     }
-                }
-            },
-        },
+                    Err((failure, message)) => {
+                        stderr.push_str(&main_entry::user_exception_report(&message));
+                        Outcome {
+                            stdout,
+                            stderr,
+                            status: main_entry::exit_status(failure),
+                        }
+                    }
+                },
+            }
+        }
     }
+}
+
+/// Whether this port can hand a tool's command line to the ported Barclay parser at all.
+///
+/// A tool is parseable when every argument it declares converts to a definition. None of the seven
+/// tools whose declarations are carried is, today: each of them declares a `GATKPath`, and the
+/// conversion a `GATKPath` goes through is not measured. See [`definitions::UNCONVERTIBLE_CLASSES`].
+pub fn parseable(tool: &str) -> bool {
+    gatk_tools::tool_declarations::declarations(tool)
+        .map(|list| definitions::missing(list).is_empty())
+        .unwrap_or(false)
+}
+
+/// The refusal the ported parser makes of a command line, if the tool is parseable at all.
+pub fn parse_failure(tool: &str, args: &[String]) -> Option<String> {
+    if !parseable(tool) {
+        return None;
+    }
+    let list = gatk_tools::tool_declarations::declarations(tool)?;
+    let mut parser = gatk_barclay::Parser::new(definitions::definitions(list));
+    let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
+    parser
+        .parse_arguments(&borrowed)
+        .err()
+        .map(|error| error.message)
 }
 
 /// The tools this port can run, which is none of them yet.

--- a/crates/gatk-cli/tests/definitions.rs
+++ b/crates/gatk-cli/tests/definitions.rs
@@ -1,0 +1,152 @@
+//! Conformance for the declaration-to-definition map against GATK 4.6.2.0.
+//!
+//! The declarations are the reference's own parser reporting itself, and the definitions are what
+//! the ported parser consumes. This suite checks the map between them, and it checks the SIZE of
+//! the gap: four classes the reference names have no measured conversion, and every argument of
+//! those classes is a definition this port declines to build.
+//!
+//! # What this suite is for
+//!
+//!  * **a definition carrying what the declaration carries**;
+//!  * **the default rendering surviving the round trip**;
+//!  * **an enum reaching its constants**;
+//!  * **and the gap being named rather than papered over: no tool parses yet, and the reason is
+//!    one class each of them declares.**
+
+use gatk_barclay::{Parser, ValueClass};
+use gatk_cli::definitions::{
+    definition, definitions, missing, unconvertible, UNCONVERTIBLE_CLASSES,
+};
+use gatk_tools::tool_declarations::{declarations, Declaration, COUNTREADS, INDEXFEATUREFILE};
+
+fn find<'a>(list: &'a [Declaration], name: &str) -> &'a Declaration {
+    list.iter()
+        .find(|declaration| declaration.long_name == name)
+        .unwrap_or_else(|| panic!("{name}"))
+}
+
+/// A definition carries the declaration's own answers, not a second reading of them.
+#[test]
+fn a_definition_carries_the_declaration() {
+    let input = find(COUNTREADS, "interval-set-rule");
+    let built = definition(input).expect("a definition");
+    assert_eq!(built.long_name(), "interval-set-rule");
+    // `getArgumentAliases()` is the short name first and then the long one, which is what an
+    // error message names the argument by.
+    assert_eq!(built.alias_display_string(), "isr/interval-set-rule");
+    // The default survives the round trip through the value, which is what decides optionality.
+    assert_eq!(built.default_value_as_string(), "UNION");
+    assert!(built.is_optional());
+    // An enum reaches its constants, which is what the conversion and the refusal both need.
+    assert!(matches!(
+        built.class,
+        ValueClass::Enum {
+            simple_name: "IntervalSetRule",
+            ..
+        }
+    ));
+    // A required argument stays required, and a collection stays a collection.
+    let filters = find(COUNTREADS, "read-filter");
+    let built = definition(filters).expect("a definition");
+    assert!(built.is_collection);
+    // An initialised-but-empty collection renders as null, which is the reference's own collapse.
+    assert_eq!(built.default_value_as_string(), "null");
+    // A flag is a primitive boolean whose default is false.
+    let flag = definition(find(COUNTREADS, "disable-tool-default-read-filters")).expect("a flag");
+    assert!(flag.is_flag());
+    assert!(flag.field_is_primitive);
+    assert_eq!(flag.default_value_as_string(), "false");
+}
+
+/// The gap is four classes, and it is counted against the declarations rather than written down.
+#[test]
+fn the_gap_is_named_and_counted() {
+    for tool in [
+        "CountReads",
+        "CountVariants",
+        "PrintReads",
+        "ApplyBQSR",
+        "SelectVariants",
+        "IndexFeatureFile",
+        "GatherVcfsCloud",
+    ] {
+        let list = declarations(tool).unwrap_or_else(|| panic!("{tool}"));
+        let built = definitions(list);
+        let skipped = missing(list);
+        assert_eq!(built.len() + skipped.len(), list.len(), "{tool}");
+        // Every skipped argument is skipped for its class and for no other reason.
+        for name in &skipped {
+            let declaration = find(list, name);
+            assert!(unconvertible(declaration), "{tool}/{name}");
+        }
+        // And every one of them is one of the four classes, which is what makes the gap a list of
+        // measurements to take rather than an open question.
+        for declaration in list.iter().filter(|d| unconvertible(d)) {
+            assert!(
+                UNCONVERTIBLE_CLASSES.contains(&declaration.type_name),
+                "{tool}"
+            );
+            assert!(definition(declaration).is_none(), "{tool}");
+        }
+        // No tool is parseable yet, and the reason is the same for all seven: each declares a
+        // path, and the conversion a path goes through is not measured.
+        assert!(!gatk_cli::parseable(tool), "{tool}");
+        assert!(skipped.iter().any(|name| {
+            let declaration = find(list, name);
+            declaration.type_name == "GATKPath"
+        }));
+    }
+    // The smallest tool is the clearest: fourteen arguments, of which three are paths and one is
+    // a `File`, which is a different class with a different message and not the same gap twice.
+    assert_eq!(INDEXFEATUREFILE.len(), 14);
+    assert_eq!(
+        missing(INDEXFEATUREFILE),
+        ["input", "output", "tmp-dir", "arguments_file"]
+    );
+}
+
+/// The definitions that ARE built parse a command line the way the reference's parser does.
+#[test]
+fn the_definitions_that_are_built_parse() {
+    // A parser over the convertible half of CountReads answers about those arguments. It does not
+    // accept a command line, and the reason is worth stating: the plugin-controlled arguments the
+    // read-filter descriptor owns read as REQUIRED in the declarations, and the reference trims
+    // them before the required check runs because no filter selected them. That trim is the
+    // descriptor's, and it is not wired here, so the parser asks for an argument the reference
+    // never asks for.
+    let mut parser = Parser::new(definitions(COUNTREADS));
+    let untrimmed = parser
+        .parse_arguments(&["--interval-set-rule", "INTERSECTION"])
+        .expect_err("the plugin arguments are still required");
+    let named = COUNTREADS
+        .iter()
+        .find(|declaration| untrimmed.message.contains(declaration.long_name))
+        .expect("the refusal names an argument");
+    assert!(named.controlled_by.is_some(), "{}", untrimmed.message);
+    assert!(named.required, "{}", untrimmed.message);
+    let mut parser = Parser::new(definitions(COUNTREADS));
+    let refusal = parser
+        .parse_arguments(&["--interval-set-rule", "union"])
+        .expect_err("the refusal");
+    assert!(
+        refusal.message.contains("'union' is not a valid value"),
+        "{}",
+        refusal.message
+    );
+    // And the refusal lists the constants, which came from the second golden.
+    assert!(refusal.message.contains("UNION"), "{}", refusal.message);
+    assert!(
+        refusal.message.contains("INTERSECTION"),
+        "{}",
+        refusal.message
+    );
+    // The port refuses to hand a whole command line to that parser, because a third of the tool's
+    // arguments are missing from it: `parse_failure` says nothing rather than something wrong.
+    assert_eq!(
+        gatk_cli::parse_failure(
+            "CountReads",
+            &["--input".to_string(), "/dev/null".to_string()]
+        ),
+        None
+    );
+}


### PR DESCRIPTION
The map from a `Declaration` to a `gatk_barclay::Definition`, with both of its gaps named and asserted rather than described.

**The class gap.** Four of the classes the declarations name have no measured conversion: `Float` (whose refusal says `Float` where a double's says `Double`), `File` and `GATKPath` (two classes, two messages, one taggable and one not), and `FeatureInput`. No definition is built for an argument of those classes. Building one on a guessed message would be a larger claim than refusing to. `missing()` reports the gap per tool, and the test checks every skipped argument is skipped for its class alone: `IndexFeatureFile` skips exactly `input`, `output`, `tmp-dir` and `arguments_file`.

**The plugin gap.** The arguments a read-filter descriptor owns read as `required` in the declarations, and the reference trims them before the required check runs because no filter selected them. That trim belongs to the descriptor and is not wired, so a parser built over the convertible half asks for an argument the reference never asks for. The test asserts precisely that: the refusal names an argument that is `controlled_by` a descriptor and `required`.

Consequently `gatk-rs CountReads ...` still parses nothing, and `parseable()` returns false for all seven tools. What does work is the part that is measured: a definition carries the declaration's aliases, default, optionality and collection semantics, and an enum reaches the constants the second golden supplied, so `--interval-set-rule union` is refused with the reference's message and the constants listed.

Part of gatk-rs issue 819 and issue 818.