### PR TITLE
Take the eigensample rank out of the golden

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,20 +388,24 @@ jobs:
             suites: "extract-variant-annotations variant-recalibrator haplotype-based-variant-recaller flow-feature-mapper flow-pairhmm-align-reads-to-haplotypes"
           - group: oracle-backed
             index: "54/57"
-            slug: "calibrate-dragstr-model-analyze-saturation-mutagenesis-create-read-count-panel-of-normals-ground-truth-reads-builder-ground-truth-scorer"
-            suites: "calibrate-dragstr-model analyze-saturation-mutagenesis create-read-count-panel-of-normals ground-truth-reads-builder ground-truth-scorer"
+            slug: "calibrate-dragstr-model-analyze-saturation-mutagenesis-ground-truth-reads-builder-ground-truth-scorer-gnarly-genotyper"
+            suites: "calibrate-dragstr-model analyze-saturation-mutagenesis ground-truth-reads-builder ground-truth-scorer gnarly-genotyper"
           - group: oracle-backed
             index: "55/57"
-            slug: "gnarly-genotyper-model-segments-local-assembler-funcotator-main-dispatch"
-            suites: "gnarly-genotyper model-segments local-assembler funcotator main-dispatch"
+            slug: "model-segments-local-assembler-funcotator-main-dispatch-main-catalogue"
+            suites: "model-segments local-assembler funcotator main-dispatch main-catalogue"
           - group: oracle-backed
             index: "56/57"
-            slug: "main-catalogue-main-entry-splitting-index-allele-frequency-qc-calculate-contamination"
-            suites: "main-catalogue main-entry splitting-index allele-frequency-qc calculate-contamination"
+            slug: "main-entry-splitting-index-allele-frequency-qc-calculate-contamination-tool-argument-declarations"
+            suites: "main-entry splitting-index allele-frequency-qc calculate-contamination tool-argument-declarations"
           - group: oracle-backed
             index: "57/57"
-            slug: "tool-argument-declarations-usage-text-bwa-index-image-tool-argument-enums"
-            suites: "tool-argument-declarations usage-text bwa-index-image tool-argument-enums"
+            slug: "usage-text-bwa-index-image-tool-argument-enums"
+            suites: "usage-text bwa-index-image tool-argument-enums"
+          - group: golden-pending
+            index: "1/1"
+            slug: "create-read-count-panel-of-normals"
+            suites: "create-read-count-panel-of-normals"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -6,8 +6,8 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 
 | state | tools | share |
 |---|---:|---:|
-| oracle-backed | 227 | 73.0% |
-| golden-pending | 1 | 0.3% |
+| oracle-backed | 226 | 72.7% |
+| golden-pending | 2 | 0.6% |
 | unchecked | 0 | 0.0% |
 | not started | 83 | 26.7% |
 | **total** | **311** | |
@@ -162,7 +162,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers, tool-argument-declarations, tool-argument-enums, usage-text | 5 | not measured |
 | `CountVariants` | variant-walker | oracle-backed | count-variants, tool-argument-declarations, tool-argument-enums | 3 | not measured |
 | `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | not measured |
-| `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |
+| `CreateReadCountPanelOfNormals` | cnv-segmentation | golden-pending | create-read-count-panel-of-normals | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |
 | `DenoiseReadCounts` | cnv-segmentation | oracle-backed | denoise-read-counts | 1 | not measured |
 | `DepthOfCoverage` | locus-walker | oracle-backed | depth-of-coverage | 1 | not measured |

--- a/docs/a-rank-is-not-a-byte.md
+++ b/docs/a-rank-is-not-a-byte.md
@@ -1,0 +1,46 @@
+# A rank is not a byte
+
+`CreateReadCountPanelOfNormals` writes a panel whose last component is a basis of eigensamples,
+computed by a singular value decomposition. The dump reported how many there were. The number moved:
+
+    committed golden (produced on CI)   eigensamples=8
+    a later CI run, same image          eigensamples=6
+    this laptop, twice, same container   eigensamples=7
+
+The three numbers are three answers to the same question about the same fixture, and none of them
+is wrong. The count is the decomposition's RANK, which is the number of singular values a solver
+judged to be non-zero, and that judgement is a comparison against a tolerance made on values that
+are themselves the output of an iterative, distributed solver. Nothing in the tool's input decides
+it; the arithmetic path does.
+
+This is the third hazard of this kind the programme has hit, and they are worth naming together:
+
+  * **log4j's clock**, which is time and was masked;
+  * **BWA's index image**, whose differing bytes are in-process POINTERS
+    (`docs/pointers-that-reach-the-output.md`);
+  * and a **rank**, which is a decision about a number rather than the number itself.
+
+The first two are things the reference writes down that are not about the data. This one is
+different and more insidious: it IS about the data, it is stable enough to look reproducible, and it
+is what a reader would naturally record. The suite carried it as a golden line for weeks and only a
+re-run on a differently loaded runner showed it moving.
+
+## What the suite reports instead
+
+Two facts that do not move:
+
+  * `eigensamples-at-most`, the number of samples the panel was built from, which is the cap the
+    rank is taken under and is a count of the input;
+  * `eigensamples-positive`, whether the basis is empty at all, which is the DECISION the tool
+    makes when every singular value is zero and is what the refusal path downstream depends on.
+
+The singular values themselves were never in the golden, and their count is the same rank, so what
+is reported of them is whether the panel hands them over: a panel with no eigensamples refuses,
+which is a decision rather than a number.
+
+## The rule this leaves
+
+A number a golden holds has to be a count of something the input decides, or a value the reference
+computes by a path that has no tolerance in it. A rank, a cluster count, an iteration count and a
+convergence flag are none of those. Where one of them is the interesting fact, measure the BOUND it
+is taken under and the branch it selects, and say in the dump why the number itself is absent.

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6172,13 +6172,13 @@
     },
     {
       "id": "create-read-count-panel-of-normals",
-      "status": "oracle-backed",
+      "status": "golden-pending",
       "title": "which intervals and which samples reach the panel",
       "harness": "tools/readfilter-conformance",
       "tools": [
         "CreateReadCountPanelOfNormals"
       ],
-      "why": "The samples vary in SHAPE and not in depth, because the first thing the tool does is divide depth out again: a fixture that varied only the depth left the nine samples' median coverages agreeing to five decimal places, and which one the extreme-median filter called the maximum flipped once on CI. The medians are now separated by fourteen per cent or more, except for the one pair that is deliberately identical, which sits mid-ranking where no percentile filter reaches for it.",
+      "why": "The samples vary in SHAPE and not in depth, because the first thing the tool does is divide depth out again: a fixture that varied only the depth left the nine samples' median coverages agreeing to five decimal places, and which one the extreme-median filter called the maximum flipped once on CI. The medians are now separated by fourteen per cent or more, except for the one pair that is deliberately identical, which sits mid-ranking where no percentile filter reaches for it. The NUMBER of eigensamples is not in the golden: it is the decomposition's rank, and the same fixture answered six, seven and eight on three machines. What is carried is the cap the rank is taken under and whether the basis is empty. See docs/a-rank-is-not-a-byte.md.",
       "compare": {
         "mode": "lines"
       },

--- a/tools/readfilter-conformance/CreateReadCountPanelOfNormalsDump.java
+++ b/tools/readfilter-conformance/CreateReadCountPanelOfNormalsDump.java
@@ -28,8 +28,10 @@
  *   - THE PANEL KEEPS BOTH THE ORIGINAL INTERVALS AND THE SURVIVING ONES, so the file says what
  *     was dropped as well as what was kept, and the ORIGINAL count is the input's whatever the
  *     filters did;
- *   - THE NUMBER OF EIGENSAMPLES IS CAPPED AT THE NUMBER OF SAMPLES THAT SURVIVED, so asking for
- *     a hundred over nine samples with two filtered out gives seven;
+ *   - THE NUMBER OF EIGENSAMPLES IS CAPPED AT THE NUMBER OF SAMPLES, and the number itself is a
+ *     RANK rather than a count of anything the tool was given: the same fixture answered six on
+ *     one runner, seven on another and eight on the machine that produced the first golden, so
+ *     what is measured is the cap and whether the basis is empty;
  *   - A PANEL OF ONE SAMPLE IS ACCEPTED, has no eigensamples, and REFUSES to hand over its
  *     singular values rather than handing over an empty array;
  *   - AND THE INPUTS MUST AGREE ON THEIR INTERVALS, one that does not being refused by name.
@@ -278,7 +280,15 @@ public class CreateReadCountPanelOfNormalsDump {
             final HDF5SVDReadCountPanelOfNormals panel = HDF5SVDReadCountPanelOfNormals.read(file);
             System.out.printf("panel\t%s\tversion=%s%n", label,
                     Double.toString(panel.getVersion()));
-            System.out.printf("panel\t%s\teigensamples=%d%n", label, panel.getNumEigensamples());
+            // The NUMBER of eigensamples is the decomposition's rank, and a rank is not a byte:
+            // the same fixture gave six here and seven on the machine that produced this golden,
+            // and eight on a third. What is reported is what does not move: the bound the number
+            // is capped at, and whether the basis is empty. See
+            // `docs/a-rank-is-not-a-byte.md`.
+            System.out.printf("panel\t%s\teigensamples-at-most=%d%n", label,
+                    panel.getOriginalReadCounts().length);
+            System.out.printf("panel\t%s\teigensamples-positive=%b%n", label,
+                    panel.getNumEigensamples() > 0);
             System.out.printf("panel\t%s\toriginal-intervals=%d%n", label,
                     panel.getOriginalIntervals().size());
             System.out.printf("panel\t%s\tpanel-intervals=%s%n", label,
@@ -287,13 +297,13 @@ public class CreateReadCountPanelOfNormalsDump {
                     panel.getOriginalReadCounts().length);
             System.out.printf("matrix\t%s\tfractional-medians=%s%n", label,
                     ReferenceQueryDump.escape(vector(panel.getPanelIntervalFractionalMedians())));
-            // The singular values are the SVD's own, computed by a distributed solver: only
-            // their COUNT is reported, the values themselves not being what this measures. A
-            // panel with no eigensamples REFUSES to hand them over rather than handing over an
-            // empty array, so the reader is asked inside its own guard.
+            // The singular values are the SVD's own, computed by a distributed solver, and their
+            // COUNT is the same rank that moves, so what is reported is whether the panel hands
+            // them over at all: one with no eigensamples REFUSES rather than handing over an
+            // empty array, which is a decision and not a number.
             try {
-                System.out.printf("panel\t%s\tsingular-values=%d%n", label,
-                        panel.getSingularValues().length);
+                System.out.printf("panel\t%s\tsingular-values-available=%b%n", label,
+                        panel.getSingularValues().length > 0);
             } catch (final Exception e) {
                 System.out.printf("error\t%s\tsingular-values\t%s:%s%n", label,
                         e.getClass().getName(),


### PR DESCRIPTION
An oracle-backed suite failed on gatk-rs#988 for a reason that has nothing to do with that PR: `create-read-count-panel-of-normals` reported `eigensamples=6` against a golden that says `8`, and this laptop says `7` twice in a row.

All three are right. The count is the SVD's **rank**: the number of singular values a distributed solver judged non-zero, which is a comparison against a tolerance on values the solver produced iteratively. Nothing in the fixture decides it, so it was never a fact about the tool.

The suite now reports what does not move:

* `eigensamples-at-most`, the number of samples the panel was built from, which is the cap the rank is taken under and a count of the input;
* `eigensamples-positive`, whether the basis is empty, which is the decision the refusal path downstream depends on;
* `singular-values-available` instead of their count, since that count is the same rank. A panel with no eigensamples refuses to hand them over, and a refusal is a decision rather than a number.

`docs/a-rank-is-not-a-byte.md` puts it beside the two hazards of its kind already hit (log4j's clock; BWA's in-process pointers) and states why this one is worse: it *is* about the data, it looks reproducible, and it is what a reader would naturally record.

The suite goes back to `golden-pending` with the stale golden still declared and committed, so the Rust test keeps passing while the new candidate is produced. gatk-rs#988 needs a rebase onto this before its own shard can go green.