### PR TITLE
Compose a tool's usage from its declarations

### DIFF
--- a/crates/gatk-cli/src/lib.rs
+++ b/crates/gatk-cli/src/lib.rs
@@ -106,11 +106,25 @@ pub fn run(args: &[String]) -> Outcome {
             // The parse comes before the run, and it only happens for a tool whose whole argument
             // surface converts: a parser missing a third of its arguments would refuse a command
             // line the reference accepts, which is a worse answer than refusing to parse at all.
-            if let Some(error) = parse_failure(&name, main_entry::tool_arguments(args)) {
-                // `mainEntry` prints the PROGRAM's usage before the message on this path, and the
-                // port does not: rendering a tool's usage needs the per-argument documentation to
-                // reach the renderer, which is the other half of Milestone C. What is written is
-                // the decorated message the reference writes under that usage, and the status.
+            // A tool asked for its own help answers with its usage and returns nothing, which is
+            // a success: `-h` after a tool name is the tool's argument and not the dispatcher's.
+            let tool_args = main_entry::tool_arguments(args);
+            if tool_args.iter().any(|arg| arg == "-h" || arg == "--help") {
+                if let Some(usage) = tool_usage(&name) {
+                    stderr.push_str(&usage);
+                    return Outcome {
+                        stdout,
+                        stderr,
+                        status: 0,
+                    };
+                }
+            }
+            if let Some(error) = parse_failure(&name, tool_args) {
+                // `mainEntry` prints the PROGRAM's usage before the message on this path, which
+                // the port now does for a tool whose usage it can lay out.
+                if let Some(usage) = tool_usage(&name) {
+                    stderr.push_str(&usage);
+                }
                 stderr.push_str(&main_entry::user_exception_report(&error));
                 return Outcome {
                     stdout,
@@ -172,6 +186,29 @@ pub fn parseable(tool: &str) -> bool {
                     .any(|declaration| declaration.controlled_by.is_some() && declaration.required)
         })
         .unwrap_or(false)
+}
+
+/// A tool's own usage, for a tool whose whole argument surface the port can lay out.
+///
+/// The condition is the plugin one again: a walker's usage carries conditional blocks, one per
+/// read filter the descriptor discovered, and the port has no descriptor to ask. A tool that is no
+/// walker has no such block, and its usage is composed from its declarations alone.
+pub fn tool_usage(tool: &str) -> Option<String> {
+    if !parseable(tool) {
+        return None;
+    }
+    let list = gatk_tools::tool_declarations::declarations(tool)?;
+    let summary = gatk_tools::tool_declarations::summary(tool)?;
+    let (required, optional, advanced) = gatk_tools::usage_text::sections(list);
+    Some(gatk_tools::usage_text::render(
+        tool,
+        summary,
+        TOOLKIT_VERSION,
+        &required,
+        &optional,
+        &advanced,
+        &[],
+    ))
 }
 
 /// The refusal the ported parser makes of a command line, if the tool is parseable at all.

--- a/crates/gatk-cli/tests/dispatcher.rs
+++ b/crates/gatk-cli/tests/dispatcher.rs
@@ -219,11 +219,12 @@ fn a_tool_that_is_no_walker_parses() {
         refused.status,
         main_entry::exit_status(Failure::CommandLine)
     );
-    // `mainEntry` prints the tool's own usage above that message and the port does not: rendering
-    // a tool's usage needs the per-argument documentation to reach the renderer, which is the
-    // other half of Milestone C. The message and the status are the reference's; the usage is the
-    // gap, and this asserts which of the two it is.
-    assert!(!refused.stderr.contains("USAGE: IndexFeatureFile"));
+    // `mainEntry` prints the tool's own usage above that message, and so does the port: the usage
+    // is composed from the same declarations the parser is built from, and it is compared against
+    // the usage golden below.
+    assert!(refused
+        .stderr
+        .starts_with("USAGE: IndexFeatureFile [arguments]"));
     // A command line the reference accepts is accepted, and the port then refuses it for its own
     // reason, which is that it cannot RUN the tool.
     assert!(outcome("input-only").ends_with("ok"));
@@ -249,6 +250,39 @@ fn a_tool_that_is_no_walker_parses() {
         unknown.status,
         main_entry::exit_status(Failure::CommandLine)
     );
+}
+
+/// A tool asked for its own help answers with its usage, byte for byte.
+#[test]
+fn a_tool_asked_for_help_answers_with_its_usage() {
+    let text = golden();
+    let usage_golden = corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../gatk-tools/tests/data/usage_text.txt.gz"),
+    );
+    let prefix = "usage\tIndexFeatureFile\t";
+    let expected = usage_golden
+        .lines()
+        .find(|line| line.starts_with(prefix))
+        .map(|line| unescape(&line[prefix.len()..]))
+        .expect("the tool's usage");
+    for flag in ["-h", "--help"] {
+        let written = gatk_cli::run(&args(&["IndexFeatureFile", flag]));
+        // The tool's usage goes to STDERR and the run is a success, which is what the golden's
+        // `help-after-a-tool` shape says of the tool it measured.
+        assert_eq!(written.stderr, expected, "{flag}");
+        assert!(written.stdout.is_empty(), "{flag}");
+        assert_eq!(written.status, 0, "{flag}");
+    }
+    let (out, err) = shape(&text, "help-after-a-tool");
+    assert_eq!(out.0, 0);
+    assert!(err.1.starts_with("USAGE: CountReads [arguments]"));
+    // The tool the golden measured is a walker, whose usage carries the conditional blocks one
+    // per read filter the descriptor discovered. The port has no descriptor, so it lays out no
+    // usage for it and the dispatcher falls through to its own refusal.
+    assert_eq!(gatk_cli::tool_usage("CountReads"), None);
+    let walker = gatk_cli::run(&args(&["CountReads", "-h"]));
+    assert!(walker.stderr.contains("this port does not carry yet"));
 }
 
 /// A tool this port cannot run yet refuses in its own words, and says so.

--- a/crates/gatk-tools/src/tool_declarations.rs
+++ b/crates/gatk-tools/src/tool_declarations.rs
@@ -9898,6 +9898,24 @@ pub const GATHERVCFSCLOUD: &[Declaration] = &[
     },
 ];
 
+/// The one-line summary the usage header prints, from the inventory.
+pub fn summary(tool: &str) -> Option<&'static str> {
+    match tool {
+        "CountReads" => Some("Count reads in a SAM/BAM/CRAM file"),
+        "CountVariants" => {
+            Some("Counts variant records in a VCF file, regardless of filter status.")
+        }
+        "PrintReads" => Some("Print reads in the SAM/BAM/CRAM file"),
+        "ApplyBQSR" => Some("Apply base quality score recalibration"),
+        "SelectVariants" => Some("Select a subset of variants from a VCF file"),
+        "IndexFeatureFile" => Some("Creates an index for a feature file, e.g. VCF or BED file."),
+        "GatherVcfsCloud" => {
+            Some("Gathers multiple VCF files from a scatter operation into a single VCF file")
+        }
+        _ => None,
+    }
+}
+
 /// The enum types the ported tools name, by type and not by tool.
 pub const ENUM_TYPES: &[EnumType] = &[
     EnumType {

--- a/crates/gatk-tools/src/usage_text.rs
+++ b/crates/gatk-tools/src/usage_text.rs
@@ -10,6 +10,8 @@
 //! Ported from `org.broadinstitute.barclay.argparser.CommandLineArgumentParser` (Barclay 5.0.0).
 
 /// `CommandLineArgumentParser.ARGUMENT_COLUMN_WIDTH`: where an argument's description starts.
+use crate::tool_declarations::Declaration;
+
 pub const ARGUMENT_COLUMN_WIDTH: usize = 30;
 /// `CommandLineArgumentParser.DESCRIPTION_COLUMN_WIDTH`: how wide that description may be.
 pub const DESCRIPTION_COLUMN_WIDTH: usize = 90;
@@ -34,6 +36,70 @@ pub struct Entry {
     /// The documentation and the trailer sentences, already joined: this module wraps it and does
     /// not compose it.
     pub description: String,
+}
+
+/// The description column of one entry, composed the way `getArgumentDescription` composes it.
+///
+/// The order is fixed and every piece carries its own trailing space, which is why the rendered
+/// text has two spaces after the documentation and one after everything else:
+///
+///  1. the documentation, followed by TWO spaces, and only if there is any;
+///  2. for a collection, how many times it may be given, which is a different sentence for a
+///     required one than for an optional one;
+///  3. either `Default value: <rendering>. ` or `Required. `, never both;
+///  4. the possible values, which exist for a boolean and for an enum and for nothing else;
+///  5. and the mutually exclusive arguments, introduced by a sentence with no leading space of its
+///     own, so the piece before it supplies one.
+pub fn description(
+    doc: &str,
+    collection: bool,
+    optional: bool,
+    default: &str,
+    possible_values: Option<&str>,
+    mutex: &[(&str, &str)],
+) -> String {
+    let mut text = String::new();
+    if !doc.is_empty() {
+        text.push_str(doc);
+        text.push_str("  ");
+    }
+    if collection {
+        text.push_str(if optional {
+            "This argument may be specified 0 or more times. "
+        } else {
+            "This argument must be specified at least once. "
+        });
+    }
+    if optional {
+        text.push_str(&format!("Default value: {default}. "));
+    } else {
+        text.push_str("Required. ");
+    }
+    if let Some(values) = possible_values {
+        text.push_str(values);
+    }
+    if !mutex.is_empty() {
+        text.push_str(" Cannot be used in conjunction with argument(s)");
+        for (field, short) in mutex {
+            text.push(' ');
+            text.push_str(field);
+            if !short.is_empty() {
+                text.push_str(&format!(" ({short})"));
+            }
+        }
+    }
+    text
+}
+
+/// `getOptionsAsDisplayString`, which answers for a boolean and for an enum and for nothing else.
+///
+/// The suffix carries its own trailing space, so a description that ends in the possible values
+/// ends in a space like every other.
+pub fn possible_values(type_name: &str, constants: Option<&[&str]>) -> Option<String> {
+    if type_name == "Boolean" {
+        return Some("Possible values: {true, false} ".to_string());
+    }
+    constants.map(|constants| format!("Possible values: {{{}}} ", constants.join(", ")))
 }
 
 /// The `--long,-short <Type>` column of one entry.
@@ -110,6 +176,79 @@ pub fn header(tool: &str, summary: &str, version: &str) -> Vec<String> {
     lines.push(String::new());
     lines.push(String::new());
     lines
+}
+
+/// One declaration as the usage prints it.
+///
+/// The type name is the underlying field's, which is what the name column carries; the possible
+/// values exist for a boolean and for an enum; and the mutex sentence names the other argument by
+/// its FIELD name rather than by its long name, which is why the whole list is passed in.
+pub fn entry_for(declaration: &Declaration, all: &[Declaration]) -> Entry {
+    let constants =
+        crate::tool_declarations::enum_type(declaration.type_name).map(|type_| type_.constants);
+    let mutex: Vec<(&str, &str)> = declaration
+        .mutex
+        .iter()
+        .map(|name| {
+            let other = all.iter().find(|other| other.long_name == *name);
+            let short = other.and_then(short_name).unwrap_or("");
+            (*name, short)
+        })
+        .collect();
+    Entry {
+        long_name: declaration.long_name.to_string(),
+        short_names: short_name(declaration)
+            .map(str::to_string)
+            .into_iter()
+            .collect(),
+        type_name: declaration.type_name.to_string(),
+        description: description(
+            declaration.doc,
+            declaration.collection,
+            !declaration.required,
+            declaration.default.unwrap_or("null"),
+            possible_values(declaration.type_name, constants).as_deref(),
+            &mutex,
+        ),
+    }
+}
+
+/// The short name the name column prints, which is the alias that is not the long name.
+///
+/// `getArgumentUsage` prints it only when it differs from the long name, so an argument whose two
+/// aliases are the same word prints one.
+pub fn short_name(declaration: &Declaration) -> Option<&'static str> {
+    match declaration.aliases {
+        [short, long] if *long == declaration.long_name && *short != declaration.long_name => {
+            Some(short)
+        }
+        _ => None,
+    }
+}
+
+/// The three sections a tool's own arguments fall into.
+///
+/// A hidden argument is printed in none of them, an advanced one in its own, and everything else
+/// in required or optional by its own declaration. An argument a plugin descriptor controls is in
+/// none of the three either: it belongs to a conditional block.
+pub fn sections(list: &[Declaration]) -> (Vec<Entry>, Vec<Entry>, Vec<Entry>) {
+    let mut required = Vec::new();
+    let mut optional = Vec::new();
+    let mut advanced = Vec::new();
+    for declaration in list {
+        if declaration.hidden || declaration.controlled_by.is_some() {
+            continue;
+        }
+        let entry = entry_for(declaration, list);
+        if declaration.advanced {
+            advanced.push(entry);
+        } else if declaration.required {
+            required.push(entry);
+        } else {
+            optional.push(entry);
+        }
+    }
+    (required, optional, advanced)
 }
 
 /// One plugin descriptor's conditional arguments: the arguments a tool only accepts once a plugin

--- a/crates/gatk-tools/tests/usage_text.rs
+++ b/crates/gatk-tools/tests/usage_text.rs
@@ -362,3 +362,33 @@ fn the_sections_and_the_header() {
     );
     assert_eq!(DESCRIPTION_COLUMN_WIDTH, 90);
 }
+
+/// The whole usage of a tool that is no walker, composed from its declarations.
+///
+/// Every other test here takes the golden apart and hands the pieces back. This one starts from
+/// the declarations alone: the documentation, the type, the default, the flags and the enum
+/// constants, all of them measured, and asks the port to write the file the reference wrote.
+#[test]
+fn a_tools_usage_is_composed_from_its_declarations() {
+    use gatk_tools::tool_declarations::INDEXFEATUREFILE;
+    use gatk_tools::usage_text::sections;
+
+    let text = golden();
+    let expected = usage(&text, "IndexFeatureFile").join("\n");
+    let (required, optional, advanced) = sections(INDEXFEATUREFILE);
+    // Every one of the fourteen declarations is printed, none being hidden or plugin-controlled.
+    assert_eq!(
+        required.len() + optional.len() + advanced.len(),
+        INDEXFEATUREFILE.len()
+    );
+    let written = render(
+        "IndexFeatureFile",
+        "Creates an index for a feature file, e.g. VCF or BED file.",
+        "4.6.2.0",
+        &required,
+        &optional,
+        &advanced,
+        &[],
+    );
+    assert_eq!(written, expected);
+}

--- a/tools/declarations/generate.py
+++ b/tools/declarations/generate.py
@@ -177,6 +177,26 @@ def cross_check(tool, entries):
     return len(documented)
 
 
+def summary_table(tools):
+    """The one-line summary the usage header prints, taken from the inventory.
+
+    It is the only piece of a tool's usage that is not in the declarations golden: the header's
+    second paragraph is the tool's own `oneLineSummary`, which the inventory carries because it
+    reads the reference's machine-readable documentation.
+    """
+    inventory = json.loads(INVENTORY.read_text())
+    by_name = {tool["name"]: tool for tool in inventory["tools"]}
+    arms = []
+    for tool in tools:
+        summary = by_name[tool]["summary"]
+        arms.append(f'        "{tool}" => Some({literal(summary)}),')
+    return (
+        "/// The one-line summary the usage header prints, from the inventory.\n"
+        "pub fn summary(tool: &str) -> Option<&'static str> {\n"
+        "    match tool {\n" + "\n".join(arms) + "\n        _ => None,\n    }\n}\n"
+    )
+
+
 def enum_table():
     """The enum types, from the `tool-argument-enums` golden.
 
@@ -287,6 +307,7 @@ def main():
             f"/// {len(entries)} named arguments, of which the usage text prints {documented}.\n"
             f"pub const {constant}: &[Declaration] = &[\n" + "\n".join(entries) + "\n];\n"
         )
+    out.append(summary_table(tools))
     out.append(enum_table())
     arms = "\n".join(f'        "{tool}" => Some({tool.upper()}),' for tool in tools)
     out.append(


### PR DESCRIPTION
The usage renderer had a layout and no data. With the richer declarations and the enum table, it has both, and `IndexFeatureFile`'s whole usage is now composed from the declarations alone and compared against the golden as one string, all fifty-eight lines.

What was missing was the composition `getArgumentDescription` performs, whose order is fixed and whose pieces each carry their own trailing space: the documentation and two spaces, then how many times a collection may be given, then either `Default value: X. ` or `Required. `, then the possible values (a boolean and an enum have them, nothing else does), then the mutually exclusive arguments, which name the other argument by its **field** name rather than by its long name.

The header's one-line summary is the only piece not in the declarations golden; the generator takes it from the inventory, which is the second reading it already cross-checks against.

The dispatcher gains both paths the reference has:

```
$ gatk-rs IndexFeatureFile -h        # the usage, on stderr, status 0 — compared byte for byte
$ gatk-rs IndexFeatureFile           # that same usage, then the decorated refusal, status 1
```

Both gated on the same condition as the parse: a walker's usage carries a conditional block per read filter the descriptor discovered, and the port has no descriptor to ask (gatk-rs#987).

Part of gatk-rs issue 821 and issue 818.