### PR TITLE
Run IndexFeatureFile from the command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "gatk-barclay",
  "gatk-corpus",
  "gatk-tools",
+ "htsjdk-bgzf",
 ]
 
 [[package]]

--- a/crates/gatk-cli/Cargo.toml
+++ b/crates/gatk-cli/Cargo.toml
@@ -15,6 +15,9 @@ path = "src/main.rs"
 [dependencies]
 gatk-barclay = { path = "../gatk-barclay" }
 gatk-tools = { path = "../gatk-tools" }
+# The file plumbing under a runner: a block-compressed input is decompressed before the port's own
+# function is handed its text.
+htsjdk-bgzf.workspace = true
 
 [dev-dependencies]
 gatk-corpus = { path = "../gatk-corpus" }

--- a/crates/gatk-cli/src/lib.rs
+++ b/crates/gatk-cli/src/lib.rs
@@ -23,6 +23,7 @@
 //! Ported from `org.broadinstitute.hellbender.Main`.
 
 pub mod definitions;
+pub mod runners;
 
 use gatk_tools::main_entry::{self, Failure, Route, Stream};
 
@@ -225,13 +226,28 @@ pub fn parse_failure(tool: &str, args: &[String]) -> Option<String> {
         .map(|error| error.message)
 }
 
-/// The tools this port can run, which is none of them yet.
+/// The tools this port can run, which is one of them.
 ///
 /// A name that resolves and has no runner is not a name that does not resolve: the reference would
 /// have run it, and saying so is the honest answer. What it is NOT is a refusal the reference
 /// makes, which is why [`not_ported`] says whose refusal it is.
-pub fn runner(_name: &str) -> Option<Runner> {
-    None
+pub fn runner(name: &str) -> Option<Runner> {
+    match name {
+        "IndexFeatureFile" => Some(run_index_feature_file),
+        _ => None,
+    }
+}
+
+/// The one runner, which needs the parsed command line rather than the raw one.
+fn run_index_feature_file(args: &[String]) -> Result<Option<String>, (Failure, String)> {
+    let list = gatk_tools::tool_declarations::declarations("IndexFeatureFile")
+        .expect("the declarations of a tool with a runner");
+    let mut parser = gatk_barclay::Parser::new(definitions::definitions(list));
+    let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
+    parser
+        .parse_arguments(&borrowed)
+        .map_err(|error| (Failure::CommandLine, error.message))?;
+    runners::index_feature_file(&parser)
 }
 
 /// The port's own refusal, which the reference has no equivalent of.

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -1,0 +1,96 @@
+//! The tools this port can run, and the file plumbing under them.
+//!
+//! A port's own API takes and returns bytes: `index_feature_file::build` is handed a whole file as
+//! a `&str` and answers with the index as a `Vec<u8>`, which is what a conformance suite comparing
+//! whole outputs against a golden wants. A command line wants neither: it names paths, and
+//! something has to read one and write the other.
+//!
+//! That something is here rather than in the port, deliberately. The suite's claim is about the
+//! bytes, and a `std::fs::read` in the middle of the ported function would put the filesystem
+//! inside the thing being compared.
+//!
+//! Ported from `org.broadinstitute.hellbender.tools.IndexFeatureFile`.
+
+use gatk_barclay::{Parser, Value};
+use gatk_tools::index_feature_file::{self, Refusal, Source};
+use gatk_tools::main_entry::Failure;
+
+/// What a runner answers: what the tool returned, or the failure and its message.
+pub type Outcome = Result<Option<String>, (Failure, String)>;
+
+/// The value of one named argument, as the parser left it.
+///
+/// A path argument holds a `Tagged` value, whose tag is `None` when nobody wrote one; a plain
+/// string argument holds a `Str`. Both are read the same way here because the tool wants the path
+/// and not the tag.
+pub fn argument(parser: &Parser, long_name: &str) -> Option<String> {
+    parser
+        .definitions()
+        .iter()
+        .find(|definition| definition.long_name() == long_name)
+        .and_then(|definition| match &definition.value {
+            Value::Tagged { value, .. } => Some(value.clone()),
+            Value::Str(text) => Some(text.clone()),
+            _ => None,
+        })
+}
+
+/// `IndexFeatureFile.doWork`, with the two paths read and written.
+///
+/// The reference returns the index's path, which `handleResult` then prints, so this returns it
+/// too. Every refusal is the port's own [`Refusal`], and each of them is a `UserException`, which
+/// is status two.
+pub fn index_feature_file(parser: &Parser) -> Outcome {
+    let input = argument(parser, "input").ok_or_else(|| {
+        (
+            Failure::CommandLine,
+            "Argument input was missing: Argument 'input' is required".to_string(),
+        )
+    })?;
+    let output = argument(parser, "output");
+    let refused = |refusal: Refusal| (Failure::User, refusal.message());
+    // The reference reads the file to find a codec for it, so a file that is not there is refused
+    // before anything else is asked of it.
+    let bytes = std::fs::read(&input).map_err(|_| {
+        refused(Refusal::CouldNotReadInputFile {
+            path: input.clone(),
+        })
+    })?;
+    let text = decode(&bytes, &input).map_err(refused)?;
+    let name = output
+        .clone()
+        .unwrap_or_else(|| index_feature_file::default_output(&input));
+    index_feature_file::check_output(&input, &name, &input).map_err(refused)?;
+    // The header records the file's own identity, and its timestamp with it: a caller that wants
+    // the reference's bytes has to supply the real one, which is what this does.
+    let mut source = Source::new(&input);
+    source.timestamp = modified_millis(&input);
+    let index = index_feature_file::build(&text, &source, &input).map_err(refused)?;
+    std::fs::write(&name, index)
+        .map_err(|error| (Failure::Other, format!("could not write {name}: {error}")))?;
+    Ok(Some(name))
+}
+
+/// The file's text, decompressed when the name says it is block compressed.
+fn decode(bytes: &[u8], path: &str) -> Result<String, Refusal> {
+    let raw = if path.ends_with(".gz") {
+        htsjdk_bgzf::read::decompress_all(bytes).map_err(|_| Refusal::NoSuitableCodecs {
+            path: path.to_string(),
+        })?
+    } else {
+        bytes.to_vec()
+    };
+    String::from_utf8(raw).map_err(|_| Refusal::NoSuitableCodecs {
+        path: path.to_string(),
+    })
+}
+
+/// `File.lastModified()` in milliseconds, which the index header carries.
+fn modified_millis(path: &str) -> i64 {
+    std::fs::metadata(path)
+        .and_then(|data| data.modified())
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|since| since.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/crates/gatk-cli/tests/dispatcher.rs
+++ b/crates/gatk-cli/tests/dispatcher.rs
@@ -225,12 +225,17 @@ fn a_tool_that_is_no_walker_parses() {
     assert!(refused
         .stderr
         .starts_with("USAGE: IndexFeatureFile [arguments]"));
-    // A command line the reference accepts is accepted, and the port then refuses it for its own
-    // reason, which is that it cannot RUN the tool.
+    // A command line the reference accepts is accepted, and the tool then RUNS: `/dev/null` is a
+    // file the parser is happy with and no codec claims, so the refusal that comes back is the
+    // tool's own and not the parser's.
     assert!(outcome("input-only").ends_with("ok"));
     let accepted = gatk_cli::run(&args(&["IndexFeatureFile", "-I", "/dev/null"]));
     assert!(!accepted.stderr.contains("Argument input was missing"));
-    assert!(accepted.stderr.contains("this port does not carry yet"));
+    assert!(
+        accepted.stderr.contains("because no suitable codecs found"),
+        "{}",
+        accepted.stderr
+    );
     assert_eq!(accepted.status, main_entry::exit_status(Failure::User));
     // And an argument the tool does not declare is refused by the parser, as the golden says.
     assert!(outcome("an-interval").contains("not a recognized option"));

--- a/crates/gatk-cli/tests/index_feature_file_end_to_end.rs
+++ b/crates/gatk-cli/tests/index_feature_file_end_to_end.rs
@@ -1,0 +1,158 @@
+//! The first tool this port runs from a command line, end to end.
+//!
+//! The bytes of the index are compared against the golden by
+//! `gatk-tools/tests/index_feature_file.rs`, which hands the ported function the fixture's text.
+//! What this suite is for is the layer between that function and a command line: reading the named
+//! file, deciding what to call the output, writing it, and returning the path the reference
+//! returns.
+//!
+//! # What this suite is for
+//!
+//!  * **the file plumbing: a path in, a file out, and the name the reference chose**;
+//!  * **the source the header records, which is the input's own path and timestamp**;
+//!  * **the refusals reaching the dispatcher as the reference's statuses**;
+//!  * **and `handleResult` printing the path the tool returned.**
+
+use gatk_corpus as corpus;
+use gatk_tools::index_feature_file::{build, default_output, Source};
+use gatk_tools::main_entry::{self, Failure};
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../gatk-tools/tests/data/index_feature_file.txt.gz"),
+    )
+}
+
+fn bytes(text: &str, kind: &str, label: &str) -> Vec<u8> {
+    let prefix = format!("{kind}\t{label}\t");
+    let encoded = text
+        .lines()
+        .find(|line| line.starts_with(&prefix))
+        .map(|line| line[prefix.len()..].to_string())
+        .unwrap_or_else(|| panic!("{kind}/{label}"));
+    corpus::decode_base64(&encoded)
+}
+
+fn args(list: &[&str]) -> Vec<String> {
+    list.iter().map(|arg| (*arg).to_string()).collect()
+}
+
+/// A directory of this test's own, named after the case so two cases cannot collide.
+fn scratch(case: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("gatk-cli-{case}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("a scratch directory");
+    dir
+}
+
+/// The tool writes the index the port builds, under the name the reference chose.
+#[test]
+fn the_index_is_written_beside_its_input() {
+    let text = golden();
+    let dir = scratch("plain");
+    let input = dir.join("reads.vcf");
+    std::fs::write(&input, bytes(&text, "input", "plain")).expect("the fixture");
+    let path = input.to_string_lossy().to_string();
+
+    let written = gatk_cli::run(&args(&["IndexFeatureFile", "-I", &path]));
+    assert_eq!(written.status, 0, "{}", written.stderr);
+    // `handleResult` prints what the tool returned, which is the index's path.
+    let expected_output = default_output(&path);
+    assert_eq!(
+        written.stdout,
+        format!("Tool returned:\n{expected_output}\n")
+    );
+    // Which is the same name the golden recorded, once the dump's directory is put back.
+    let recorded = golden()
+        .lines()
+        .find(|line| line.starts_with("returned\tplain\t"))
+        .map(|line| line["returned\tplain\t".len()..].to_string())
+        .expect("the returned path");
+    assert_eq!(recorded, "<dir>/reads.vcf.idx");
+    assert!(expected_output.ends_with("reads.vcf.idx"));
+
+    // The file exists, and it is the bytes the port builds for that source: the path and the
+    // timestamp the header records are the input file's own, which is what the plumbing is for.
+    let produced = std::fs::read(&expected_output).expect("the index");
+    let mut source = Source::new(&path);
+    source.timestamp = std::fs::metadata(&input)
+        .and_then(|data| data.modified())
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|since| since.as_millis() as i64)
+        .expect("a timestamp");
+    let text_in = String::from_utf8(bytes(&text, "input", "plain")).expect("a text fixture");
+    let expected = build(&text_in, &source, &path).expect("the index");
+    assert_eq!(produced, expected);
+    // And the timestamp is NOT zero, which is what says the plumbing read it rather than leaving
+    // the default the suite's own fixtures use.
+    assert!(source.timestamp > 0);
+}
+
+/// An explicit output is used as it is given.
+#[test]
+fn an_explicit_output_is_used_as_given() {
+    let text = golden();
+    let dir = scratch("explicit");
+    let input = dir.join("reads.vcf");
+    std::fs::write(&input, bytes(&text, "input", "plain")).expect("the fixture");
+    let output = dir.join("elsewhere.idx");
+    let written = gatk_cli::run(&args(&[
+        "IndexFeatureFile",
+        "-I",
+        &input.to_string_lossy(),
+        "-O",
+        &output.to_string_lossy(),
+    ]));
+    assert_eq!(written.status, 0, "{}", written.stderr);
+    assert!(output.exists());
+    assert!(!dir.join("reads.vcf.idx").exists());
+    assert!(written.stdout.ends_with("elsewhere.idx\n"));
+}
+
+/// A refusal reaches the dispatcher as the reference's own status and message.
+#[test]
+fn a_refusal_reaches_the_dispatcher() {
+    let text = golden();
+    let dir = scratch("absent");
+    let missing = dir.join("absent.vcf");
+    let written = gatk_cli::run(&args(&[
+        "IndexFeatureFile",
+        "-I",
+        &missing.to_string_lossy(),
+    ]));
+    // `CouldNotReadInputFile` is a UserException, which is status two and not one.
+    assert_eq!(written.status, main_entry::exit_status(Failure::User));
+    let recorded = text
+        .lines()
+        .find(|line| line.starts_with("error\tabsent\t"))
+        .expect("the golden's refusal");
+    let message = recorded
+        .split_once("CouldNotReadInputFile:")
+        .expect("the message")
+        .1;
+    assert!(
+        written
+            .stderr
+            .contains(&message.replace("<dir>", &dir.to_string_lossy())),
+        "{}",
+        written.stderr
+    );
+    // A file that exists and has no codec is a different refusal with a different message.
+    let notes = dir.join("notes.txt");
+    std::fs::write(&notes, b"nothing a codec knows\n").expect("the fixture");
+    let written = gatk_cli::run(&args(&["IndexFeatureFile", "-I", &notes.to_string_lossy()]));
+    assert_eq!(written.status, main_entry::exit_status(Failure::User));
+    assert!(
+        written.stderr.contains("because no suitable codecs found"),
+        "{}",
+        written.stderr
+    );
+    // And a command line the parser refuses is status one, before any file is opened.
+    let refused = gatk_cli::run(&args(&["IndexFeatureFile", "--no-such-argument", "1"]));
+    assert_eq!(
+        refused.status,
+        main_entry::exit_status(Failure::CommandLine)
+    );
+}


### PR DESCRIPTION
The first tool this port runs end to end.

```
$ gatk-rs IndexFeatureFile -I reads.vcf
Tool returned:
/…/reads.vcf.idx
```

What was missing was not the logic but the layer under it, which is Milestone C.3: `index_feature_file::build` is handed a whole file as a `&str` and answers with the index as bytes, which is right for a suite comparing whole outputs against a golden and is not what a command line names.

That layer lives in `gatk-cli` and not in the port, deliberately. The suite's claim is about the bytes, and a `std::fs::read` inside the ported function would put the filesystem inside the thing being compared.

The index header records the input's own path **and** its last-modified time, so the runner reads that time rather than leaving the zero the suite's fixtures use; the test asserts both that the written file equals what the port builds for that source and that the timestamp is not zero.

Refusals arrive as the reference's statuses: `CouldNotReadInputFile` is a `UserException` at status two, where a parse failure is a `CommandLineException` at status one.

Part of gatk-rs issue 818 and issue 820.