### PR TITLE
Commit the first argument-coverage number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,7 @@ jobs:
       - name: Run the array against both sides
         run: |
           python3 tools/coverage/measure.py --tool IndexFeatureFile \
-            --port target/release/gatk-rs
+            --port target/release/gatk-rs --corpus-dir /tmp/coverage-corpus
 
       - name: The committed measurement is the one this run produces
         # Same rule as a golden: the number in the tree has to be the number CI re-derives, or the
@@ -469,11 +469,15 @@ jobs:
         run: git --no-pager diff --stat tools/coverage/measured.json
 
       - name: Publish what the run measured
+        # The corpus goes with the number, and not as decoration: a share of 5/6 says a row
+        # diverged and says nothing about which, and the corpus is where that is read.
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: candidate-coverage
-          path: tools/coverage/measured.json
+          path: |
+            tools/coverage/measured.json
+            /tmp/coverage-corpus/
           if-no-files-found: ignore
 
   inventory:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -201,7 +201,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GroupedSVCluster` | sv-caller | oracle-backed | grouped-sv-cluster | 1 | not measured |
 | `GtfToBed` | assembly-caller | oracle-backed | gtf-to-bed | 1 | not measured |
 | `HaplotypeBasedVariantRecaller` | assembly-caller | oracle-backed | haplotype-based-variant-recaller | 1 | not measured |
-| `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file, tool-argument-declarations, tool-argument-enums, usage-text | 4 | not measured |
+| `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file, tool-argument-declarations, tool-argument-enums, usage-text | 4 | t=2, 5/6 rows (83%) |
 | `JointGermlineCNVSegmentation` | sv-caller | oracle-backed | joint-germline-cnv-segmentation | 1 | not measured |
 | `LearnReadOrientationModel` | assembly-caller | oracle-backed | learn-read-orientation-model | 1 | not measured |
 | `LeftAlignAndTrimVariants` | variant-transform | oracle-backed | left-align-and-trim-variants | 1 | not measured |

--- a/tools/conformance/ci.template.yml
+++ b/tools/conformance/ci.template.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Run the array against both sides
         run: |
           python3 tools/coverage/measure.py --tool IndexFeatureFile \
-            --port target/release/gatk-rs
+            --port target/release/gatk-rs --corpus-dir /tmp/coverage-corpus
 
       - name: The committed measurement is the one this run produces
         # Same rule as a golden: the number in the tree has to be the number CI re-derives, or the
@@ -174,11 +174,15 @@ jobs:
         run: git --no-pager diff --stat tools/coverage/measured.json
 
       - name: Publish what the run measured
+        # The corpus goes with the number, and not as decoration: a share of 5/6 says a row
+        # diverged and says nothing about which, and the corpus is where that is read.
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: candidate-coverage
-          path: tools/coverage/measured.json
+          path: |
+            tools/coverage/measured.json
+            /tmp/coverage-corpus/
           if-no-files-found: ignore
 
   inventory:

--- a/tools/coverage/measure.py
+++ b/tools/coverage/measure.py
@@ -54,15 +54,24 @@ def main(argv):
     parser.add_argument("--tool", action="append", required=True)
     parser.add_argument("--port", required=True, help="the linux/amd64 port binary")
     parser.add_argument("--t", type=int, default=2)
+    parser.add_argument(
+        "--corpus-dir",
+        help="where to write each tool's row-by-row corpus, which is what a divergence is read from",
+    )
     options = parser.parse_args(argv)
 
     tools = {}
     for tool in options.tool:
+        command = [
+            sys.executable, str(RUNNER), "--tool", tool,
+            "--t", str(options.t), "--port", options.port,
+        ]
+        if options.corpus_dir:
+            corpus = Path(options.corpus_dir)
+            corpus.mkdir(parents=True, exist_ok=True)
+            command += ["--corpus", str(corpus / f"{tool}.t{options.t}.txt")]
         result = subprocess.run(
-            [
-                sys.executable, str(RUNNER), "--tool", tool,
-                "--t", str(options.t), "--port", options.port,
-            ],
+            command,
             capture_output=True,
             text=True,
         )

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -1,0 +1,23 @@
+{
+  "$comment": [
+    "Produced by tools/coverage/measure.py from run_array.py's own summary, in the pinned",
+    "container on real x86-64. `share` is the fraction of the array's rows on which the port",
+    "answered exactly as the reference did, refusals included.",
+    "",
+    "It is not a byte-identity claim over the argument surface: an array covers PAIRS of argument",
+    "values, and `distinct_outputs` says how many of those pairs the corpus can actually observe.",
+    "A tool whose accepted rows all produce one output has an array that covers its arguments",
+    "without testing them."
+  ],
+  "tools": {
+    "IndexFeatureFile": {
+      "rows": 6,
+      "accepted": 5,
+      "rejected": 1,
+      "distinct_outputs": 5,
+      "matched": 5,
+      "t": 2,
+      "share": 0.833
+    }
+  }
+}


### PR DESCRIPTION
The CI job from gatk-rs#996 produced a number, and this commits it:

```
| `IndexFeatureFile` | … | oracle-backed | … | 4 | t=2, 5/6 rows (83%) |
```

That is the first cell of the dashboard's argument-coverage column that is not `not measured`, and it is a measurement rather than a target: five of the six rows get the same answer from the port as from the reference, refusals included, and one does not.

**Which one is not in the number**, so the corpus now travels with it. A share of five in six says a row diverged and says nothing about which; the corpus is where that is read, and CI publishes both from this PR on. The next run is what names the row.

Part of gatk-rs issue 822 and issue 83.