### PR TITLE
Give the unported branch a refusal of its own

### DIFF
--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -48,7 +48,13 @@ pub fn index_feature_file(parser: &Parser) -> Outcome {
         )
     })?;
     let output = argument(parser, "output");
-    let refused = |refusal: Refusal| (Failure::User, refusal.message());
+    // Every refusal the port makes here is a UserException in the reference, EXCEPT the one the
+    // reference does not make: a tabix index this port cannot write is the port's own gap, and it
+    // is reported as one rather than as a status the reference would have exited with.
+    let refused = |refusal: Refusal| match refusal {
+        Refusal::TabixIsNotWritten { .. } => (Failure::Other, refusal.message()),
+        _ => (Failure::User, refusal.message()),
+    };
     // The reference reads the file to find a codec for it, so a file that is not there is refused
     // before anything else is asked of it.
     let bytes = std::fs::read(&input).map_err(|_| {

--- a/crates/gatk-tools/src/index_feature_file.rs
+++ b/crates/gatk-tools/src/index_feature_file.rs
@@ -68,6 +68,15 @@ pub enum Refusal {
     WrongIndexExtension { path: String },
     /// The features are not in order, which Tribble raises and the tool wraps.
     CouldNotIndexFile { path: String, detail: String },
+    /// THE PORT'S OWN refusal, which the reference never makes: a block-compressed input needs a
+    /// tabix index, and this port has no writer for one.
+    ///
+    /// It is a separate variant because the alternative was borrowing
+    /// [`Refusal::WrongIndexExtension`], and that put the reference's words on the port's gap: a
+    /// covering array run against the binary reported the two as the same answer, and the row
+    /// where the reference writes a tabix index and the port cannot read as a refusal the
+    /// reference agrees with. A gap has to say it is one.
+    TabixIsNotWritten { path: String },
 }
 
 impl Refusal {
@@ -85,6 +94,9 @@ impl Refusal {
             Refusal::CouldNotIndexFile { .. } => {
                 "org.broadinstitute.hellbender.exceptions.UserException$CouldNotIndexFile"
             }
+            // No Java class: the reference does not make this refusal, and naming one of its
+            // exceptions here would be a claim about the reference.
+            Refusal::TabixIsNotWritten { .. } => "",
         }
     }
 
@@ -102,6 +114,10 @@ impl Refusal {
             Refusal::CouldNotIndexFile { path, detail } => {
                 format!("Error while trying to create index for {path}. Error was: {detail}")
             }
+            Refusal::TabixIsNotWritten { path } => format!(
+                "{path} needs a tabix index, which this port does not write yet. This message is \
+                 the port's own and not GATK's."
+            ),
         }
     }
 }
@@ -248,8 +264,9 @@ pub fn build(text: &str, source: &Source, file_name: &str) -> Result<Vec<u8>, Re
     let (index_type, properties, contigs, interval_contigs) = match index_kind(file_name) {
         IndexKind::Tabix => {
             // The caller is expected to have taken the tabix branch itself: this port has no
-            // writer for it, and the golden records those bytes for a later brick.
-            return Err(Refusal::WrongIndexExtension {
+            // writer for it, and the golden records those bytes for a later brick. The refusal is
+            // the PORT'S own, so that nothing downstream can read it as the reference's.
+            return Err(Refusal::TabixIsNotWritten {
                 path: source.path.clone(),
             });
         }

--- a/crates/gatk-tools/tests/index_feature_file.rs
+++ b/crates/gatk-tools/tests/index_feature_file.rs
@@ -130,6 +130,33 @@ fn the_default_output_is_appended_to_the_whole_name() {
     assert_eq!(default_output("reads.vcf.gz"), "reads.vcf.gz.tbi");
 }
 
+/// The port's own refusal is not one of the reference's, and says so.
+#[test]
+fn the_tabix_branch_refuses_in_the_ports_own_words() {
+    let text = golden();
+    // The reference writes a tabix index for this input, and the golden holds those bytes.
+    assert!(!bytes(&text, "index", "compressed").is_empty());
+    // The branch is chosen by the NAME, so the plain fixture's text under the compressed
+    // fixture's name reaches it without this test having to decompress anything.
+    let ours = build(
+        &input(&text, "plain"),
+        &source("compressed"),
+        name("compressed"),
+    )
+    .expect_err("the port has no tabix writer");
+    // No Java class, because the reference makes no such refusal: naming one of its exceptions
+    // here would be a claim about the reference rather than about this port.
+    assert_eq!(ours.java_class(), "");
+    assert!(ours.message().contains("this port does not write yet"));
+    // And it is NOT the refusal the reference makes for a mismatched extension, which is what a
+    // covering array run against the binary caught: the two used to be the same variant, so a row
+    // where the reference writes an index and the port cannot read as agreement.
+    let theirs = Refusal::WrongIndexExtension {
+        path: format!("<dir>/{}", name("compressed")),
+    };
+    assert_ne!(ours.message(), theirs.message());
+}
+
 #[test]
 fn a_block_compressed_input_refuses_an_output_that_is_not_a_tbi() {
     let text = golden();


### PR DESCRIPTION
The covering array earned its keep on its first run. The one row of six that did not match:

```
arguments  5  --input=/work/fixtures/reads.vcf.gz --output=/work/out/index.tbi
reference  5  index.tbi: BINARY sha256=20f3ca0b… bytes=103
port       5  EXIT=2 A USER ERROR has occurred: The index for /work/fixtures/reads.vcf.gz must be written to a file with a ".tbi" extension
```

A block-compressed input needs a tabix index and this port has no writer for one, so `build` refused — with `WrongIndexExtension`, which is the *reference's* refusal for a mismatched output extension. The reference makes no refusal here at all: it writes the index.

Borrowing that message put the reference's words on the port's gap, and it was invisible until a row asked both sides the same question. `TabixIsNotWritten` now carries no Java class, because naming one of the reference's exceptions would be a claim about the reference, and the dispatcher reports it as the port's own failure rather than as a status the reference would have exited with.

The coverage number does not move (the row still diverges, and it should: the reference writes an index and the port does not), but it now diverges honestly.