### PR TITLE
Measure two more tools' declarations and usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,8 +400,12 @@ jobs:
             suites: "main-catalogue main-entry splitting-index allele-frequency-qc calculate-contamination"
           - group: oracle-backed
             index: "57/57"
-            slug: "tool-argument-declarations-usage-text-bwa-index-image-tool-argument-enums-tool-argument-value-classes"
-            suites: "tool-argument-declarations usage-text bwa-index-image tool-argument-enums tool-argument-value-classes"
+            slug: "bwa-index-image-tool-argument-enums-tool-argument-value-classes"
+            suites: "bwa-index-image tool-argument-enums tool-argument-value-classes"
+          - group: golden-pending
+            index: "1/1"
+            slug: "tool-argument-declarations-usage-text"
+            suites: "tool-argument-declarations usage-text"
     steps:
       - uses: actions/checkout@v7
 

--- a/tools/argument-conformance/ToolArgumentDeclarationDump.java
+++ b/tools/argument-conformance/ToolArgumentDeclarationDump.java
@@ -90,6 +90,17 @@ public class ToolArgumentDeclarationDump {
         // Picard's argument and not this tool's.
         declarations("GatherVcfsCloud",
                 new org.broadinstitute.hellbender.tools.GatherVcfsCloud());
+        // Two more tools that are no walkers, chosen because the port can RUN them: each takes a
+        // file and answers, so a declaration for one of them is a command line the binary can be
+        // handed end to end rather than only parsed.
+        //
+        // `CheckTerminatorBlock` and `BuildBamIndex` would have been two more and are not here:
+        // they are PICARD's tools, which GATK dispatches to, so their declarations come from
+        // Picard's own parser and belong in picard-rs's measurement rather than this one.
+        declarations("PrintBGZFBlockInformation",
+                new org.broadinstitute.hellbender.tools.PrintBGZFBlockInformation());
+        declarations("CreateHadoopBamSplittingIndex",
+                new org.broadinstitute.hellbender.tools.spark.CreateHadoopBamSplittingIndex());
 
         // A read walker: its own input, and the arguments it inherits.
         parse("CountReads", "no-arguments", new String[]{});

--- a/tools/argument-conformance/UsageTextDump.java
+++ b/tools/argument-conformance/UsageTextDump.java
@@ -47,6 +47,13 @@ public class UsageTextDump {
         usage("CountReads", new org.broadinstitute.hellbender.tools.CountReads());
         usage("IndexFeatureFile", new org.broadinstitute.hellbender.tools.IndexFeatureFile());
         usage("GatherVcfsCloud", new org.broadinstitute.hellbender.tools.GatherVcfsCloud());
+        // The two the port can run, whose usage the dispatcher answers `-h` with. The other two
+        // of that shape, CheckTerminatorBlock and BuildBamIndex, are Picard's and are measured
+        // there.
+        usage("PrintBGZFBlockInformation",
+                new org.broadinstitute.hellbender.tools.PrintBGZFBlockInformation());
+        usage("CreateHadoopBamSplittingIndex",
+                new org.broadinstitute.hellbender.tools.spark.CreateHadoopBamSplittingIndex());
     }
 
     /** The text the tool's own parser renders, and the two spellings that ask for it. */

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6432,7 +6432,7 @@
     },
     {
       "id": "tool-argument-declarations",
-      "status": "oracle-backed",
+      "status": "golden-pending",
       "title": "what one tool declares, and therefore which command lines it accepts",
       "harness": "tools/argument-conformance",
       "tools": [
@@ -6458,7 +6458,7 @@
     },
     {
       "id": "usage-text",
-      "status": "oracle-backed",
+      "status": "golden-pending",
       "title": "the usage text Barclay renders, which is a rendering and not prose",
       "harness": "tools/argument-conformance",
       "tools": [


### PR DESCRIPTION
The argument-coverage column covers one tool because the binary can run one tool. This measures the declarations and the usage of two more that it could run: `PrintBGZFBlockInformation` and `CreateHadoopBamSplittingIndex`, each of which takes a file and answers.

`CheckTerminatorBlock` and `BuildBamIndex` are the same shape and are deliberately absent: they are Picard's tools, which GATK dispatches to, so their declarations come from Picard's own parser and belong in picard-rs's measurement rather than this one.

Both suites go back to `golden-pending` with their stale goldens still declared and committed, so `tools/declarations/generate.py --check` and the Rust tests keep passing while the candidates are produced.