### PR TITLE
Measure the Long class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,8 +400,12 @@ jobs:
             suites: "main-catalogue main-entry splitting-index allele-frequency-qc calculate-contamination"
           - group: oracle-backed
             index: "57/57"
-            slug: "tool-argument-declarations-usage-text-bwa-index-image-tool-argument-enums-tool-argument-value-classes"
-            suites: "tool-argument-declarations usage-text bwa-index-image tool-argument-enums tool-argument-value-classes"
+            slug: "tool-argument-declarations-usage-text-bwa-index-image-tool-argument-enums"
+            suites: "tool-argument-declarations usage-text bwa-index-image tool-argument-enums"
+          - group: golden-pending
+            index: "1/1"
+            slug: "tool-argument-value-classes"
+            suites: "tool-argument-value-classes"
     steps:
       - uses: actions/checkout@v7
 

--- a/tools/argument-conformance/ToolArgumentValueClassDump.java
+++ b/tools/argument-conformance/ToolArgumentValueClassDump.java
@@ -82,6 +82,12 @@ public class ToolArgumentValueClassDump {
 
         @Argument(fullName = "feature", doc = "a FeatureInput", optional = true)
         public FeatureInput<VariantContext> feature;
+
+        @Argument(fullName = "count", shortName = "C", doc = "a Long", optional = true)
+        public Long count;
+
+        @Argument(fullName = "primitive-count", doc = "a long", optional = true)
+        public long primitiveCount = 7L;
     }
 
     static void emit(final String kind, final String... parts) {
@@ -121,6 +127,8 @@ public class ToolArgumentValueClassDump {
         emit("field", label, "fraction", String.valueOf(target.fraction));
         emit("field", label, "primitive-fraction", String.valueOf(target.primitiveFraction));
         emit("field", label, "feature", String.valueOf(target.feature));
+        emit("field", label, "count", String.valueOf(target.count));
+        emit("field", label, "primitive-count", String.valueOf(target.primitiveCount));
         if (target.path != null) {
             emit("tag", label, "path", String.valueOf(target.path.getTag()),
                     attributes(target.path.getTagAttributes()));
@@ -201,6 +209,18 @@ public class ToolArgumentValueClassDump {
         run("a-fraction-with-an-underscore", "--fraction", "1_000");
         run("a-fraction-with-a-leading-plus", "--fraction", "+1.5");
         run("a-fraction-that-rounds-to-a-float", "--fraction", "0.1000000000000000055511151231257827");
+
+        // The `Long`, which one of the ported tools declares and no golden had measured: its
+        // range is not an int's, and its refusal names `Long` where an integer's names `Integer`.
+        run("a-count", "--count", "42");
+        run("a-count-at-a-longs-limit", "--count", "9223372036854775807");
+        run("a-count-past-an-ints-limit", "--count", "2147483648");
+        run("a-count-past-a-longs-limit", "--count", "9223372036854775808");
+        run("a-count-that-is-not-a-number", "--count", "abc");
+        run("a-count-with-a-plus", "--count", "+42");
+        run("a-count-with-a-space", "--count", " 42");
+        run("a-count-in-hexadecimal", "--count", "0x2a");
+        run("a-primitive-count", "--primitive-count", "42");
 
         run("a-primitive-fraction", "--primitive-fraction", "0.25");
         run("a-primitive-fraction-that-is-not-a-number", "--primitive-fraction", "abc");

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6526,7 +6526,7 @@
     },
     {
       "id": "tool-argument-value-classes",
-      "status": "oracle-backed",
+      "status": "golden-pending",
       "title": "the four value classes a tool declares and the port cannot yet convert",
       "harness": "tools/argument-conformance",
       "tools": [],


### PR DESCRIPTION
`CreateHadoopBamSplittingIndex` declares a `Long`, the one class in the nine tools' declarations that no golden measures, so the port declines to build a definition for it and the tool does not parse (gatk-rs#1000 states that gap). Nine cases close it.

Two boundaries a port would place wrong:

* **a `Long` is not an `Integer` with a wider range.** Its refusal names `Long`, it accepts `2147483648` and refuses `9223372036854775808`;
* **and it is not a `Float` with a narrower grammar.** `Long.valueOf` refuses a leading space where `Float.valueOf` trims one, and refuses `0x2a` where the float takes `0x1p3`. Both take a leading plus.

The suite goes back to `golden-pending` with its stale golden still declared and committed.