### PR TITLE
Ask whether the file is BGZF before walking it

### DIFF
--- a/crates/gatk-cli/tests/index_feature_file_end_to_end.rs
+++ b/crates/gatk-cli/tests/index_feature_file_end_to_end.rs
@@ -164,8 +164,11 @@ fn a_report_is_returned_where_a_file_is_not_named() {
         &plain.to_string_lossy(),
     ]));
     assert_eq!(refused.status, main_entry::exit_status(Failure::User));
+    // The reference asks whether the file is block compressed BEFORE it walks it, so the refusal
+    // is about what the file is and not about how its first bytes frame. A covering array run
+    // against the binary is what found the port answering the other one.
     assert!(
-        refused.stderr.contains("Incorrect header size for file"),
+        refused.stderr.contains("File is not a valid BGZF file"),
         "{}",
         refused.stderr
     );

--- a/crates/gatk-tools/src/print_bgzf_block_information.rs
+++ b/crates/gatk-tools/src/print_bgzf_block_information.rs
@@ -147,6 +147,22 @@ pub fn blocks(file: &[u8], path: &str) -> Result<Vec<Block>, Refusal> {
 /// `doWork()`: the whole report, given the file's own name as the first line quotes it.
 pub fn report(file: &[u8], file_name: &str, path: &str) -> (String, Option<Refusal>) {
     let mut text = format!("BGZF block information for file: {file_name}\n\n");
+    // `doWork` asks `BlockCompressedInputStream.isValidFile` BEFORE it walks anything, so a file
+    // that is not block compressed is refused for what it is rather than for how its first bytes
+    // frame: a long plain file has enough bytes for a header and frames as a premature end, which
+    // is the refusal the walk earns and not the one the tool gives.
+    //
+    // The check was in this module and nothing called it: the suite asked it directly and the
+    // walk did not, so the two disagreed the moment a caller ran the tool rather than the suite.
+    // A covering array run against the binary is what found that.
+    if !is_block_compressed(file) {
+        return (
+            text,
+            Some(Refusal::NotBlockCompressed {
+                path: path.to_string(),
+            }),
+        );
+    }
     let (found, refusal) = match blocks(file, path) {
         Ok(found) => (found, None),
         // The refusal comes after the blocks already printed, and those stay on disk.


### PR DESCRIPTION
The covering array's second tool came back at 2 of 4, and the two rows that diverged say why:

```
reference  2  EXIT=2 … Couldn't read file file:///work/fixtures/reads.vcf. Error was: File is not a valid BGZF file…
port       2  EXIT=2 … Couldn't read file. Error was: Error while parsing BGZF file. with exception: Premature end of file…
```

`doWork` calls `BlockCompressedInputStream.isValidFile` **before** it walks anything, so a file that is not block compressed is refused for what it is. The port walked straight in, and a long plain file has enough bytes for a header, so it framed as a premature end: the refusal the walk earns rather than the one the tool gives.

The check was already in the module and **nothing called it**. The suite asked it directly and the walk did not, so the two agreed for exactly as long as nobody ran the tool through anything but the suite. That is the failure mode the array exists to catch, and it caught it on its second tool.

The suite's own goldens are unchanged and still pass: they cover a short plain file, whose walk happened to earn the same refusal by a different route.