### PR TITLE
Commit the second coverage number, which is 4 of 4

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -220,7 +220,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `Pileup` | locus-walker | oracle-backed | pileup-tool | 1 | not measured |
 | `PostProcessReadsForRSEM` | record-transform | oracle-backed | post-process-reads-for-rsem | 1 | not measured |
 | `PreprocessIntervals` | interval-utility | oracle-backed | preprocess-intervals | 1 | not measured |
-| `PrintBGZFBlockInformation` | unclassified | oracle-backed | print-bgzf-block-information | 1 | not measured |
+| `PrintBGZFBlockInformation` | unclassified | oracle-backed | print-bgzf-block-information | 1 | t=2, 4/4 rows (100%) |
 | `PrintDistantMates` | record-transform | oracle-backed | print-distant-mates | 1 | not measured |
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |
 | `PrintReadCounts` | sv-caller | oracle-backed | print-read-counts | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -18,6 +18,15 @@
       "matched": 5,
       "t": 2,
       "share": 0.833
+    },
+    "PrintBGZFBlockInformation": {
+      "rows": 4,
+      "accepted": 2,
+      "rejected": 2,
+      "distinct_outputs": 2,
+      "matched": 4,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
| tool | coverage |
|---|---|
| `IndexFeatureFile` | t=2, 5/6 rows (83%) |
| `PrintBGZFBlockInformation` | t=2, **4/4 rows (100%)** |

The second tool reaches four of four after the ordering fix that the same array asked for (gatk-rs#1003). Two of those four rows are refusals, so the hundred per cent includes reproducing what the reference refuses and not only what it writes.

The first stays at five of six, and the row it misses is the tabix index this port does not write: a gap in the port rather than a bug in it, which is why the number does not move until a tabix writer lands.