### PR TITLE
Port LoglessPairHMM

### DIFF
--- a/crates/gatk-engine/src/lib.rs
+++ b/crates/gatk-engine/src/lib.rs
@@ -70,6 +70,7 @@ pub mod mutect_hard_filters;
 pub mod natural_log_utils;
 pub mod normal_artifact_filter;
 pub mod overhang_fixing_manager;
+pub mod pair_hmm;
 pub mod permutation;
 pub mod persistence_optimizer;
 pub mod pileup;

--- a/crates/gatk-engine/src/pair_hmm.rs
+++ b/crates/gatk-engine/src/pair_hmm.rs
@@ -1,0 +1,190 @@
+//! `LoglessPairHMM`: the likelihood of a read given a haplotype, in linear space.
+//!
+//! The model is a three-state HMM over the read and the haplotype: match, insertion and deletion.
+//! What makes it "logless" is that the recursion runs in LINEAR probability space and is kept from
+//! underflowing by an initial condition of `2^1020`, subtracted back off at the end. A log-space
+//! version exists in the reference and gives slightly different bits, which is why the golden
+//! records both and this ports the one the callers use.
+//!
+//! Ported from `org.broadinstitute.hellbender.utils.pairhmm.LoglessPairHMM`,
+//! `org.broadinstitute.hellbender.utils.pairhmm.PairHMMModel` and the two helpers they reach:
+//! `QualityUtils.qualToProb`, `QualityUtils.qualToErrorProb` and
+//! `MathUtils.approximateLog10SumLog10`.
+
+use crate::math_utils::{qual_to_error_prob, qual_to_prob};
+
+/// `LoglessPairHMM.INITIAL_CONDITION`, which is `2^1020`: large enough that the recursion cannot
+/// underflow a double, and a power of two so that dividing it out costs no precision.
+pub fn initial_condition() -> f64 {
+    2f64.powi(1020)
+}
+/// Its base-ten logarithm, subtracted from the answer. Computed rather than written down: a
+/// transcribed decimal is a different double from `Math.log10(Math.pow(2, 1020))`, and the
+/// difference lands in the seventh digit of every likelihood.
+pub fn initial_condition_log10() -> f64 {
+    initial_condition().log10()
+}
+/// `TRISTATE_CORRECTION`: a mismatch may be any of the three other bases, so the error probability
+/// is divided by three.
+pub const TRISTATE_CORRECTION: f64 = 3.0;
+/// `QualityUtils.MAX_QUAL`.
+pub const MAX_QUAL: usize = 254;
+
+/// The six transitions the model carries, in the reference's own order.
+pub const MATCH_TO_MATCH: usize = 0;
+pub const INDEL_TO_MATCH: usize = 1;
+pub const MATCH_TO_INSERTION: usize = 2;
+pub const INSERTION_TO_INSERTION: usize = 3;
+pub const MATCH_TO_DELETION: usize = 4;
+pub const DELETION_TO_DELETION: usize = 5;
+pub const TRANS_PROB_ARRAY_LENGTH: usize = 6;
+
+/// `MathUtils.JacobianLogTable`, which is a quantised correction rather than a computed one.
+///
+/// The table holds `log10(1 + 10^-k*step)` for `k` from zero to eighty thousand, and a difference
+/// beyond `MAX_TOLERANCE` contributes nothing at all. Computing the correction exactly instead
+/// would be a different function, and the two disagree in the last bits.
+pub const JACOBIAN_MAX_TOLERANCE: f64 = 8.0;
+pub const JACOBIAN_TABLE_STEP: f64 = 0.0001;
+
+/// `MathUtils.fastRound`, which rounds away from zero rather than to even.
+pub fn fast_round(value: f64) -> i32 {
+    if value > 0.0 {
+        (value + 0.5) as i32
+    } else {
+        (value - 0.5) as i32
+    }
+}
+
+/// `JacobianLogTable.get`, computed at the table's own quantisation.
+///
+/// The reference builds the table once and reads it by index; reading it by index is what this
+/// reproduces, so the value is the table's entry and not `log10(1 + 10^-difference)`.
+pub fn jacobian_log(difference: f64) -> f64 {
+    let index = fast_round(difference / JACOBIAN_TABLE_STEP);
+    let quantised = f64::from(index) * JACOBIAN_TABLE_STEP;
+    (1.0 + 10f64.powf(-quantised)).log10()
+}
+
+/// `MathUtils.approximateLog10SumLog10`.
+pub fn approximate_log10_sum_log10(a: f64, b: f64) -> f64 {
+    if a > b {
+        return approximate_log10_sum_log10(b, a);
+    }
+    if a == f64::NEG_INFINITY {
+        return b;
+    }
+    let difference = b - a;
+    b + if difference < JACOBIAN_MAX_TOLERANCE {
+        jacobian_log(difference)
+    } else {
+        0.0
+    }
+}
+
+/// `PairHMMModel.matchToMatchProb`, which is one minus the probability that EITHER an insertion or
+/// a deletion opened.
+///
+/// The reference reads a triangular cache built at class-init with `log1p`, and computes the same
+/// expression only for a quality past `MAX_QUAL`. Both paths are written out here because the
+/// cached one is not `1 - 10^log10sum`: it is `exp(log1p(-min(1, 10^log10sum)))`, which is a
+/// different double for a small sum.
+pub fn match_to_match_prob(insertion_qual: i32, deletion_qual: i32) -> f64 {
+    let (min_qual, max_qual) = if insertion_qual <= deletion_qual {
+        (insertion_qual, deletion_qual)
+    } else {
+        (deletion_qual, insertion_qual)
+    };
+    let log10_sum =
+        approximate_log10_sum_log10(-0.1 * f64::from(min_qual), -0.1 * f64::from(max_qual));
+    if max_qual as usize > MAX_QUAL {
+        return 1.0 - 10f64.powf(log10_sum);
+    }
+    // `Math.log1p(-Math.min(1, Math.pow(10, log10Sum))) * INV_LN10`, then `Math.pow(10, that)`.
+    let log10 = (-(10f64.powf(log10_sum)).min(1.0)).ln_1p() * std::f64::consts::LOG10_E;
+    10f64.powf(log10)
+}
+
+/// `PairHMMModel.qualToTransProbs` for one base.
+pub fn qual_to_trans_probs(
+    insertion_qual: u8,
+    deletion_qual: u8,
+    gap_continuation: u8,
+) -> [f64; TRANS_PROB_ARRAY_LENGTH] {
+    let mut dest = [0.0; TRANS_PROB_ARRAY_LENGTH];
+    dest[MATCH_TO_MATCH] = match_to_match_prob(i32::from(insertion_qual), i32::from(deletion_qual));
+    dest[MATCH_TO_INSERTION] = qual_to_error_prob(f64::from(insertion_qual));
+    dest[MATCH_TO_DELETION] = qual_to_error_prob(f64::from(deletion_qual));
+    dest[INDEL_TO_MATCH] = qual_to_prob(f64::from(gap_continuation));
+    dest[INSERTION_TO_INSERTION] = qual_to_error_prob(f64::from(gap_continuation));
+    dest[DELETION_TO_DELETION] = dest[INSERTION_TO_INSERTION];
+    dest
+}
+
+/// `initializePriors`: the probability of the read's base given the haplotype's.
+///
+/// An `N` on either side matches, which is what keeps an uncalled base from costing a mismatch.
+pub fn prior(read_base: u8, haplotype_base: u8, quality: u8) -> f64 {
+    if read_base == haplotype_base || read_base == b'N' || haplotype_base == b'N' {
+        qual_to_prob(f64::from(quality))
+    } else {
+        qual_to_error_prob(f64::from(quality)) / TRISTATE_CORRECTION
+    }
+}
+
+/// `computeReadLikelihoodGivenHaplotypeLog10`, the whole recursion.
+///
+/// The three matrices are padded by one in each direction, the deletion row is seeded with the
+/// initial condition spread over the haplotype's length, and the answer is the log of the last
+/// row's match and insertion terms with that condition taken back off.
+pub fn read_likelihood_given_haplotype_log10(
+    haplotype: &[u8],
+    read: &[u8],
+    read_quals: &[u8],
+    insertion_quals: &[u8],
+    deletion_quals: &[u8],
+    gap_continuation: &[u8],
+) -> f64 {
+    let padded_read = read.len() + 1;
+    let padded_haplotype = haplotype.len() + 1;
+    let mut matches = vec![vec![0.0f64; padded_haplotype]; padded_read];
+    let mut insertions = vec![vec![0.0f64; padded_haplotype]; padded_read];
+    let mut deletions = vec![vec![0.0f64; padded_haplotype]; padded_read];
+
+    // The seed is spread over the haplotype, so a longer haplotype starts from a smaller value and
+    // the answer does not depend on its length.
+    let initial = initial_condition() / haplotype.len() as f64;
+    for cell in deletions[0].iter_mut() {
+        *cell = initial;
+    }
+
+    let mut transitions = vec![[0.0f64; TRANS_PROB_ARRAY_LENGTH]; padded_read];
+    for index in 0..read.len() {
+        transitions[index + 1] = qual_to_trans_probs(
+            insertion_quals[index],
+            deletion_quals[index],
+            gap_continuation[index],
+        );
+    }
+
+    for i in 1..padded_read {
+        for j in 1..padded_haplotype {
+            let p = prior(read[i - 1], haplotype[j - 1], read_quals[i - 1]);
+            matches[i][j] = p
+                * (matches[i - 1][j - 1] * transitions[i][MATCH_TO_MATCH]
+                    + insertions[i - 1][j - 1] * transitions[i][INDEL_TO_MATCH]
+                    + deletions[i - 1][j - 1] * transitions[i][INDEL_TO_MATCH]);
+            insertions[i][j] = matches[i - 1][j] * transitions[i][MATCH_TO_INSERTION]
+                + insertions[i - 1][j] * transitions[i][INSERTION_TO_INSERTION];
+            deletions[i][j] = matches[i][j - 1] * transitions[i][MATCH_TO_DELETION]
+                + deletions[i][j - 1] * transitions[i][DELETION_TO_DELETION];
+        }
+    }
+
+    let end = padded_read - 1;
+    let mut total = 0.0;
+    for j in 1..padded_haplotype {
+        total += matches[end][j] + insertions[end][j];
+    }
+    total.log10() - initial_condition_log10()
+}

--- a/crates/gatk-engine/tests/pair_hmm_port.rs
+++ b/crates/gatk-engine/tests/pair_hmm_port.rs
@@ -1,0 +1,256 @@
+//! Conformance for `LoglessPairHMM` against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/PairHmmDump.java`, which ran three implementations
+//! over twelve read and haplotype pairs and printed each likelihood as its RAW BITS as well as its
+//! decimal form. The port targets the scalar `LoglessPairHMM`, which is the one the oracle
+//! contract pins.
+//!
+//! # What this suite is for
+//!
+//!  * **every one of the twelve likelihoods, compared as bits and not as decimals**;
+//!  * **the initial condition, which is what keeps the linear recursion from underflowing**;
+//!  * **the transition probabilities, whose match-to-match term is a cached expression and not
+//!    `1 - 10^x`**;
+//!  * **and the tristate correction a mismatch pays.**
+
+use gatk_corpus as corpus;
+use gatk_engine::pair_hmm::{
+    approximate_log10_sum_log10, initial_condition, initial_condition_log10, match_to_match_prob,
+    prior, qual_to_trans_probs, read_likelihood_given_haplotype_log10, INDEL_TO_MATCH,
+    MATCH_TO_DELETION, MATCH_TO_INSERTION, MATCH_TO_MATCH, TRISTATE_CORRECTION,
+};
+
+fn golden() -> String {
+    corpus::read_golden(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/pair_hmm.txt.gz"),
+    )
+}
+
+/// One case's LoglessPairHMM answer, as the bits the golden holds.
+fn bits(text: &str, label: &str) -> u64 {
+    let prefix = format!("likelihood\t{label}\tLoglessPairHMM=");
+    let row = text
+        .lines()
+        .find(|line| line.starts_with(&prefix))
+        .map(|line| line[prefix.len()..].to_string())
+        .unwrap_or_else(|| panic!("likelihood/{label}"));
+    let (hex, _) = row.split_once(',').expect("bits and a decimal");
+    u64::from_str_radix(hex, 16).expect("the bits")
+}
+
+/// One pair of the fixture: the haplotype, the read, and the four qualities.
+struct Pair {
+    label: &'static str,
+    haplotype: &'static str,
+    read: &'static str,
+    base: u8,
+    insertion: u8,
+    deletion: u8,
+    gap: u8,
+}
+
+const PAIRS: [Pair; 12] = [
+    Pair {
+        label: "identical",
+        haplotype: "ACGTACGTACGT",
+        read: "ACGTACGTACGT",
+        base: 30,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+    Pair {
+        label: "one-mismatch",
+        haplotype: "ACGTACGTACGT",
+        read: "ACGTAAGTACGT",
+        base: 30,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+    Pair {
+        label: "short-read",
+        haplotype: "ACGTACGTACGTACGT",
+        read: "ACGTACGT",
+        base: 30,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+    Pair {
+        label: "deletion",
+        haplotype: "ACGTACGTACGT",
+        read: "ACGTACGT",
+        base: 30,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+    Pair {
+        label: "insertion",
+        haplotype: "ACGTACGT",
+        read: "ACGTTTTTACGT",
+        base: 30,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+    Pair {
+        label: "low-base-quality",
+        haplotype: "ACGTACGTACGT",
+        read: "ACGTAAGTACGT",
+        base: 2,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+    Pair {
+        label: "high-base-quality",
+        haplotype: "ACGTACGTACGT",
+        read: "ACGTAAGTACGT",
+        base: 60,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+    Pair {
+        label: "at-the-quality-threshold",
+        haplotype: "ACGTACGTACGT",
+        read: "ACGTAAGTACGT",
+        base: 18,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+    Pair {
+        label: "below-the-quality-threshold",
+        haplotype: "ACGTACGTACGT",
+        read: "ACGTAAGTACGT",
+        base: 17,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+    Pair {
+        label: "cheap-gaps",
+        haplotype: "ACGTACGTACGT",
+        read: "ACGTACGT",
+        base: 30,
+        insertion: 10,
+        deletion: 10,
+        gap: 5,
+    },
+    Pair {
+        label: "long",
+        haplotype: "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT",
+        read: "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT",
+        base: 30,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+    Pair {
+        label: "homopolymer",
+        haplotype: "AAAAAAAAAAAA",
+        read: "AAAAAAAAAA",
+        base: 30,
+        insertion: 45,
+        deletion: 45,
+        gap: 10,
+    },
+];
+
+fn likelihood(pair: &Pair) -> f64 {
+    let read = pair.read.as_bytes();
+    let quals = vec![pair.base; read.len()];
+    let insertions = vec![pair.insertion; read.len()];
+    let deletions = vec![pair.deletion; read.len()];
+    let gaps = vec![pair.gap; read.len()];
+    read_likelihood_given_haplotype_log10(
+        pair.haplotype.as_bytes(),
+        read,
+        &quals,
+        &insertions,
+        &deletions,
+        &gaps,
+    )
+}
+
+/// Every one of the twelve, compared as bits.
+#[test]
+fn every_likelihood_matches_the_golden() {
+    let text = golden();
+    for pair in &PAIRS {
+        let ours = likelihood(pair);
+        assert_eq!(
+            ours.to_bits(),
+            bits(&text, pair.label),
+            "{}: {ours} against the golden's own",
+            pair.label
+        );
+    }
+}
+
+/// The initial condition, and what it is for.
+#[test]
+fn the_initial_condition_is_a_power_of_two() {
+    // `Math.pow(2, 1020)`, which is exact, and its log10.
+    assert_eq!(initial_condition(), 2f64.powi(1020));
+    assert_eq!(initial_condition_log10(), initial_condition().log10());
+    // It is subtracted back off, so the answer does not depend on it: doubling the haplotype's
+    // length does not scale the likelihood, because the seed is spread over that length.
+    let text = golden();
+    let identical = bits(&text, "identical");
+    assert!(f64::from_bits(identical) < 0.0);
+}
+
+/// The transition probabilities, whose match-to-match term is not `1 - 10^x`.
+#[test]
+fn the_match_to_match_term_is_the_cached_expression() {
+    let probs = qual_to_trans_probs(45, 45, 10);
+    // The two indel openings are the plain error probabilities of their own qualities.
+    assert_eq!(probs[MATCH_TO_INSERTION], 10f64.powf(-4.5));
+    assert_eq!(probs[MATCH_TO_DELETION], 10f64.powf(-4.5));
+    // The gap continuation is one probability read two ways.
+    assert_eq!(probs[INDEL_TO_MATCH], 1.0 - 10f64.powf(-1.0));
+    // The match-to-match term is written as `exp(log1p(-min(1, 10^sum)))` and not as
+    // `1 - 10^sum`. The two agree bit for bit at this quality, and the reference writes the first
+    // because it does not agree everywhere: `log1p` is what keeps a sum near one from losing its
+    // significant digits. The port carries the reference's spelling rather than the shorter one
+    // it happens to equal here.
+    let sum = approximate_log10_sum_log10(-4.5, -4.5);
+    let naive = 1.0 - 10f64.powf(sum);
+    assert_eq!(probs[MATCH_TO_MATCH].to_bits(), naive.to_bits());
+    // Where the difference shows: a quality of one on both sides puts the sum near zero, and
+    // there the two spellings are different doubles.
+    let small = qual_to_trans_probs(1, 1, 10);
+    let small_sum = approximate_log10_sum_log10(-0.1, -0.1);
+    assert_ne!(
+        small[MATCH_TO_MATCH].to_bits(),
+        (1.0 - 10f64.powf(small_sum)).to_bits()
+    );
+    // A quality past the maximum takes the other branch, which IS the naive expression.
+    let past = match_to_match_prob(255, 255);
+    assert_eq!(
+        past,
+        1.0 - 10f64.powf(approximate_log10_sum_log10(-25.5, -25.5))
+    );
+}
+
+/// A mismatch pays the tristate correction, and an `N` pays nothing.
+#[test]
+fn a_mismatch_is_divided_by_three() {
+    assert_eq!(TRISTATE_CORRECTION, 3.0);
+    let matched = prior(b'A', b'A', 30);
+    let mismatched = prior(b'A', b'C', 30);
+    assert_eq!(matched, 1.0 - 10f64.powf(-3.0));
+    assert_eq!(mismatched, 10f64.powf(-3.0) / 3.0);
+    // An `N` on either side is a match, whichever side it is on.
+    assert_eq!(prior(b'N', b'C', 30), matched);
+    assert_eq!(prior(b'A', b'N', 30), matched);
+    // And the quality moves it: the golden's two extremes differ by orders of magnitude.
+    let text = golden();
+    let low = f64::from_bits(bits(&text, "low-base-quality"));
+    let high = f64::from_bits(bits(&text, "high-base-quality"));
+    assert!(high < low, "a higher quality makes a mismatch cost more");
+}


### PR DESCRIPTION
Milestone G3.2. The `pair-hmm` golden has been oracle-backed since the three implementations were measured against each other, and nothing had been ported against it. This ports the scalar `LoglessPairHMM`, which is the one the oracle contract pins, and all twelve likelihoods come back **bit for bit**.

The one thing that had to be got right to reach that: the initial condition's logarithm. Writing `307.05064432012435` rather than computing `Math.log10(Math.pow(2, 1020))` gives a different double, and the difference lands in the seventh digit of every answer. Both constants are computed rather than transcribed.

Two places where the reference's spelling matters and the shorter one would have passed most tests:

* the match-to-match probability is `exp(log1p(-min(1, 10^sum)))` and not `1 - 10^sum`. They agree bit for bit at quality 45 and disagree at quality 1, which the test asserts on both sides;
* the Jacobian correction is a **quantised table lookup**, so the value is the table's entry at a rounded index rather than the exact logarithm.

The likelihoods are compared as raw bits and not as decimals: a decimal rendering hides the last three digits, which is exactly where an approximation that is nearly right lands.

Part of gatk-rs issue 71.