### PR TITLE
Measure the read filter catalogue and each tool's defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,10 @@ jobs:
             index: "58/58"
             slug: "plugin-argument-ownership"
             suites: "plugin-argument-ownership"
+          - group: golden-pending
+            index: "1/1"
+            slug: "read-filter-catalogue"
+            suites: "read-filter-catalogue"
     steps:
       - uses: actions/checkout@v7
 

--- a/tools/argument-conformance/ReadFilterCatalogueDump.java
+++ b/tools/argument-conformance/ReadFilterCatalogueDump.java
@@ -1,0 +1,100 @@
+/*
+ * The read filter catalogue and each tool's defaults, taken from the reference.
+ *
+ * Two sets a walker's usage prints and a port cannot derive.
+ *
+ *   - THE CATALOGUE: every read filter `ClassFinder` discovered, which is what `--read-filter`
+ *     lists as its possible values. It is the filter LIBRARY, and a filter with no arguments is in
+ *     it and is therefore not in the ownership table;
+ *   - AND THE TOOL'S OWN DEFAULTS: what `getDefaultReadFilters()` returned, which is what
+ *     `--disable-read-filter` lists as its possible values. That set is per tool: `CountReads`
+ *     takes `ReadWalker`'s one filter and `ApplyBQSR` takes the same, while a tool that is no
+ *     walker has no descriptor at all.
+ *
+ * The second set is the one the trim is still short of. A default counts as SELECTED, so a default
+ * filter's own arguments are accepted with no `--read-filter` on the command line, and a port
+ * without the list refuses a command line the reference takes.
+ *
+ * Both are read off the descriptor the tool's own parser built, through
+ * `getAllowedValuesForDescriptorHelp`, which is the same call the usage rendering makes. Sets have
+ * no order, so both are sorted here; the usage sorts them too, and `usage-text` is where that
+ * order is compared.
+ *
+ * Output:
+ *
+ *     catalogue\t<count>\t<every filter name, space separated, sorted>
+ *     descriptor\t<tool>\t<the descriptor's display name, or none>
+ *     defaults\t<tool>\t<the tool's default filter names, space separated, sorted>
+ *     allowed\t<tool>\t<argument long name>\t<its possible values, space separated, sorted>
+ *
+ * Usage: ReadFilterCatalogueDump
+ */
+
+import org.broadinstitute.barclay.argparser.CommandLineArgumentParser;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class ReadFilterCatalogueDump {
+
+    public static void main(final String[] args) {
+        System.out.println("# ReadFilterCatalogueDump: the filter library and each tool's defaults");
+
+        // The catalogue, off the first tool that has a descriptor at all: discovery is the
+        // descriptor's and does not depend on which tool asked.
+        final GATKReadFilterPluginDescriptor first =
+                descriptor(new org.broadinstitute.hellbender.tools.CountReads());
+        final List<String> catalogue =
+                sorted(first.getAllowedValuesForDescriptorHelp("read-filter"));
+        System.out.printf("catalogue\t%d\t%s%n", catalogue.size(), String.join(" ", catalogue));
+
+        // The nine tools whose declarations this port carries, walkers and not.
+        tool("CountReads", new org.broadinstitute.hellbender.tools.CountReads());
+        tool("CountVariants", new org.broadinstitute.hellbender.tools.walkers.CountVariants());
+        tool("PrintReads", new org.broadinstitute.hellbender.tools.PrintReads());
+        tool("ApplyBQSR", new org.broadinstitute.hellbender.tools.walkers.bqsr.ApplyBQSR());
+        tool("SelectVariants",
+                new org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants());
+        tool("IndexFeatureFile", new org.broadinstitute.hellbender.tools.IndexFeatureFile());
+        tool("GatherVcfsCloud", new org.broadinstitute.hellbender.tools.GatherVcfsCloud());
+        tool("PrintBGZFBlockInformation",
+                new org.broadinstitute.hellbender.tools.PrintBGZFBlockInformation());
+        tool("CreateHadoopBamSplittingIndex",
+                new org.broadinstitute.hellbender.tools.spark.CreateHadoopBamSplittingIndex());
+    }
+
+    /** The read filter descriptor the tool's own parser built, or null where it built none. */
+    static GATKReadFilterPluginDescriptor descriptor(final CommandLineProgram target) {
+        final CommandLineArgumentParser parser =
+                (CommandLineArgumentParser) target.getCommandLineParser();
+        return parser.getPluginDescriptor(GATKReadFilterPluginDescriptor.class);
+    }
+
+    static void tool(final String name, final CommandLineProgram target) {
+        final GATKReadFilterPluginDescriptor plugin = descriptor(target);
+        if (plugin == null) {
+            System.out.printf("descriptor\t%s\tnone%n", name);
+            return;
+        }
+        System.out.printf("descriptor\t%s\t%s%n", name, plugin.getDisplayName());
+        // `--disable-read-filter`'s possible values ARE the tool's defaults, which is how the
+        // usage prints them and the only place the list is visible from outside the tool.
+        final List<String> defaults =
+                sorted(plugin.getAllowedValuesForDescriptorHelp("disable-read-filter"));
+        System.out.printf("defaults\t%s\t%s%n", name, String.join(" ", defaults));
+        for (final String argument : new String[]{"read-filter", "disable-read-filter"}) {
+            final List<String> allowed = sorted(plugin.getAllowedValuesForDescriptorHelp(argument));
+            System.out.printf("allowed\t%s\t%s\t%s%n", name, argument, String.join(" ", allowed));
+        }
+    }
+
+    static List<String> sorted(final Set<String> values) {
+        final List<String> list = new ArrayList<>(values == null ? Set.of() : values);
+        Collections.sort(list);
+        return list;
+    }
+}

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6561,6 +6561,26 @@
           "why": "From the pinned container on a real x86-64 runner, published as the golden-pending artefact of the run that added this suite, and identical to the local smoke run. 62 rows: 28 controlled arguments with their owning filter class, 12 of them required, then the six answers of isDependentArgumentAllowed with and without tool defaults and ten command lines through the trim."
         }
       ]
+    },
+    {
+      "id": "read-filter-catalogue",
+      "status": "golden-pending",
+      "title": "the read filter library, and which of them each tool takes as defaults",
+      "harness": "tools/argument-conformance",
+      "tools": [
+        "GATKReadFilterPluginDescriptor"
+      ],
+      "compare": {
+        "mode": "lines"
+      },
+      "why": "A tool's DEFAULT read filters count as selected, so their arguments are accepted with no --read-filter on the command line, and the list is per tool rather than per descriptor. It is also what --disable-read-filter prints as its possible values and --read-filter prints the whole catalogue, so a walker's usage cannot be composed without both sets. Neither is derivable: the declarations record an argument's type as String and carry no possible values, and a filter with no arguments is in the catalogue and in no ownership row.",
+      "cases": [
+        {
+          "dump": "ReadFilterCatalogueDump",
+          "golden": null,
+          "why": "The catalogue once, then the nine tools whose declarations this port carries: the descriptor's display name or none for a tool that is no walker, the tool's defaults, and the possible values of the two arguments that print them."
+        }
+      ]
     }
   ],
   "probes": []


### PR DESCRIPTION
Two sets a walker's usage prints and a port cannot derive from anything it has.

The CATALOGUE is every read filter the descriptor's `ClassFinder` discovered, which is what `--read-filter` lists as its possible values. It is the filter library rather than the ownership table frozen in #1008: a filter with no arguments is in it and is in no ownership row.

The DEFAULTS are what a tool's `getDefaultReadFilters()` returned, which is what `--disable-read-filter` lists. That set is per tool, and it is the one the trim is still short of after #987: a default counts as SELECTED, so a default filter's own arguments are accepted with no `--read-filter` on the command line, and a port without the list refuses a command line the reference takes.

Both come off the descriptor the tool's own parser built, through the same `getAllowedValuesForDescriptorHelp` the usage rendering calls, for the nine tools whose declarations this port carries. Four of them build no descriptor at all, which the dump records as `none` rather than as an empty set.

The suite is `golden-pending`. The candidate has to come from the oracle on a real x86-64 runner; the local run is only a smoke test.

Part of #818 and #821: with these two sets and the ownership table, a walker's usage can be composed and compared against the `usage-text` golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)