### PR TITLE
Measure what CountReads returns and what it writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,10 @@ jobs:
             index: "58/58"
             slug: "plugin-argument-ownership-read-filter-catalogue-mutex-target-names"
             suites: "plugin-argument-ownership read-filter-catalogue mutex-target-names"
+          - group: golden-pending
+            index: "1/1"
+            slug: "count-reads-plumbing"
+            suites: "count-reads-plumbing"
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -159,7 +159,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountBases` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
 | `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
-| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers, tool-argument-declarations, tool-argument-enums, usage-text | 5 | not measured |
+| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, tool-argument-declarations, tool-argument-enums, usage-text | 6 | not measured |
 | `CountVariants` | variant-walker | oracle-backed | count-variants, tool-argument-declarations, tool-argument-enums | 3 | not measured |
 | `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | not measured |
 | `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |

--- a/tools/argument-conformance/CountReadsPlumbingDump.java
+++ b/tools/argument-conformance/CountReadsPlumbingDump.java
@@ -1,0 +1,124 @@
+/*
+ * What `CountReads` writes and returns, taken from the reference.
+ *
+ * The count itself is measured in `count-reads-and-bases`, which hands the ported function a
+ * corpus and compares the number. What is NOT measured there is the layer between that number and
+ * a command line: what the tool RETURNS, which `handleResult` prints, and what it WRITES when
+ * `-O` names a file. A port with the number and without those two runs no command line.
+ *
+ * Six behaviours this is built to catch.
+ *
+ *   - THE TOOL RETURNS THE COUNT, so `Tool returned:` is followed by a number and not by a path;
+ *   - THE FILE HOLDS THE NUMBER AND NOTHING ELSE, with no trailing newline: the reference writes
+ *     it with `print`, and a port that used `println` would write a file one byte longer;
+ *   - `-O` DOES NOT SUPPRESS THE RETURN: the number is written AND returned;
+ *   - `-L` COUNTS WHAT THE INTERVAL HOLDS, which is the walker's traversal rather than the tool's
+ *     own filter;
+ *   - `--read-filter` ADDS TO THE DEFAULTS rather than replacing them, and
+ *     `--disable-tool-default-read-filters` is what replaces them;
+ *   - AND A MISSING INPUT IS A REFUSAL BEFORE ANY OF IT, whose class and wording are the
+ *     reference's.
+ *
+ * The input is the shared fixture corpus, so a covering array row and a case here read the same
+ * bytes: eight reads on one contig, seven hundred bases apart, one of them flagged a duplicate.
+ *
+ * Output:
+ *
+ *     returned\t<case>\t<the object the tool returned, as String.valueOf writes it>
+ *     file\t<case>\t<the output file's bytes, base64, or absent where none was written>
+ *     error\t<case>\t<exception class>:<message>
+ *
+ * Usage: CountReadsPlumbingDump
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+
+public class CountReadsPlumbingDump {
+
+    static final Path FIXTURES = Paths.get("fixtures");
+
+    public static void main(final String[] args) throws Exception {
+        System.out.println("# CountReadsPlumbingDump: what the tool returns and what it writes");
+
+        run("the-whole-file", true);
+        run("no-output-file", false);
+        run("an-interval", true, "-L", "chr1:1-1000");
+        run("an-interval-with-nothing-in-it", true, "-L", "chr1:50000-60000");
+        run("a-second-filter", true, "--read-filter", "NotDuplicateReadFilter");
+        run("the-defaults-disabled", true, "--disable-tool-default-read-filters");
+        run("a-mapping-quality-filter", true,
+                "--read-filter", "MappingQualityReadFilter", "--minimum-mapping-quality", "70");
+        run("an-absent-input", true, "--input", "/work/nowhere.bam");
+        run("no-input-at-all", true);
+    }
+
+    static void run(final String name, final boolean withOutput, final String... extra)
+            throws Exception {
+        final Path dir = Files.createTempDirectory("countreads");
+        final Path out = dir.resolve("count.txt");
+        final List<String> argv = new ArrayList<>();
+        final List<String> tail = Arrays.asList(extra);
+        // `an-absent-input` names its own input and `no-input-at-all` names none, so the fixture is
+        // added only where neither did.
+        if (!tail.contains("--input") && !name.equals("no-input-at-all")) {
+            argv.addAll(List.of("--input", FIXTURES.resolve("reads.bam").toString()));
+        }
+        if (withOutput) {
+            argv.addAll(List.of("--output", out.toString()));
+        }
+        argv.addAll(tail);
+
+        // The tool's own logging goes to a sink: it carries a clock, and what is measured is the
+        // value and the file rather than the noise around them.
+        final PrintStream original = System.out;
+        String returned = null;
+        String error = null;
+        try {
+            System.setOut(new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8));
+            // `instanceMain` returns the tool's own result object, which is what `handleResult`
+            // prints under `Tool returned:` and what a port has to produce.
+            returned = String.valueOf(new org.broadinstitute.hellbender.Main()
+                    .instanceMain(prepend(argv)));
+        } catch (final Exception | AssertionError e) {
+            Throwable cause = e;
+            while (cause.getCause() != null && cause.getCause() != cause) {
+                cause = cause.getCause();
+            }
+            error = cause.getClass().getName() + ":"
+                    + String.valueOf(cause.getMessage()).replace(dir.toString(), "<dir>");
+        } finally {
+            System.setOut(original);
+        }
+
+        if (returned != null) {
+            emit("returned", name, returned);
+        }
+        if (error != null) {
+            emit("error", name, error);
+        }
+        if (withOutput && Files.exists(out)) {
+            emit("file", name, Base64.getEncoder().encodeToString(Files.readAllBytes(out)));
+        }
+    }
+
+    /** `Main`'s own argv: the tool's name first. */
+    static String[] prepend(final List<String> argv) {
+        final List<String> whole = new ArrayList<>(List.of("CountReads"));
+        whole.addAll(argv);
+        return whole.toArray(new String[0]);
+    }
+
+    static void emit(final String kind, final String name, final String payload) {
+        System.out.printf("%s\t%s\t%s%n", kind, name,
+                payload.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n"));
+    }
+}

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6599,6 +6599,27 @@
           "why": "From the pinned container on a real x86-64 runner, published as the golden-pending artefact of the run that added this suite, and identical to the local smoke run. Four mutex arguments, all of them a read filter's, over two of the four tools: the target's long name, the target definition's FIELD name, and the sentence the usage renders from the second."
         }
       ]
+    },
+    {
+      "id": "count-reads-plumbing",
+      "status": "golden-pending",
+      "needs_fixtures": true,
+      "title": "what CountReads returns and what it writes, which is the layer between the count and a command line",
+      "harness": "tools/argument-conformance",
+      "tools": [
+        "CountReads"
+      ],
+      "compare": {
+        "mode": "keyed"
+      },
+      "why": "`count-reads-and-bases` measures the number. What decides whether a port can RUN the tool is the layer around it: the value handleResult prints, the bytes -O receives (the number with no trailing newline, written with print rather than println), and the refusal a missing input earns before any of it.",
+      "cases": [
+        {
+          "dump": "CountReadsPlumbingDump",
+          "golden": null,
+          "why": "Nine command lines over the shared fixture BAM: the whole file with and without an output, an interval that holds reads and one that does not, a second read filter and the defaults disabled, a mapping quality filter that keeps nothing, an input that does not exist and no input at all."
+        }
+      ]
     }
   ],
   "probes": []

--- a/tools/coverage/MakeFixtures.java
+++ b/tools/coverage/MakeFixtures.java
@@ -2,13 +2,21 @@
  * The corpus a covering array is run over, written inside the pinned container.
  *
  * The fixtures are NOT committed: they are rebuilt from this program on every run, which keeps
- * them deterministic and keeps binary files out of the tree. The three of them are the three
- * shapes IndexFeatureFile's index kinds fall into: a plain VCF (linear index), a BED (linear index
- * over a different codec) and a block-compressed VCF (tabix).
+ * them deterministic and keeps binary files out of the tree. Three of them are the three shapes
+ * IndexFeatureFile's index kinds fall into: a plain VCF (linear index), a BED (linear index over a
+ * different codec) and a block-compressed VCF (tabix). The fourth is a small coordinate-sorted BAM
+ * with its index, which is what a read walker needs to run at all.
  *
  * Usage: MakeFixtures <directory>
  */
 
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 
@@ -41,6 +49,38 @@ public class MakeFixtures {
         return text.toString();
     }
 
+    /** A small coordinate-sorted BAM: eight reads on one contig, one of them a duplicate. */
+    static void bam(final Path bam) {
+        final SAMFileHeader header = new SAMFileHeader();
+        final SAMSequenceDictionary dictionary = new SAMSequenceDictionary();
+        dictionary.addSequence(new SAMSequenceRecord("chr1", 100000));
+        header.setSequenceDictionary(dictionary);
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        final SAMReadGroupRecord group = new SAMReadGroupRecord("rg1");
+        group.setSample("sample1");
+        group.setLibrary("lib1");
+        group.setPlatformUnit("unit1");
+        group.setPlatform("ILLUMINA");
+        header.addReadGroup(group);
+        try (final SAMFileWriter writer =
+                     new SAMFileWriterFactory().setCreateIndex(true).makeBAMWriter(header, true,
+                             bam.toFile())) {
+            for (int index = 0; index < 8; index++) {
+                final SAMRecord record = new SAMRecord(header);
+                record.setReadName("HWI:1:FC:1:1:" + (index + 1) + ":" + (index + 1));
+                record.setFlags(index == 7 ? 0x400 : 0);
+                record.setReferenceName("chr1");
+                record.setAlignmentStart(100 + index * 700);
+                record.setCigarString("10M");
+                record.setMappingQuality(60);
+                record.setReadString("ACGTACGTAC");
+                record.setBaseQualityString("IIIIIIIIII");
+                record.setAttribute("RG", "rg1");
+                writer.addAlignment(record);
+            }
+        }
+    }
+
     public static void main(final String[] args) throws Exception {
         // The deflater is pinned exactly as the oracle contract pins it for goldens: a fixture
         // that is not byte-reproducible would make a coverage measurement unrepeatable.
@@ -53,6 +93,7 @@ public class MakeFixtures {
                      new BlockCompressedOutputStream(dir.resolve("reads.vcf.gz").toFile())) {
             out.write(vcf().getBytes(StandardCharsets.UTF_8));
         }
+        bam(dir.resolve("reads.bam"));
         System.out.println("wrote " + dir);
     }
 }


### PR DESCRIPTION
`count-reads-and-bases` measures the number. What decides whether a port can RUN the tool is the layer around it, and none of that is in any golden: the value `handleResult` prints, the bytes `-O` receives, and the refusal a missing input earns before either.

Nine command lines over a new shared fixture, a small coordinate-sorted BAM with its index, written by the same program the covering arrays get their corpus from so a row there and a case here read the same bytes.

The file is the claim worth having: the whole file's count arrives as `OA==`, which is one byte, `8`, with no trailing newline. The reference writes it with `print`, and a port that used `println` would write a file one byte longer than the reference's for every run of the tool.

The rest are the traversal reaching the plumbing: an interval that holds two reads and one that holds none, a second read filter that drops the duplicate, the tool defaults disabled, a mapping quality threshold that keeps nothing, an input that does not exist and no input at all.

The suite is `golden-pending`. The candidate has to come from the oracle on a real x86-64 runner; the local run is only a smoke test.

Part of #820 (C.3, the file plumbing) and #822 (C.5, the covering arrays, which need a BAM fixture to reach a read walker at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)