### PR TITLE
Record what the covering arrays measured

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -159,7 +159,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountBases` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
 | `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
-| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, tool-argument-declarations, tool-argument-enums, usage-text | 6 | not measured |
+| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, tool-argument-declarations, tool-argument-enums, usage-text | 6 | t=2, 4/18 rows (22%), **1 distinct output** |
 | `CountVariants` | variant-walker | oracle-backed | count-variants, tool-argument-declarations, tool-argument-enums | 3 | not measured |
 | `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | not measured |
 | `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |
@@ -201,7 +201,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GroupedSVCluster` | sv-caller | oracle-backed | grouped-sv-cluster | 1 | not measured |
 | `GtfToBed` | assembly-caller | oracle-backed | gtf-to-bed | 1 | not measured |
 | `HaplotypeBasedVariantRecaller` | assembly-caller | oracle-backed | haplotype-based-variant-recaller | 1 | not measured |
-| `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file, tool-argument-declarations, tool-argument-enums, usage-text | 4 | t=2, 5/6 rows (83%) |
+| `IndexFeatureFile` | unclassified | oracle-backed | index-feature-file, tool-argument-declarations, tool-argument-enums, usage-text | 4 | t=2, 7/8 rows (88%) |
 | `JointGermlineCNVSegmentation` | sv-caller | oracle-backed | joint-germline-cnv-segmentation | 1 | not measured |
 | `LearnReadOrientationModel` | assembly-caller | oracle-backed | learn-read-orientation-model | 1 | not measured |
 | `LeftAlignAndTrimVariants` | variant-transform | oracle-backed | left-align-and-trim-variants | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -11,13 +11,13 @@
   ],
   "tools": {
     "IndexFeatureFile": {
-      "rows": 6,
+      "rows": 8,
       "accepted": 5,
-      "rejected": 1,
+      "rejected": 3,
       "distinct_outputs": 5,
-      "matched": 5,
+      "matched": 7,
       "t": 2,
-      "share": 0.833
+      "share": 0.875
     },
     "PrintBGZFBlockInformation": {
       "rows": 4,
@@ -27,6 +27,15 @@
       "matched": 4,
       "t": 2,
       "share": 1.0
+    },
+    "CountReads": {
+      "rows": 18,
+      "accepted": 3,
+      "rejected": 15,
+      "distinct_outputs": 1,
+      "matched": 4,
+      "t": 2,
+      "share": 0.222
     }
   }
 }


### PR DESCRIPTION
From the run that added the array (#1015), in the pinned container on a real x86-64 runner: the number is CI's rather than this machine's, the same way a golden is.

`CountReads` reproduces 4 of its 18 rows. That is a low number and it is the honest one: fifteen rows are refused by the reference, eleven of them because the row hands a read walker a file that is not a BAM, and the port refuses those with the decompressor's message and the wrong status rather than with the reader's:

```
reference  EXIT=3 java.lang.IllegalArgumentException: Dictionary cannot have size zero
port       EXIT=2 A USER ERROR has occurred: Malformed("InvalidGzipHeader")
```

#1016 is that gap, measured rather than described.

`IndexFeatureFile` moves from 5/6 to 7/8: the BAM the corpus grew is a row it refuses, and the port reproduces one of the two new refusals.

The array's other number is worth reading beside the share: `distinct_outputs=1` says every accepted row of `CountReads` produced the same count, so eighteen rows over eighteen arguments are testing the argument parser and the refusals rather than the traversal. A corpus that separates them is what would make the share mean more than it does.

Part of #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)