### PR TITLE
Let a tool declare the fixture values that are its own

### DIFF
--- a/tools/coverage/README.md
+++ b/tools/coverage/README.md
@@ -39,6 +39,25 @@ Fixtures belong to the repository that runs the array, not to the inventory: `ga
 which BAMs `picard-rs` keeps. Every argument left without one is reported by name, so the gap is
 visible rather than silent.
 
+`--INPUT` is one argument name over tools that do not read the same kind of file, so a single
+shared list is wrong for some of them: giving `BedToIntervalList` a BAM produces an array whose
+every row the reference refuses for the same reason, which measures the fixture and not the tool.
+A tool may therefore declare its own values, which **replace** the shared ones for that tool only:
+
+```json
+{
+  "values": { "--INPUT": ["/work/fixtures/small.bam"] },
+  "per_tool": {
+    "BedToIntervalList": { "--INPUT": ["/work/fixtures/targets.bed"] }
+  }
+}
+```
+
+The override is per tool rather than per type because a type is not enough either: two tools
+taking a `File` can want a BED and an interval list. It replaces the list rather than extending it,
+because the reason to declare one is that the shared value is wrong here, not that it is
+incomplete.
+
 ## The rule this code exists to enforce
 
 A covering array over invented values proves nothing, and fails silently, because the array still

--- a/tools/coverage/covering.py
+++ b/tools/coverage/covering.py
@@ -267,7 +267,7 @@ def report(tool, domain, excluded, rows, t, total_tuples, missing, numeric_polic
 
 
 def summarize_all(inventory_path, t, fixtures, numeric_policy, limit=None, excluded_by_hand=None,
-                  declared_constraints=()):
+                  declared_constraints=(), per_tool_fixtures=None):
     """Size the whole coverage programme: rows per tool, and the total across the inventory.
 
     This is the number the plan needs and did not have. A tool's row count is how many oracle runs
@@ -280,7 +280,10 @@ def summarize_all(inventory_path, t, fixtures, numeric_policy, limit=None, exclu
     rows_total = args_in = args_out = 0
     per_tool = []
     for tool in inventory["tools"][:limit]:
-        domain, excluded = domains.build(tool, fixtures, numeric_policy, excluded_by_hand)
+        # A tool that declares its own fixture values gets them here, so sizing the programme
+        # counts the array a tool will actually run rather than the one its shared paths imply.
+        own = domains.for_tool(fixtures, per_tool_fixtures or {}, tool["name"])
+        domain, excluded = domains.build(tool, own, numeric_policy, excluded_by_hand)
         params = sorted(domain)
         if len(params) < t:
             per_tool.append(
@@ -338,7 +341,7 @@ def main(argv):
         ap.error("pass --tool <name> or --all")
 
     raw_fixtures = json.load(open(args.fixtures)) if args.fixtures else {}
-    fixtures, hand_excluded = domains.load_fixtures(raw_fixtures)
+    fixtures, hand_excluded, per_tool_fixtures = domains.load_fixtures(raw_fixtures)
     declared_constraints = (
         raw_fixtures.get("constraints", []) if isinstance(raw_fixtures, dict) else []
     )
@@ -347,6 +350,7 @@ def main(argv):
         summary = summarize_all(
             args.inventory, args.t, fixtures, args.numeric_policy,
             excluded_by_hand=hand_excluded, declared_constraints=declared_constraints,
+            per_tool_fixtures=per_tool_fixtures,
         )
         print(
             f"t={summary['t']} policy={summary['numeric_policy']} "
@@ -371,6 +375,7 @@ def main(argv):
         return 0
 
     tool = load_tool(args.tool, args.inventory)
+    fixtures = domains.for_tool(fixtures, per_tool_fixtures, tool["name"])
     domain, excluded = domains.build(tool, fixtures, args.numeric_policy, hand_excluded)
     params = sorted(domain)
 

--- a/tools/coverage/domains.py
+++ b/tools/coverage/domains.py
@@ -148,10 +148,39 @@ def domain_of(arg, fixtures, numeric_policy="strict", excluded_by_hand=None):
 
 
 def load_fixtures(raw):
-    """Accept either {"values": {...}, "exclude": {...}} or a bare argument-to-values mapping."""
-    if isinstance(raw, dict) and ("values" in raw or "exclude" in raw):
-        return raw.get("values", {}), raw.get("exclude", {})
-    return raw or {}, {}
+    """Accept either {"values": ..., "exclude": ..., "per_tool": ...} or a bare mapping.
+
+    Returns `(values, exclude, per_tool)`. `values` is what every tool sees for an argument name;
+    `per_tool` maps a tool name to the values that *replace* them for that tool.
+
+    Why the third: `--INPUT` is one name over tools that do not read the same kind of file at all.
+    A shared list of BAMs gives `BedToIntervalList` an array whose every row the reference refuses
+    for the same reason, which measures the fixture rather than the tool. The override is per tool
+    and not per type because a type is not enough either: two tools taking a `File` can want a BED
+    and an interval list.
+    """
+    if isinstance(raw, dict) and ("values" in raw or "exclude" in raw or "per_tool" in raw):
+        per_tool = {
+            name: entry
+            for name, entry in (raw.get("per_tool") or {}).items()
+            if not name.startswith("$")
+        }
+        return raw.get("values", {}), raw.get("exclude", {}), per_tool
+    return raw or {}, {}, {}
+
+
+def for_tool(values, per_tool, name):
+    """The fixture values a named tool sees: the shared ones, with its own overriding.
+
+    An override replaces an argument's whole list rather than extending it, because the point of
+    declaring one is that the shared value is *wrong* for this tool, not that it is incomplete.
+    """
+    own = per_tool.get(name)
+    if not own:
+        return values
+    merged = dict(values)
+    merged.update({key: entry for key, entry in own.items() if not key.startswith("$")})
+    return merged
 
 
 def build(tool, fixtures, numeric_policy="strict", excluded_by_hand=None):

--- a/tools/coverage/fixtures.json
+++ b/tools/coverage/fixtures.json
@@ -21,6 +21,14 @@
     "kinds of tool, and a read walker refuses a VCF the way IndexFeatureFile refuses a BAM, so both",
     "refusals are rows rather than exclusions."
   ],
+  "$per_tool": [
+    "A tool whose `--INPUT` is not the kind of file the shared value names declares its own here,",
+    "as `\"per_tool\": { \"<Tool>\": { \"--INPUT\": [...] } }`. The override replaces the shared list",
+    "for that tool only. This repository has no such tool yet; picard-rs does, and the mechanism",
+    "lives here because the generator does.",
+    "",
+    "See tools/coverage/README.md."
+  ],
   "values": {
     "--input": [
       "/work/fixtures/reads.vcf",


### PR DESCRIPTION
`--INPUT` is one argument name over tools that do not read the same kind of file. The fixtures file maps a name to values, so `BedToIntervalList`, `SortGff`, `NormalizeFasta` and every other tool whose input is not a BAM gets the BAM list, and its array becomes rows the reference refuses for one reason. That measures the fixture, not the tool, and it is why those tools have no array at all today.

A tool may now declare its own values under `per_tool`; they **replace** the shared ones for that tool alone:

```json
{
  "values": { "--INPUT": ["/work/fixtures/small.bam"] },
  "per_tool": { "BedToIntervalList": { "--INPUT": ["/work/fixtures/targets.bed"] } }
}
```

Per tool rather than per type, because a type is not enough either: two tools taking a `File` can want a BED and an interval list. Replaces rather than extends, because the reason to write one is that the shared value is wrong here, not that it is incomplete.

Nothing in this repository declares one yet — picard-rs will — and the mechanism lives here because the generator does. Arrays generated without a `per_tool` block are byte-for-byte what they were (checked: `CollectQualityYieldMetrics` t=2 and `HaplotypeCaller` t=2 verify identically).

`python3 tools/preflight.py`: every gate green on the pinned 1.97.1 toolchain.

Unblocks the picard-rs side of IPNP-BIPN/picard-rs#113.