### PR TITLE
Call the textual index writer where it lives now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,15 +26,6 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -155,16 +146,6 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -174,23 +155,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -299,17 +270,7 @@ dependencies = [
  "htsjdk-tribble",
  "htsjdk-vcf",
  "jmath",
- "md-5 0.11.0",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
+ "md-5",
 ]
 
 [[package]]
@@ -321,30 +282,32 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2#4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
 dependencies = [
  "htsjdk-bgzf",
- "md-5 0.10.6",
+ "jmath",
+ "md-5",
 ]
 
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2#4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
 dependencies = [
  "flate2",
  "libz-sys",
+ "md-5",
 ]
 
 [[package]]
 name = "htsjdk-metrics"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2#4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
 
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2#4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
 dependencies = [
  "flate2",
  "htsjdk-bam",
@@ -353,7 +316,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2#4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
 dependencies = [
  "htsjdk-tribble",
  "jmath",
@@ -381,7 +344,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2#4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
 
 [[package]]
 name = "lexical-core"
@@ -453,22 +416,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -723,12 +676,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # resolved it. A pin nothing resolves is a pin nothing checks, so the line arrives with its first
 # caller.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4fd4c136c0d5fba8a4c39edfcaa0f96dbde71dc2" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
 # GatherBamFiles writes a .md5 beside its output, which is the only digest a ported tool computes
 # for itself. htsjdk-bam already pulls this crate in for the same algorithm.
 md-5 = "0.11.0"

--- a/crates/gatk-tools/src/print_file_diagnostics.rs
+++ b/crates/gatk-tools/src/print_file_diagnostics.rs
@@ -27,7 +27,6 @@
 //! printed after every real bin, out of numeric order, always claiming two chunks: the first pair
 //! is offsets, the second is the aligned and unaligned counts printed in the same hexadecimal.
 
-use htsjdk_bam::bin::{bin_summary_string, MAX_BINS};
 use htsjdk_bam::index::{read_bai, BaiParseError, BamIndex};
 
 /// Which analyzer the name selects.
@@ -80,27 +79,6 @@ pub fn analyzer_for(raw: &str) -> Result<Analyzer, DiagnosticsError> {
     }
 }
 
-/// `Long.toString(value, 16)`, which is lower case and unpadded and prints a negative value with a
-/// leading minus rather than as two's complement.
-fn hex(value: u64) -> String {
-    let signed = value as i64;
-    if signed < 0 {
-        format!("-{:x}", signed.unsigned_abs())
-    } else {
-        format!("{signed:x}")
-    }
-}
-
-/// `Chunk.toString`, which is the two virtual pointers as `block:offset`.
-fn chunk_string(pointer: u64) -> String {
-    format!("{}:{}", pointer >> 16, pointer & 0xFFFF)
-}
-
-/// `BlockCompressedFilePointerUtil.asAddressOffsetString`.
-fn address_offset(pointer: u64) -> String {
-    format!("{}:{}", pointer >> 16, pointer & 0xFFFF)
-}
-
 /// `BAIAnalyzer.doAnalysis`: the whole report of one `.bai`.
 pub fn bai_report(bai: &[u8]) -> Result<String, DiagnosticsError> {
     let index = read_bai(bai).map_err(|error| DiagnosticsError::Unreadable {
@@ -113,85 +91,10 @@ pub fn bai_report(bai: &[u8]) -> Result<String, DiagnosticsError> {
 }
 
 /// `TextualBAMIndexWriter` over an index already read.
+///
+/// The renderer moved to `htsjdk-bam::textual_index`: the format is htsjdk's, not this tool's, and
+/// it is measured there against the reference over the same `.bai` files the index suite measures
+/// as bytes. This tool keeps the analyzer that chooses it and the refusal that names the argument.
 pub fn render(index: &BamIndex) -> String {
-    let mut out = String::new();
-    out.push_str(&format!("n_ref={}\n", index.references.len()));
-    for (reference, content) in index.references.iter().enumerate() {
-        let bins: Vec<_> = content
-            .bins
-            .iter()
-            .filter(|bin| bin.bin_number != MAX_BINS)
-            .collect();
-        if bins.is_empty() {
-            // `writeNullContent`, whose two lines have no space after the `=`.
-            out.push_str(&format!("Reference {reference} has n_bin=0\n"));
-            out.push_str(&format!("Reference {reference} has n_intv=0\n"));
-            continue;
-        }
-        let counted = bins.len() + usize::from(content.metadata.is_some());
-        out.push_str(&format!("Reference {reference} has n_bin= {counted}\n"));
-        for bin in &bins {
-            out.push_str(&format!(
-                "  Ref {reference} bin {} ({}) has n_chunk= {}\n",
-                bin.bin_number,
-                bin_summary_string(bin.bin_number),
-                bin.chunks.len()
-            ));
-            if bin.chunks.is_empty() {
-                out.push('\n');
-            }
-            for chunk in &bin.chunks {
-                out.push_str(&format!(
-                    "     Chunk: {}-{} start: {} end: {}\n",
-                    chunk_string(chunk.start),
-                    chunk_string(chunk.end),
-                    hex(chunk.start),
-                    hex(chunk.end)
-                ));
-            }
-        }
-
-        // `writeChunkMetaData`, always bin 37450 and always two chunks when metadata is there.
-        match content.metadata {
-            None => {
-                out.push_str(&format!("  Ref {reference} bin 37450 has n_chunk= 0\n"));
-                out.push('\n');
-            }
-            Some(metadata) => {
-                out.push_str(&format!("  Ref {reference} bin 37450 has n_chunk= 2\n"));
-                out.push_str(&format!(
-                    "     Chunk:  start: {} end: {}\n",
-                    hex(metadata.first_offset),
-                    hex(metadata.last_offset)
-                ));
-                out.push_str(&format!(
-                    "     Chunk:  start: {} end: {}\n",
-                    hex(metadata.aligned as u64),
-                    hex(metadata.unaligned as u64)
-                ));
-            }
-        }
-
-        if content.linear_index.is_empty() {
-            out.push_str(&format!("Reference {reference} has n_intv= 0\n"));
-            continue;
-        }
-        out.push_str(&format!(
-            "Reference {reference} has n_intv= {}\n",
-            content.linear_index.len()
-        ));
-        for (window, entry) in content.linear_index.iter().enumerate() {
-            if *entry != 0 {
-                out.push_str(&format!(
-                    "  Ref {reference} ioffset for {window} is {}\n",
-                    address_offset(*entry)
-                ));
-            }
-        }
-    }
-    out.push_str(&format!(
-        "No Coordinate Count={}\n",
-        index.no_coordinate_records
-    ));
-    out
+    htsjdk_bam::textual_index::render(index)
 }


### PR DESCRIPTION
The pin moves to htsjdk-rs `main`, which carries the twelve classes this repository and picard-rs had been porting locally (IPNP-BIPN/htsjdk-rs#201 and the moves after it), and `PrintFileDiagnostics` takes up the first of them.

`TextualBAMIndexWriter`'s format is htsjdk's, not this tool's: the spacing that differs between an empty reference (`n_bin=0`) and every other line (`n_bin= 4`), the pseudo-bin counted with the real bins and printed after them out of numeric order, the **signed** hexadecimal. Eighty-three lines of it lived here because there was nowhere else to put them. They are in `htsjdk-bam::textual_index` now (IPNP-BIPN/htsjdk-rs#212), measured against the reference over the same `.bai` files the `build-index` suite measures as bytes.

This tool keeps what is its own: the analyzer chosen by the file's name, and the refusal that quotes the raw argument.

**Every golden here is unchanged** — which is the acceptance test the move set itself: the class lives there, the consumer calls it, and the consumer's own suites still pass.

`python3 tools/preflight.py`: every gate green on the pinned 1.97.1 toolchain.