### PR TITLE
Measure the other handler, and stop printing one banner for both

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,10 @@ jobs:
             index: "58/58"
             slug: "plugin-argument-ownership-read-filter-catalogue-mutex-target-names-count-reads-plumbing-read-walker-refusals"
             suites: "plugin-argument-ownership read-filter-catalogue mutex-target-names count-reads-plumbing read-walker-refusals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "main-non-user"
+            suites: "main-non-user"
     steps:
       - uses: actions/checkout@v7
 

--- a/crates/gatk-cli/src/lib.rs
+++ b/crates/gatk-cli/src/lib.rs
@@ -28,7 +28,7 @@
 pub mod definitions;
 pub mod runners;
 
-use gatk_tools::main_entry::{self, Failure, Route, Stream};
+use gatk_tools::main_entry::{self, Failure, Route, Stream, Thrown};
 
 /// The reference's own pins, which `printVersionInfo` reads off the jar's manifest.
 pub const TOOLKIT_NAME: &str = "The Genome Analysis Toolkit (GATK)";
@@ -56,7 +56,7 @@ pub struct Outcome {
 /// The list is empty of walkers on purpose: a tool becomes reachable here the moment its name
 /// resolves, and runnable only once its arguments have a declaration to parse against. The gap
 /// between the two is Milestone C's, and it is visible rather than papered over.
-pub type Runner = fn(&[String]) -> Result<Option<String>, (Failure, String)>;
+pub type Runner = fn(&[String]) -> Result<Option<String>, Thrown>;
 
 /// `Main.instanceMain`, with the two streams returned rather than written.
 pub fn run(args: &[String]) -> Outcome {
@@ -161,12 +161,16 @@ pub fn run(args: &[String]) -> Outcome {
                             status: 0,
                         }
                     }
-                    Err((failure, message)) => {
-                        stderr.push_str(&main_entry::user_exception_report(&message));
+                    Err(thrown) => {
+                        // Which handler this reaches is the throwable's own answer: a
+                        // `UserException` is decorated with the banner, and anything else is
+                        // printed as `handleNonUserException` prints it, which is the exception's
+                        // CLASS in front of its message and no banner at all (#1020).
+                        stderr.push_str(&thrown.report());
                         Outcome {
                             stdout,
                             stderr,
-                            status: main_entry::exit_status(failure),
+                            status: thrown.status(),
                         }
                     }
                 },
@@ -274,27 +278,27 @@ pub fn runner(name: &str) -> Option<Runner> {
 }
 
 /// The runners, each of which needs the parsed command line rather than the raw one.
-fn run_count_reads(args: &[String]) -> Result<Option<String>, (Failure, String)> {
+fn run_count_reads(args: &[String]) -> Result<Option<String>, Thrown> {
     runners::count_reads(&parsed("CountReads", args)?)
 }
 
-fn run_index_feature_file(args: &[String]) -> Result<Option<String>, (Failure, String)> {
+fn run_index_feature_file(args: &[String]) -> Result<Option<String>, Thrown> {
     runners::index_feature_file(&parsed("IndexFeatureFile", args)?)
 }
 
-fn run_print_bgzf_block_information(args: &[String]) -> Result<Option<String>, (Failure, String)> {
+fn run_print_bgzf_block_information(args: &[String]) -> Result<Option<String>, Thrown> {
     runners::print_bgzf_block_information(&parsed("PrintBGZFBlockInformation", args)?)
 }
 
 /// The tool's own parser, over the command line the dispatcher was handed.
-fn parsed(tool: &str, args: &[String]) -> Result<gatk_barclay::Parser, (Failure, String)> {
+fn parsed(tool: &str, args: &[String]) -> Result<gatk_barclay::Parser, Thrown> {
     let list = gatk_tools::tool_declarations::declarations(tool)
         .expect("the declarations of a tool with a runner");
     let mut parser = parser_for(tool, list);
     let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
     parser
         .parse_arguments(&borrowed)
-        .map_err(|error| (Failure::CommandLine, error.message))?;
+        .map_err(|error| Thrown::command_line(error.message))?;
     Ok(parser)
 }
 

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -16,12 +16,17 @@
 use gatk_barclay::{Parser, Value};
 use gatk_engine::reads::ReadsDataSource;
 use gatk_tools::index_feature_file::{self, Refusal, Source};
-use gatk_tools::main_entry::Failure;
+use gatk_tools::main_entry::{Thrown, PORT_FAILURE, PORT_LIMITATION};
 use htsjdk_bam::header::SamHeader;
 use htsjdk_bam::record::BamRecord;
 
-/// What a runner answers: what the tool returned, or the failure and its message.
-pub type Outcome = Result<Option<String>, (Failure, String)>;
+/// What a runner answers: what the tool returned, or what it threw.
+///
+/// A [`Thrown`] rather than a message, because the two handlers `mainEntry` calls write different
+/// things: `handleUserException` decorates the message with a banner, and `handleNonUserException`
+/// prints the exception's own CLASS in front of it. A runner that only reported a message left the
+/// dispatcher with one banner to print for both (`main-non-user`).
+pub type Outcome = Result<Option<String>, Thrown>;
 
 /// The value of one named argument, as the parser left it.
 ///
@@ -47,18 +52,15 @@ pub fn argument(parser: &Parser, long_name: &str) -> Option<String> {
 /// is status two.
 pub fn index_feature_file(parser: &Parser) -> Outcome {
     let input = argument(parser, "input").ok_or_else(|| {
-        (
-            Failure::CommandLine,
-            "Argument input was missing: Argument 'input' is required".to_string(),
-        )
+        Thrown::command_line("Argument input was missing: Argument 'input' is required")
     })?;
     let output = argument(parser, "output");
     // Every refusal the port makes here is a UserException in the reference, EXCEPT the one the
     // reference does not make: a tabix index this port cannot write is the port's own gap, and it
     // is reported as one rather than as a status the reference would have exited with.
     let refused = |refusal: Refusal| match refusal {
-        Refusal::TabixIsNotWritten { .. } => (Failure::Other, refusal.message()),
-        _ => (Failure::User, refusal.message()),
+        Refusal::TabixIsNotWritten { .. } => Thrown::non_user(PORT_LIMITATION, refusal.message()),
+        _ => Thrown::user(refusal.message()),
     };
     // The reference reads the file to find a codec for it, so a file that is not there is refused
     // before anything else is asked of it.
@@ -77,8 +79,9 @@ pub fn index_feature_file(parser: &Parser) -> Outcome {
     let mut source = Source::new(&input);
     source.timestamp = modified_millis(&input);
     let index = index_feature_file::build(&text, &source, &input).map_err(refused)?;
-    std::fs::write(&name, index)
-        .map_err(|error| (Failure::Other, format!("could not write {name}: {error}")))?;
+    std::fs::write(&name, index).map_err(|error| {
+        Thrown::non_user(PORT_FAILURE, format!("could not write {name}: {error}"))
+    })?;
     Ok(Some(name))
 }
 
@@ -89,14 +92,10 @@ pub fn index_feature_file(parser: &Parser) -> Outcome {
 /// what a tool returns.
 pub fn print_bgzf_block_information(parser: &Parser) -> Outcome {
     let input = argument(parser, "bgzf-file").ok_or_else(|| {
-        (
-            Failure::CommandLine,
-            "Argument bgzf-file was missing: Argument 'bgzf-file' is required".to_string(),
-        )
+        Thrown::command_line("Argument bgzf-file was missing: Argument 'bgzf-file' is required")
     })?;
     let bytes = std::fs::read(&input).map_err(|_| {
-        (
-            Failure::User,
+        Thrown::user(
             gatk_tools::print_bgzf_block_information::Refusal::DoesNotExist {
                 path: input.clone(),
             }
@@ -109,19 +108,20 @@ pub fn print_bgzf_block_information(parser: &Parser) -> Outcome {
         .unwrap_or_else(|| input.clone());
     let (report, refusal) = gatk_tools::print_bgzf_block_information::report(&bytes, &name, &input);
     match argument(parser, "output") {
-        Some(path) => std::fs::write(&path, report)
-            .map_err(|error| (Failure::Other, format!("could not write {path}: {error}")))?,
+        Some(path) => std::fs::write(&path, report).map_err(|error| {
+            Thrown::non_user(PORT_FAILURE, format!("could not write {path}: {error}"))
+        })?,
         // With no output the report goes to standard output, which the dispatcher prints as the
         // tool's own return value.
         None => {
             if let Some(refusal) = refusal {
-                return Err((Failure::User, refusal.message()));
+                return Err(Thrown::user(refusal.message()));
             }
             return Ok(Some(report));
         }
     }
     match refusal {
-        Some(refusal) => Err((Failure::User, refusal.message())),
+        Some(refusal) => Err(Thrown::user(refusal.message())),
         None => Ok(None),
     }
 }
@@ -215,7 +215,7 @@ fn read_filter<'a>(
     parser: &'a Parser,
     tool: &str,
     header: &'a SamHeader,
-) -> Result<Filter<'a>, (Failure, String)> {
+) -> Result<Filter<'a>, Thrown> {
     let mut names: Vec<String> = Vec::new();
     if !flag(parser, "disable-tool-default-read-filters") {
         names.extend(
@@ -246,8 +246,8 @@ fn read_filter<'a>(
                 max: maximum,
             });
         } else {
-            return Err((
-                Failure::Other,
+            return Err(Thrown::non_user(
+                PORT_LIMITATION,
                 format!(
                     "{name} is a GATK read filter that this port does not carry yet. This message is the port's own and not GATK's."
                 ),
@@ -279,16 +279,13 @@ pub fn count_reads(parser: &Parser) -> Outcome {
     // hands it, and refuses the rest rather than silently counting the first.
     let inputs = arguments(parser, "input");
     if inputs.len() > 1 {
-        return Err((
-            Failure::Other,
-            "More than one --input is a GATK feature that this port does not carry yet. This message is the port's own and not GATK's.".to_string(),
+        return Err(Thrown::non_user(
+            PORT_LIMITATION,
+            "More than one --input is a GATK feature that this port does not carry yet. This message is the port's own and not GATK's.",
         ));
     }
     let input = inputs.into_iter().next().ok_or_else(|| {
-        (
-            Failure::CommandLine,
-            "Argument input was missing: Argument 'input' is required".to_string(),
-        )
+        Thrown::command_line("Argument input was missing: Argument 'input' is required")
     })?;
     let path = std::path::Path::new(&input);
     // What a walker makes of the file is the READER's answer and not the tool's, and it is three
@@ -312,14 +309,14 @@ pub fn count_reads(parser: &Parser) -> Outcome {
         compressed,
         intervals_given,
     ) {
-        return Err((
-            if refusal.is_user() {
-                Failure::User
-            } else {
-                Failure::Other
-            },
-            refusal.message(),
-        ));
+        // The refusal names the exception the reference throws, and the non-user handler PRINTS
+        // that class: a walker refusing an interval over a stream with no dictionary answers
+        // `java.lang.IllegalArgumentException: ...` and not a banner (#1020).
+        return Err(if refusal.is_user() {
+            Thrown::user(refusal.message())
+        } else {
+            Thrown::non_user(refusal.exception(), refusal.message())
+        });
     }
     let index = path.with_extension("bam.bai");
     let source = if index.exists() {
@@ -327,23 +324,23 @@ pub fn count_reads(parser: &Parser) -> Outcome {
     } else {
         ReadsDataSource::open_unindexed(path)
     }
-    .map_err(|error| (Failure::User, format!("{error:?}")))?;
+    .map_err(|error| Thrown::user(format!("{error:?}")))?;
 
     let header = source.header().clone();
     let mut intervals = Vec::new();
     for query in arguments(parser, "intervals") {
         let interval = gatk_engine::interval::parse_interval(&query, &header)
-            .map_err(|error| (Failure::User, format!("{error:?}")))?;
+            .map_err(|error| Thrown::user(format!("{error:?}")))?;
         intervals.push(interval);
     }
     let filter = read_filter(parser, "CountReads", &header)?;
     let count = gatk_tools::count_reads::count_reads(&source, &intervals, &filter)
-        .map_err(|error| (Failure::User, format!("{error:?}")))?;
+        .map_err(|error| Thrown::user(format!("{error:?}")))?;
 
     if let Some(output) = argument(parser, "output") {
         // `print`, not `println`: the file is the number's digits and nothing else.
         std::fs::write(&output, gatk_tools::count_reads::output(count))
-            .map_err(|error| (Failure::Other, format!("{output}: {error}")))?;
+            .map_err(|error| Thrown::non_user(PORT_FAILURE, format!("{output}: {error}")))?;
     }
     // The tool returns the count itself, which is what `handleResult` prints.
     Ok(Some(count.to_string()))

--- a/crates/gatk-tools/src/main_entry.rs
+++ b/crates/gatk-tools/src/main_entry.rs
@@ -63,6 +63,92 @@ pub enum Failure {
     Other,
 }
 
+/// Which of the two handlers `mainEntry` gives a throwable to.
+///
+/// `handleUserException` catches `CommandLineException` and `UserException`; everything else,
+/// `OutOfMemoryError` included, falls to `handleNonUserException`. The two write different things,
+/// so the answer is not a detail of the status.
+pub fn is_user_exception(failure: Failure) -> bool {
+    matches!(failure, Failure::CommandLine | Failure::User)
+}
+
+/// What a run threw: which handler it reaches, the class the reference would name, and the message.
+///
+/// The class is carried because `handleNonUserException` PRINTS it. `handleUserException` does not,
+/// so a user exception's class is here for the same reason its status is: it is what the reference
+/// threw, and a port that only kept the message could not tell the two handlers apart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Thrown {
+    pub failure: Failure,
+    /// The exception's BINARY name, which is what `Throwable.toString` prints: a nested class
+    /// carries a `$` where its source spells a dot.
+    pub exception: &'static str,
+    /// `getLocalizedMessage`, which is `None` where the reference's is null. An empty message is
+    /// not the same thing and is `Some("")`.
+    pub message: Option<String>,
+}
+
+/// `CommandLineException`, which is a parse that failed. Barclay's, not GATK's: `Main` imports it
+/// from `org.broadinstitute.barclay.argparser`, and it is no `UserException`.
+pub const COMMANDLINE_EXCEPTION: &str = "org.broadinstitute.barclay.argparser.CommandLineException";
+/// `UserException`, which is everything the user could have written differently.
+pub const USER_EXCEPTION: &str = "org.broadinstitute.hellbender.exceptions.UserException";
+/// A capability the reference has and this port does not, which is no exception of the reference's
+/// at all. The name is deliberately not a Java one: `::` cannot appear in a binary class name, so
+/// a reader and a diff both see at once that this line is the port's and not GATK's.
+pub const PORT_LIMITATION: &str = "gatk_rs::PortLimitation";
+/// The port's own plumbing failing where no golden says what the reference does, which is a third
+/// thing again: not a refusal, and not a feature that was never carried.
+pub const PORT_FAILURE: &str = "gatk_rs::PortFailure";
+
+impl Thrown {
+    /// A `CommandLineException`: the usage, then the decorated message, then status one.
+    pub fn command_line(message: impl Into<String>) -> Self {
+        Self {
+            failure: Failure::CommandLine,
+            exception: COMMANDLINE_EXCEPTION,
+            message: Some(message.into()),
+        }
+    }
+
+    /// A `UserException`: the decorated message, then status two.
+    pub fn user(message: impl Into<String>) -> Self {
+        Self {
+            failure: Failure::User,
+            exception: USER_EXCEPTION,
+            message: Some(message.into()),
+        }
+    }
+
+    /// Anything else, which is a bug rather than a refusal: the class, the message, status three.
+    pub fn non_user(exception: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            failure: Failure::Other,
+            exception,
+            message: Some(message.into()),
+        }
+    }
+
+    /// Whether `handleUserException` is the handler this reaches.
+    pub fn is_user(&self) -> bool {
+        is_user_exception(self.failure)
+    }
+
+    /// The status `mainEntry` exits with.
+    pub fn status(&self) -> i32 {
+        exit_status(self.failure)
+    }
+
+    /// What the handler writes to stderr, which is not the same text for the two of them.
+    pub fn report(&self) -> String {
+        if self.is_user() {
+            user_exception_report(self.message.as_deref().unwrap_or_default())
+        } else {
+            non_user_exception_report(self.exception, self.message.as_deref())
+        }
+    }
+}
+
 /// `mainEntry`'s catch blocks, in the order they are written.
 pub fn exit_status(failure: Failure) -> i32 {
     match failure {
@@ -135,6 +221,23 @@ pub fn user_exception_report(message: &str) -> String {
          trace.\n",
         decorated_exception_message(USER_ERROR_PREFIX, message)
     )
+}
+
+/// `handleNonUserException`, whose whole body is `printStackTrace`.
+///
+/// The first line is `Throwable.toString()`: the class's binary name and, where there is one, `: `
+/// and the message. There is no banner, no `A USER ERROR has occurred:` prefix and no notice about
+/// a system property, which is what separates this path from the other one and what a port with a
+/// single banner gets wrong on every non-user refusal (`main-non-user`).
+///
+/// The frames under that line are the reference's own stack and this port has no equivalent to
+/// print. That is a boundary rather than an omission: the suite records the first line, which is
+/// what a row-by-row comparison reads, and that everything after it was a frame.
+pub fn non_user_exception_report(exception: &str, message: Option<&str>) -> String {
+    match message {
+        Some(message) => format!("{exception}: {message}\n"),
+        None => format!("{exception}\n"),
+    }
 }
 
 /// `printVersionInfo`, which is split across two streams.

--- a/crates/gatk-tools/tests/main_non_user.rs
+++ b/crates/gatk-tools/tests/main_non_user.rs
@@ -1,0 +1,129 @@
+//! Conformance for `handleNonUserException` against GATK 4.6.2.0, compared as the line it writes.
+//!
+//! Golden from `tools/readfilter-conformance/MainNonUserDump.java`. `main-entry` measured the
+//! OTHER handler and left this one alone, so the port had a single banner and printed it for both:
+//! a failure the reference reports as `java.lang.IllegalArgumentException: Dictionary cannot have
+//! size zero` came back as `A USER ERROR has occurred: Dictionary cannot have size zero`, with the
+//! right message, the right status and the wrong wrapper (#1020).
+//!
+//! # What this suite is for
+//!
+//!  * **the handler being `printStackTrace` and nothing else**: no banner, no prefix, no notice
+//!    about a system property;
+//!  * **the first line being `Throwable.toString()`**, which is the class's BINARY name, so a
+//!    nested class carries a `$` where its source carries a dot;
+//!  * **a null message being the class alone**, with no trailing colon, where an empty message is
+//!    the colon and nothing after it;
+//!  * **and the `Error` overload being the same handler**, so an `OutOfMemoryError` differs from
+//!    an exception only in the status `mainEntry` exits with.
+//!
+//! The frames the reference prints under that line are its own stack, and this port has none to
+//! print. That is a boundary rather than an omission, and it is stated rather than hidden: the
+//! golden's `shape` row says everything after the first line was a frame, and this test asserts
+//! that the port's report is the message and stops.
+//!
+//! While the suite is `golden-pending` the dump is named by `MAIN_NON_USER_DUMP`.
+
+use gatk_tools::main_entry::non_user_exception_report;
+
+/// The throwables the harness constructs, which are this test's inputs where the golden is its
+/// answer. The rendering is what is compared; the class and the message are what produced it.
+const CASES: &[(&str, &str, Option<&str>)] = &[
+    (
+        "illegal-argument",
+        "java.lang.IllegalArgumentException",
+        Some("Dictionary cannot have size zero"),
+    ),
+    (
+        "sam-format",
+        "htsjdk.samtools.SAMFormatException",
+        Some("Error parsing text SAM file. Not enough fields; Line 1"),
+    ),
+    ("no-message", "java.lang.IllegalStateException", None),
+    ("empty-message", "java.lang.IllegalStateException", Some("")),
+    (
+        "nested-class",
+        "MainNonUserDump$Nested",
+        Some("thrown from a class inside another"),
+    ),
+    (
+        "gatk-nested",
+        "org.broadinstitute.hellbender.exceptions.GATKException$ShouldNeverReachHereException",
+        Some("a branch that was supposed to be unreachable"),
+    ),
+    (
+        "multi-line-message",
+        "java.lang.IllegalArgumentException",
+        Some("first line\nsecond line"),
+    ),
+    (
+        "out-of-memory",
+        "java.lang.OutOfMemoryError",
+        Some("Java heap space"),
+    ),
+];
+
+fn unescape(text: &str) -> String {
+    text.replace("\\t", "\t").replace("\\n", "\n")
+}
+
+fn field(dump: &str, kind: &str, name: &str) -> String {
+    let prefix = format!("{kind}\t{name}\t");
+    dump.lines()
+        .find(|line| line.starts_with(&prefix))
+        .map(|line| unescape(&line[prefix.len()..]))
+        .unwrap_or_else(|| panic!("{kind}/{name} is not in the dump"))
+}
+
+#[test]
+fn the_non_user_handler_prints_the_class_and_the_message() {
+    let dump = match std::env::var("MAIN_NON_USER_DUMP") {
+        Ok(path) => std::fs::read_to_string(path).expect("the dump named by MAIN_NON_USER_DUMP"),
+        Err(_) => {
+            println!(
+                "skipped: the main-non-user golden is still pending. Run the suite and point \
+                 MAIN_NON_USER_DUMP at tools/conformance/pending/main-non-user.MainNonUserDump.txt"
+            );
+            return;
+        }
+    };
+
+    for (case, exception, message) in CASES {
+        let report = non_user_exception_report(exception, *message);
+        let first = report.lines().next().unwrap_or_default();
+        assert_eq!(first, field(&dump, "non-user", case), "{case}");
+
+        // The message is the whole of what follows, and the port adds nothing to it: no banner
+        // above, no property notice below. The reference's frames are the difference, and the
+        // golden's own row is what says they were frames and nothing else.
+        let expected_lines = message.map(|text| text.lines().count().max(1)).unwrap_or(1);
+        assert_eq!(
+            report.lines().count(),
+            expected_lines,
+            "{case}: extra lines"
+        );
+        assert!(report.ends_with('\n'), "{case}: the handler ends its line");
+        assert!(
+            field(&dump, "shape", case).contains("stdout=0"),
+            "{case}: the handler writes to stderr alone"
+        );
+    }
+}
+
+/// The two handlers write different things, which is the whole of the finding behind #1020.
+#[test]
+fn the_two_handlers_do_not_agree() {
+    let user = gatk_tools::main_entry::user_exception_report("Dictionary cannot have size zero");
+    let non_user = non_user_exception_report(
+        "java.lang.IllegalArgumentException",
+        Some("Dictionary cannot have size zero"),
+    );
+    assert!(user.contains("A USER ERROR has occurred: "));
+    assert!(!non_user.contains("A USER ERROR has occurred: "));
+    assert!(!non_user.contains(gatk_tools::main_entry::BANNER));
+    assert!(!non_user.contains("system property"));
+    assert_eq!(
+        non_user,
+        "java.lang.IllegalArgumentException: Dictionary cannot have size zero\n"
+    );
+}

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6351,6 +6351,26 @@
       ]
     },
     {
+      "id": "main-non-user",
+      "status": "golden-pending",
+      "title": "handleNonUserException, which is the handler handleUserException is not",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "Main"
+      ],
+      "compare": {
+        "mode": "lines"
+      },
+      "why": "`main-entry` measured `handleUserException` and left the other handler alone, so the port has one banner and prints it for both: a CountReads covering-array row shows the reference answering `java.lang.IllegalArgumentException: Dictionary cannot have size zero` and the port answering `A USER ERROR has occurred: Dictionary cannot have size zero`, with the right message, the right status and the wrong wrapper (#1020). What the reference prints on this path is `printStackTrace` and nothing else: no banner, no prefix, no property notice, and a first line that is `Throwable.toString()`, which is the class's BINARY name, so a nested class prints with a `$`.",
+      "cases": [
+        {
+          "dump": "MainNonUserDump",
+          "golden": null,
+          "why": "Eight throwables: the two a read walker reaches, a null message and an empty one, a nested class of this harness and a nested class of the reference's own, a message that spans lines, and the Error overload. The frames are not committed -- they name this harness and its line numbers -- so each case carries its first line and whether everything after it was a frame."
+        }
+      ]
+    },
+    {
       "id": "main-entry",
       "status": "oracle-backed",
       "title": "which stream each entry path writes to, what it returns, and the exit status an exception carries",

--- a/tools/readfilter-conformance/MainNonUserDump.java
+++ b/tools/readfilter-conformance/MainNonUserDump.java
@@ -1,0 +1,134 @@
+/*
+ * `handleNonUserException`, which is the handler `handleUserException` is not.
+ *
+ * `main-entry` measured `handleUserException` and left the other one alone, so a port with one
+ * banner prints it for both: a failure the reference reports as
+ *
+ *     java.lang.IllegalArgumentException: Dictionary cannot have size zero
+ *
+ * comes back from the port as
+ *
+ *     A USER ERROR has occurred: Dictionary cannot have size zero
+ *
+ * with the right message, the right status and the wrong wrapper. That is one of the two shapes of
+ * divergence a CountReads covering-array row still shows (gatk-rs#1020).
+ *
+ * Four behaviours this is built to catch.
+ *
+ *   - THE HANDLER IS printStackTrace AND NOTHING ELSE: no banner of asterisks, no
+ *     `A USER ERROR has occurred:` prefix, and no notice about a system property. Whatever else a
+ *     port prints on this path is a line the reference never writes;
+ *   - THE FIRST LINE IS Throwable.toString(), which is the class's BINARY name and, where there is
+ *     one, `: ` and the message. A nested class therefore prints with a `$` and not with the dot
+ *     its source spells it with;
+ *   - A THROWABLE WITH NO MESSAGE IS THE CLASS ALONE, with no trailing colon at all;
+ *   - AND THE Error OVERLOAD IS THE SAME HANDLER, so an OutOfMemoryError prints exactly like an
+ *     exception and differs only in the status `mainEntry` exits with.
+ *
+ * The frames after the first line name this harness and its line numbers, so committing them would
+ * make the golden fail on any edit above them. What is emitted instead is the first line, which is
+ * the whole of what a row-by-row comparison reads, and whether everything after it is a frame,
+ * which is the claim that nothing else was printed.
+ *
+ * Output:
+ *
+ *     non-user\t<case>\t<the first line, escaped>
+ *     shape\t<case>\tframes-only=<true|false>
+ *
+ * Usage: MainNonUserDump
+ */
+
+import org.broadinstitute.hellbender.Main;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+public class MainNonUserDump {
+
+    static final StringBuilder buf = new StringBuilder();
+
+    static void emit(final String kind, final String name, final String payload) {
+        buf.append(kind).append('\t').append(name).append('\t')
+                .append(payload.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n"))
+                .append('\n');
+    }
+
+    /** A nested class, so the golden says which of the two names `Throwable.toString` uses. */
+    static class Nested extends RuntimeException {
+        Nested(final String message) {
+            super(message);
+        }
+    }
+
+    /** The handler is protected, and a subclass would not be `Main`, so it is reached by reflection. */
+    static void invoke(final Class<?> type, final Throwable thrown) throws Exception {
+        final var method = Main.class.getDeclaredMethod("handleNonUserException", type);
+        method.setAccessible(true);
+        method.invoke(new Main(), thrown);
+    }
+
+    /** The clock log4j puts in front of a line, which is the only thing here that moves. */
+    static String masked(final String text) {
+        final StringBuilder out = new StringBuilder();
+        for (final String line : text.split("\n", -1)) {
+            out.append(line.replaceFirst("^\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d ", "")).append('\n');
+        }
+        return out.substring(0, Math.max(0, out.length() - 1));
+    }
+
+    static void nonUser(final String name, final Throwable thrown) throws Exception {
+        final ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+        final ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+        final PrintStream realErr = System.err;
+        final PrintStream realOut = System.out;
+        try {
+            System.setErr(new PrintStream(errBytes, true, StandardCharsets.UTF_8));
+            // Stdout is captured as well, because "the handler writes to stderr" is part of what
+            // is claimed: a port that printed the same line to the other stream would agree with
+            // a golden that only looked at one of them.
+            System.setOut(new PrintStream(outBytes, true, StandardCharsets.UTF_8));
+            invoke(thrown instanceof Error ? Error.class : Exception.class, thrown);
+        } finally {
+            System.setErr(realErr);
+            System.setOut(realOut);
+        }
+        final String[] lines = masked(errBytes.toString(StandardCharsets.UTF_8)).split("\n", -1);
+        boolean framesOnly = lines.length > 1;
+        for (int i = 1; i < lines.length; i++) {
+            if (!lines[i].isEmpty() && !lines[i].startsWith("\tat ")) {
+                framesOnly = false;
+            }
+        }
+        emit("non-user", name, lines[0]);
+        emit(
+                "shape",
+                name,
+                "frames-only=" + framesOnly + ",stdout=" + outBytes.size());
+    }
+
+    public static void main(final String[] args) throws Exception {
+        // The row that started this: an interval against a stream with no sequence dictionary.
+        nonUser("illegal-argument", new IllegalArgumentException("Dictionary cannot have size zero"));
+        // The other refusal a read walker reaches, whose class is htsjdk's rather than the JDK's.
+        nonUser("sam-format", new htsjdk.samtools.SAMFormatException(
+                "Error parsing text SAM file. Not enough fields; Line 1"));
+        // No message: the class alone, and no trailing colon.
+        nonUser("no-message", new IllegalStateException());
+        // An empty message, which is not the same thing: a colon and nothing after it.
+        nonUser("empty-message", new IllegalStateException(""));
+        // A nested class, whose binary name carries a `$` where its source name carries a dot.
+        nonUser("nested-class", new Nested("thrown from a class inside another"));
+        // A GATK exception that is itself nested, so the `$` is measured on the reference's own
+        // classes and not only on this harness's.
+        nonUser("gatk-nested", new org.broadinstitute.hellbender.exceptions.GATKException
+                .ShouldNeverReachHereException("a branch that was supposed to be unreachable"));
+        // A message that spans lines, so the golden says the first line is the class and the head
+        // of the message rather than the whole of it.
+        nonUser("multi-line-message", new IllegalArgumentException("first line\nsecond line"));
+        // The Error overload: the same handler, and the status is what differs.
+        nonUser("out-of-memory", new OutOfMemoryError("Java heap space"));
+
+        System.out.print(buf);
+    }
+}


### PR DESCRIPTION
`main-entry` measured `handleUserException` and left `handleNonUserException` alone, so the port had one banner and printed it for every refusal. A `CountReads` covering-array row shows what that costs:

```
reference  EXIT=3 java.lang.IllegalArgumentException: Dictionary cannot have size zero
port       EXIT=3 A USER ERROR has occurred: Dictionary cannot have size zero
```

The right message, the right status, the wrong wrapper. Half of #1020.

## What the other handler does

`printStackTrace` and nothing else: no banner of asterisks, no `A USER ERROR has occurred:` prefix, no notice about a system property. Its first line is `Throwable.toString()`, which is the class's **binary** name and, where there is one, `: ` and the message. So:

| case | the reference's first line |
|---|---|
| `IllegalArgumentException("Dictionary cannot have size zero")` | `java.lang.IllegalArgumentException: Dictionary cannot have size zero` |
| a **nested** class | `MainNonUserDump$Nested: ...` and `...GATKException$ShouldNeverReachHereException: ...` |
| a **null** message | `java.lang.IllegalStateException`, no trailing colon |
| an **empty** message | `java.lang.IllegalStateException: `, the colon and nothing after it |
| `OutOfMemoryError` | the same handler; only the status differs |

Eight throwables measure that. The golden holds each one's **first line** rather than the frames under it: the frames name the harness and its line numbers and would fail on any edit above them, so what is recorded instead is that everything after the first line **was** a frame, and that stdout received nothing.

## What the port does now

A runner answers with a `Thrown` — the failure, the exception's binary name, the message — and the throwable picks its own handler, because which of the two writes is not a detail of the status. The refusals a read walker makes already knew which exception the reference throws (`read-walker-refusals`); they now say so where it is printed.

Two of the classes are not the reference's, and their names say so: a capability this port does not carry is `gatk_rs::PortLimitation`, and its own plumbing failing is `gatk_rs::PortFailure`. A binary class name cannot contain `::`, so neither can be mistaken for something GATK threw.

The suite lands **golden-pending**; the golden follows from CI on a real runner.

The other half of #1020, the index a BAM's name implies, is IPNP-BIPN/htsjdk-rs#215 and lands here with the pin bump.

`python3 tools/preflight.py`: every gate green on the pinned 1.97.1 toolchain.