### PR TITLE
Ask for the index by both its names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
 dependencies = [
  "htsjdk-bgzf",
  "jmath",
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
 dependencies = [
  "flate2",
  "libz-sys",
@@ -302,12 +302,12 @@ dependencies = [
 [[package]]
 name = "htsjdk-metrics"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
 
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
 dependencies = [
  "flate2",
  "htsjdk-bam",
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
 dependencies = [
  "htsjdk-tribble",
  "jmath",
@@ -344,7 +344,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=411afed193ee19a284be7f7e21e068b4df4db9aa#411afed193ee19a284be7f7e21e068b4df4db9aa"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
 
 [[package]]
 name = "lexical-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # resolved it. A pin nothing resolves is a pin nothing checks, so the line arrives with its first
 # caller.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "411afed193ee19a284be7f7e21e068b4df4db9aa" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
 # GatherBamFiles writes a .md5 beside its output, which is the only digest a ported tool computes
 # for itself. htsjdk-bam already pulls this crate in for the same algorithm.
 md-5 = "0.11.0"

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -318,11 +318,13 @@ pub fn count_reads(parser: &Parser) -> Outcome {
             Thrown::non_user(refusal.exception(), refusal.message())
         });
     }
-    let index = path.with_extension("bam.bai");
-    let source = if index.exists() {
-        ReadsDataSource::open(path, &index)
-    } else {
-        ReadsDataSource::open_unindexed(path)
+    // The index is the one htsjdk's own search finds, not the one a single `with_extension` call
+    // guesses. `reads.bam.bai` was the only name asked for here, and htsjdk writes `reads.bai` at
+    // least as often and looks for it FIRST, so an interval query over a file indexed the other
+    // way found no index and answered zero rather than refusing (#1020).
+    let source = match htsjdk_bam::sam_files::find_index(path) {
+        Some(index) => ReadsDataSource::open(path, &index),
+        None => ReadsDataSource::open_unindexed(path),
     }
     .map_err(|error| Thrown::user(format!("{error:?}")))?;
 

--- a/crates/gatk-cli/tests/count_reads_plumbing.rs
+++ b/crates/gatk-cli/tests/count_reads_plumbing.rs
@@ -52,7 +52,7 @@ fn scratch(case: &str) -> std::path::PathBuf {
 ///
 /// Rebuilt here rather than read from disk. The bytes of the file are the writer's business and
 /// are compared in htsjdk-rs; what this suite needs is the reads the golden's cases were run over.
-fn fixture(dir: &std::path::Path) -> std::path::PathBuf {
+fn fixture_named(dir: &std::path::Path, index_name: &str) -> std::path::PathBuf {
     use htsjdk_bam::cigar::{Cigar, CigarElement, Op};
     use htsjdk_bam::header::{ReadGroup, SamHeader, SequenceRecord};
     use htsjdk_bam::record::BamRecord;
@@ -100,8 +100,13 @@ fn fixture(dir: &std::path::Path) -> std::path::PathBuf {
     let (bam, bai) = writer.finish_with_index().expect("the fixture");
     let path = dir.join("reads.bam");
     std::fs::write(&path, bam).expect("the fixture");
-    std::fs::write(dir.join("reads.bam.bai"), bai).expect("the index");
+    std::fs::write(dir.join(index_name), bai).expect("the index");
     path
+}
+
+/// The fixture with the index named the way this suite's cases were run: `reads.bam.bai`.
+fn fixture(dir: &std::path::Path) -> std::path::PathBuf {
+    fixture_named(dir, "reads.bam.bai")
 }
 
 /// Every case the golden ran, through the dispatcher.
@@ -234,4 +239,45 @@ fn the_refusals_are_the_reference_ones() {
         "{}",
         run.stderr
     );
+}
+
+/// The index htsjdk writes when it replaces the extension, which is the name it looks for FIRST.
+///
+/// `reads.bam.bai` was the only name this runner asked for, so a BAM indexed as `reads.bai` opened
+/// UNINDEXED and an interval query over it counted nothing: a wrong answer with a zero status,
+/// which is worse than a refusal. The search is htsjdk's now (`htsjdk_bam::sam_files::find_index`,
+/// measured in htsjdk-rs's `samfiles` suite), so both names answer the same number (#1020).
+#[test]
+fn an_index_named_by_replacing_the_extension_is_found() {
+    let expected = {
+        let dir = scratch("index-appended");
+        let bam = fixture_named(&dir, "reads.bam.bai");
+        let run = gatk_cli::run(&args(&[
+            "CountReads",
+            "--input",
+            &bam.to_string_lossy(),
+            "-L",
+            "chr1:1-1000",
+        ]));
+        assert_eq!(run.status, 0, "{}", run.stderr);
+        run.stdout
+    };
+    // The interval has to hold something, or the two names would agree on zero for the wrong
+    // reason: an unindexed read of the whole file also answers a number.
+    assert!(
+        expected.contains("Tool returned:\n2"),
+        "the interval counts two reads: {expected}"
+    );
+
+    let dir = scratch("index-replaced");
+    let bam = fixture_named(&dir, "reads.bai");
+    let run = gatk_cli::run(&args(&[
+        "CountReads",
+        "--input",
+        &bam.to_string_lossy(),
+        "-L",
+        "chr1:1-1000",
+    ]));
+    assert_eq!(run.status, 0, "{}", run.stderr);
+    assert_eq!(run.stdout, expected);
 }


### PR DESCRIPTION
The other half of #1020, and the half that was a wrong **answer** rather than a wrong wrapper. `CountReads` opened its index with

```rust
path.with_extension("bam.bai")
```

which is one of the two names htsjdk writes and not the one it looks for **first**. A covering-array row over the corpus's BAM counted two reads in the reference and none in the port: the interval query found no index, opened the file unindexed, and no index is not an error.

## The search is htsjdk's, so it lives there

`SamFiles.findIndex` moved to `htsjdk-bam::sam_files` with a suite of thirty-one layouts (IPNP-BIPN/htsjdk-rs#215, IPNP-BIPN/htsjdk-rs#216); this calls it, and the pin moves with it.

The measurement said the rule is not the one the method's summary gives. The extension is **replaced** before it is **appended**, so `reads.bai` and then `reads.csi` are both tried before `reads.bam.bai` — a `.csi` beside a BAM beats a `.bam.bai` beside the same file. A CRAM has no replaced `.csi` at all. A directory named like an index is stepped over, because `Files.isRegularFile` refuses it. And a search that finds nothing resolves the path's symbolic links and runs again at the real location.

## The test is the failure it fixes

The same fixture is written twice, once indexed as `reads.bam.bai` and once as `reads.bai`, and the same interval is counted over both. It asserts the interval holds two reads before comparing, so the two names cannot agree on zero for the wrong reason. Against the old lookup it fails with `left: "Tool returned:\n0\n"` and `right: "Tool returned:\n2\n"`, which is the row from the corpus.

The new coverage number follows from CI's `argument-coverage` job, which is what closes #1020.

`python3 tools/preflight.py`: every gate green on the pinned 1.97.1 toolchain.