### PR TITLE
Record the eighteen rows CountReads now reproduces

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -159,7 +159,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountBases` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
 | `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
-| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, read-walker-refusals, tool-argument-declarations, tool-argument-enums, usage-text | 7 | t=2, 4/18 rows (22%), **1 distinct output** |
+| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, read-walker-refusals, tool-argument-declarations, tool-argument-enums, usage-text | 7 | t=2, 18/18 rows (100%), **1 distinct output** |
 | `CountVariants` | variant-walker | oracle-backed | count-variants, tool-argument-declarations, tool-argument-enums | 3 | not measured |
 | `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | not measured |
 | `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -33,9 +33,9 @@
       "accepted": 3,
       "rejected": 15,
       "distinct_outputs": 1,
-      "matched": 4,
+      "matched": 18,
       "t": 2,
-      "share": 0.222
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
The covering array's third run, after the two shapes of divergence #1020 named were fixed: **4 of 18 rows became 18 of 18**, and `CountReads` is the first tool whose whole `t=2` array the port answers exactly as the reference does, refusals included.

The two were:

* **the banner.** `handleNonUserException` prints the exception's class and message where the port printed `A USER ERROR has occurred:` (#1026, #1027). Fifteen of the eighteen rows are refusals, so one wrong wrapper was most of the gap;
* **the index.** htsjdk writes the index of `reads.bam` as `reads.bai` and looks for that name **first**; the port asked for `reads.bam.bai` alone, so the one row with an interval over an indexed BAM counted nothing (#1028, IPNP-BIPN/htsjdk-rs#215).

What the number does **not** say is unchanged and still worth repeating: `distinct_outputs=1` means every *accepted* row produced the same count, so eighteen rows over eighteen arguments are testing the parser and the refusals rather than the traversal. 100% here is 100% of what this corpus can observe.

Closes #1020.