### PR TITLE
Write the tabix index, and stop refusing the file that needs one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "gkl-deflate"
+version = "0.1.0"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,7 +287,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
 dependencies = [
  "htsjdk-bgzf",
  "jmath",
@@ -292,9 +297,10 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
 dependencies = [
  "flate2",
+ "gkl-deflate",
  "libz-sys",
  "md-5",
 ]
@@ -302,21 +308,22 @@ dependencies = [
 [[package]]
 name = "htsjdk-metrics"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
 
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
 dependencies = [
  "flate2",
  "htsjdk-bam",
+ "htsjdk-bgzf",
 ]
 
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
 dependencies = [
  "htsjdk-tribble",
  "jmath",
@@ -344,7 +351,7 @@ dependencies = [
 [[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=bef0b550cb7bbd6c326dac822c2158eacd382838#bef0b550cb7bbd6c326dac822c2158eacd382838"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
 
 [[package]]
 name = "lexical-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # resolved it. A pin nothing resolves is a pin nothing checks, so the line arrives with its first
 # caller.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "bef0b550cb7bbd6c326dac822c2158eacd382838" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
 # GatherBamFiles writes a .md5 beside its output, which is the only digest a ported tool computes
 # for itself. htsjdk-bam already pulls this crate in for the same algorithm.
 md-5 = "0.11.0"

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -55,12 +55,14 @@ pub fn index_feature_file(parser: &Parser) -> Outcome {
         Thrown::command_line("Argument input was missing: Argument 'input' is required")
     })?;
     let output = argument(parser, "output");
-    // Every refusal the port makes here is a UserException in the reference, EXCEPT the one the
-    // reference does not make: a tabix index this port cannot write is the port's own gap, and it
-    // is reported as one rather than as a status the reference would have exited with.
-    let refused = |refusal: Refusal| match refusal {
-        Refusal::TabixIsNotWritten { .. } => Thrown::non_user(PORT_LIMITATION, refusal.message()),
-        _ => Thrown::user(refusal.message()),
+    // Almost every refusal here is a `UserException`, which is status two; the one that is not
+    // names its own class and takes the other handler.
+    let refused = |refusal: Refusal| {
+        if refusal.is_user() {
+            Thrown::user(refusal.message())
+        } else {
+            Thrown::non_user(refusal.java_class(), refusal.message())
+        }
     };
     // The reference reads the file to find a codec for it, so a file that is not there is refused
     // before anything else is asked of it.
@@ -78,7 +80,22 @@ pub fn index_feature_file(parser: &Parser) -> Outcome {
     // the reference's bytes has to supply the real one, which is what this does.
     let mut source = Source::new(&input);
     source.timestamp = modified_millis(&input);
-    let index = index_feature_file::build(&text, &source, &input).map_err(refused)?;
+    // A block compressed input gets a tabix index, whose positions are the pointers a BGZF reader
+    // reports rather than offsets into the text, so it is handed the FILE and not what is in it.
+    let index = match index_feature_file::index_kind(&input) {
+        index_feature_file::IndexKind::Tabix => {
+            // A `.tbi` is a BGZF file, and GATK replaces htsjdk's static deflater factory: the
+            // reference's bytes are Intel's GKL unless `--use-jdk-deflater` says otherwise, which
+            // is the argument the tool declares for exactly this.
+            let deflater = if flag(parser, "use-jdk-deflater") {
+                htsjdk_bgzf::Deflater::Jdk
+            } else {
+                htsjdk_bgzf::Deflater::Gkl
+            };
+            index_feature_file::build_tabix(&bytes, &source, &input, deflater).map_err(refused)?
+        }
+        _ => index_feature_file::build(&text, &source, &input).map_err(refused)?,
+    };
     std::fs::write(&name, index).map_err(|error| {
         Thrown::non_user(PORT_FAILURE, format!("could not write {name}: {error}"))
     })?;

--- a/crates/gatk-tools/src/index_feature_file.rs
+++ b/crates/gatk-tools/src/index_feature_file.rs
@@ -23,16 +23,34 @@
 //! [`Source::timestamp`] by default: a caller that wants the reference's own bytes has to supply
 //! the real mtime.
 //!
-//! # Tabix is measured but not built here
+//! # Tabix is a different index in a different space
 //!
-//! A block compressed input takes the tabix branch, which needs a tabix writer htsjdk-rs does not
-//! have yet. [`index_kind`] answers [`IndexKind::Tabix`] for those, [`default_output`] names the
-//! `.tbi`, and the refusal that guards its extension is ported; the bytes are not.
+//! A block compressed input takes the tabix branch, and it is not the same index with a different
+//! header: it is the BAM's binning scheme, written by [`htsjdk_tribble::tabix`], and its positions
+//! are BGZF VIRTUAL offsets rather than byte offsets into the text. [`build_tabix`] is therefore
+//! handed the file's own bytes, decompresses them once, and maps each feature's offset in the text
+//! back to the pointer a reader would report for it.
+//!
+//! That mapping is `BlockCompressedInputStream.getFilePointer`'s rule, which is not the obvious
+//! one: a pointer never dangles past the end of a block, so an offset sitting exactly at a block
+//! boundary is the NEXT block's address with offset zero. The file's end is the same rule reached
+//! at the terminator block.
+//!
+//! # The `.tbi` is a BGZF file, so the deflater decides its bytes
+//!
+//! `TabixIndex.write` block compresses through `BlockCompressedOutputStream`, whose deflater is a
+//! STATIC factory GATK replaces: the reference's `.tbi` is Intel's GKL and not the JDK's zlib
+//! unless `--use-jdk-deflater` says otherwise. The golden's own block settles it -- 104 bytes,
+//! which `java.util.zip` gives at no level and GKL gives at five -- so [`build_tabix`] takes the
+//! deflater as an argument rather than assuming either.
 
+use htsjdk_bgzf::read::BgzfReader;
+use htsjdk_bgzf::{vfp, Deflater};
 use htsjdk_tribble::index::{IntervalChrIndex, TribbleIndex, INTERVAL_TREE, LINEAR, VERSION};
 use htsjdk_tribble::index_write::{
     BalanceApproach, BuiltIndex, DynamicIndexCreator, Feature, LinearIndexCreator,
 };
+use htsjdk_tribble::tabix::{FeatureRef, TabixFormat, TabixIndexCreator};
 
 /// `OPTIMAL_GVCF_INDEX_BIN_SIZE`.
 pub const OPTIMAL_GVCF_INDEX_BIN_SIZE: i32 = 128_000;
@@ -68,19 +86,13 @@ pub enum Refusal {
     WrongIndexExtension { path: String },
     /// The features are not in order, which Tribble raises and the tool wraps.
     CouldNotIndexFile { path: String, detail: String },
-    /// THE PORT'S OWN refusal, which the reference never makes: a block-compressed input needs a
-    /// tabix index, and this port has no writer for one.
-    ///
-    /// It is a separate variant because the alternative was borrowing
-    /// [`Refusal::WrongIndexExtension`], and that put the reference's words on the port's gap: a
-    /// covering array run against the binary reported the two as the same answer, and the row
-    /// where the reference writes a tabix index and the port cannot read as a refusal the
-    /// reference agrees with. A gap has to say it is one.
-    TabixIsNotWritten { path: String },
+    /// The bytes handed to [`build_tabix`] are not a BGZF stream, which a name ending `.gz` had
+    /// promised they were.
+    NotBlockCompressed { path: String, detail: String },
 }
 
 impl Refusal {
-    pub fn java_class(&self) -> &str {
+    pub fn java_class(&self) -> &'static str {
         match self {
             Refusal::CouldNotReadInputFile { .. } => {
                 "org.broadinstitute.hellbender.exceptions.UserException$CouldNotReadInputFile"
@@ -94,10 +106,17 @@ impl Refusal {
             Refusal::CouldNotIndexFile { .. } => {
                 "org.broadinstitute.hellbender.exceptions.UserException$CouldNotIndexFile"
             }
-            // No Java class: the reference does not make this refusal, and naming one of its
-            // exceptions here would be a claim about the reference.
-            Refusal::TabixIsNotWritten { .. } => "",
+            // htsjdk's own words for a stream whose first block is not one: GATK does not wrap it.
+            Refusal::NotBlockCompressed { .. } => "htsjdk.samtools.SAMFormatException",
         }
+    }
+
+    /// Whether `handleUserException` is the handler this reaches, which decides the status.
+    ///
+    /// All but one are a `UserException`. `SAMFormatException` is not, so a stream that promised
+    /// to be block compressed and was not exits three rather than two.
+    pub fn is_user(&self) -> bool {
+        !matches!(self, Refusal::NotBlockCompressed { .. })
     }
 
     pub fn message(&self) -> String {
@@ -114,10 +133,9 @@ impl Refusal {
             Refusal::CouldNotIndexFile { path, detail } => {
                 format!("Error while trying to create index for {path}. Error was: {detail}")
             }
-            Refusal::TabixIsNotWritten { path } => format!(
-                "{path} needs a tabix index, which this port does not write yet. This message is \
-                 the port's own and not GATK's."
-            ),
+            Refusal::NotBlockCompressed { path, detail } => {
+                format!("{path} is not a block compressed file: {detail}")
+            }
         }
     }
 }
@@ -244,6 +262,134 @@ fn end_attribute(info: &str) -> Option<i32> {
         .and_then(|value| value.parse().ok())
 }
 
+/// Where each block of a BGZF stream begins, on both sides of the decompression.
+///
+/// `(block address in the file, offset of the block's first byte in the decompressed text)`, plus
+/// the address one past the last data block, which is where the terminator sits.
+struct BlockMap {
+    blocks: Vec<(u64, usize)>,
+    text_length: usize,
+    end_address: u64,
+}
+
+impl BlockMap {
+    /// `BlockCompressedInputStream.getFilePointer` for an offset into the decompressed text.
+    ///
+    /// The rule is not "the block holding this byte, and the offset within it": a pointer never
+    /// dangles past the end of a block, so an offset sitting exactly on a boundary belongs to the
+    /// NEXT block at offset zero. The end of the text is that same rule reached at the terminator.
+    fn virtual_offset(&self, offset: usize) -> i64 {
+        if offset >= self.text_length {
+            return vfp::make_file_pointer(self.end_address, 0).unwrap_or(0) as i64;
+        }
+        // The last block whose text begins at or before this offset, which is the one holding it.
+        let (address, start) = self
+            .blocks
+            .iter()
+            .rev()
+            .find(|(_, start)| *start <= offset)
+            .copied()
+            .expect("a block for every offset of the text");
+        vfp::make_file_pointer(address, (offset - start) as u32).unwrap_or(0) as i64
+    }
+}
+
+/// Decompress the stream and record where each block began on both sides of it.
+fn block_map(compressed: &[u8], path: &str) -> Result<(String, BlockMap), Refusal> {
+    let refused = |detail: String| Refusal::NotBlockCompressed {
+        path: path.to_string(),
+        detail,
+    };
+    let mut reader = BgzfReader::new(compressed);
+    let mut text = Vec::new();
+    let mut blocks = Vec::new();
+    let mut end_address = 0u64;
+    loop {
+        let block = reader
+            .next_block()
+            .map_err(|error| refused(format!("{error:?}")))?;
+        let Some(block) = block else { break };
+        end_address = block.block_address + block.block_compressed_size as u64;
+        // A terminator block carries no data, and it is where the file's end pointer lands rather
+        // than a block any offset falls inside.
+        if !block.data.is_empty() {
+            blocks.push((block.block_address, text.len()));
+            text.extend_from_slice(&block.data);
+        }
+    }
+    if blocks.is_empty() && text.is_empty() && compressed.is_empty() {
+        return Err(refused("the file is empty".to_string()));
+    }
+    let text_length = text.len();
+    let text = String::from_utf8(text).map_err(|error| refused(format!("{error}")))?;
+    Ok((
+        text,
+        BlockMap {
+            blocks,
+            text_length,
+            end_address,
+        },
+    ))
+}
+
+/// `IndexFactory.createTabixIndex`, then `index.write(path)`: the `.tbi` a block compressed input
+/// gets where a plain one gets a `.idx`.
+///
+/// The bytes are the FILE's, not its text, because a tabix index's positions are the pointers a
+/// BGZF reader would report and those cannot be recovered from the decompressed bytes alone.
+pub fn build_tabix(
+    compressed: &[u8],
+    source: &Source,
+    file_name: &str,
+    deflater: Deflater,
+) -> Result<Vec<u8>, Refusal> {
+    let codec = codec_for(file_name).ok_or_else(|| Refusal::NoSuitableCodecs {
+        path: source.path.clone(),
+    })?;
+    let (text, map) = block_map(compressed, &source.path)?;
+    let found = features(&text, codec);
+    let ordered: Vec<Feature> = found.iter().map(|(feature, _)| feature.clone()).collect();
+    // The same check the Tribble branch makes, in the same words: `createIndex` runs it before the
+    // creator sees anything, whichever creator it is.
+    htsjdk_tribble::index_write::check_ordering(&ordered, &source.path).map_err(|error| {
+        Refusal::CouldNotIndexFile {
+            path: source.path.clone(),
+            detail: wrapped(&error),
+        }
+    })?;
+
+    let mut creator = TabixIndexCreator::new(match codec {
+        Codec::Vcf => TabixFormat::VCF,
+        Codec::Bed => TabixFormat::BED,
+    });
+    for (feature, offset) in &found {
+        // `featToString`, which is what the reference's own refusal quotes.
+        let description = format!("{}:{}-{}", feature.contig, feature.start, feature.end);
+        let entry = FeatureRef {
+            contig: &feature.contig,
+            start: feature.start,
+            end: feature.end,
+            description: &description,
+            // No sequence dictionary: `IndexFeatureFile` passes one only when `--sequence-dictionary`
+            // is given, and it decides an allocation rather than any byte.
+            sequence_length: 0,
+        };
+        creator
+            .add_feature(entry, map.virtual_offset(*offset as usize))
+            .map_err(|error| Refusal::CouldNotIndexFile {
+                path: source.path.clone(),
+                detail: format!("{}: {}", error.java_class(), error.message()),
+            })?;
+    }
+    let index = creator
+        .finish(map.virtual_offset(map.text_length))
+        .map_err(|error| Refusal::CouldNotIndexFile {
+            path: source.path.clone(),
+            detail: format!("{}: {}", error.java_class(), error.message()),
+        })?;
+    Ok(index.write_with(deflater))
+}
+
 /// `IndexFactory.createIndex` for the two branches that write a `.idx`, then `index.write(path)`.
 pub fn build(text: &str, source: &Source, file_name: &str) -> Result<Vec<u8>, Refusal> {
     let codec = codec_for(file_name).ok_or_else(|| Refusal::NoSuitableCodecs {
@@ -263,11 +409,14 @@ pub fn build(text: &str, source: &Source, file_name: &str) -> Result<Vec<u8>, Re
     let file_size = text.len() as i64;
     let (index_type, properties, contigs, interval_contigs) = match index_kind(file_name) {
         IndexKind::Tabix => {
-            // The caller is expected to have taken the tabix branch itself: this port has no
-            // writer for it, and the golden records those bytes for a later brick. The refusal is
-            // the PORT'S own, so that nothing downstream can read it as the reference's.
-            return Err(Refusal::TabixIsNotWritten {
+            // A tabix index is not a Tribble index with a different header, and it is not built
+            // from text: its positions are virtual offsets into the file that was handed in.
+            // [`build_tabix`] takes those bytes; this function only ever sees the text.
+            return Err(Refusal::CouldNotIndexFile {
                 path: source.path.clone(),
+                detail: "a block compressed input takes build_tabix, which is handed the file's \
+                         own bytes. This message is the port's own and not GATK's."
+                    .to_string(),
             });
         }
         IndexKind::Linear => {

--- a/crates/gatk-tools/tests/index_feature_file.rs
+++ b/crates/gatk-tools/tests/index_feature_file.rs
@@ -18,7 +18,7 @@
 //! # What the golden does not pin down here
 //!
 //! The tabix branch. Its bytes are in the golden for a later brick, and this port answers
-//! `IndexKind::Tabix` for those names without writing anything. The suite asserts the choice and
+//! `IndexKind::Tabix` for those names, and `build_tabix` writes one. The suite asserts the choice and
 //! the naming, not the bytes.
 //!
 //! The timestamp the reference embeds is zeroed by the dump, so the bytes compared here are the
@@ -26,8 +26,9 @@
 
 use gatk_corpus as corpus;
 use gatk_tools::index_feature_file::{
-    build, codec_for, default_output, index_kind, IndexKind, Refusal, Source,
+    build, build_tabix, codec_for, default_output, index_kind, IndexKind, Refusal, Source,
 };
+use htsjdk_bgzf::Deflater;
 
 fn golden() -> String {
     corpus::read_golden(
@@ -130,31 +131,43 @@ fn the_default_output_is_appended_to_the_whole_name() {
     assert_eq!(default_output("reads.vcf.gz"), "reads.vcf.gz.tbi");
 }
 
-/// The port's own refusal is not one of the reference's, and says so.
+/// The `.tbi` a block compressed input gets, against the reference's own bytes.
+///
+/// The golden carries the compressed FILE as well as its index, which is what makes this
+/// comparable at all: a tabix index's positions are the pointers a BGZF reader reports, so they
+/// depend on where the blocks fall and not only on the features.
 #[test]
-fn the_tabix_branch_refuses_in_the_ports_own_words() {
+fn a_block_compressed_input_gets_the_reference_tabix_index() {
     let text = golden();
-    // The reference writes a tabix index for this input, and the golden holds those bytes.
-    assert!(!bytes(&text, "index", "compressed").is_empty());
-    // The branch is chosen by the NAME, so the plain fixture's text under the compressed
-    // fixture's name reaches it without this test having to decompress anything.
-    let ours = build(
-        &input(&text, "plain"),
+    let compressed = bytes(&text, "input", "compressed");
+    // GATK replaces htsjdk's static deflater factory, so the reference's own `.tbi` is GKL's
+    // bytes: its single block is 104 long, which `java.util.zip` gives at no level.
+    let ours = build_tabix(
+        &compressed,
         &source("compressed"),
         name("compressed"),
+        Deflater::Gkl,
     )
-    .expect_err("the port has no tabix writer");
-    // No Java class, because the reference makes no such refusal: naming one of its exceptions
-    // here would be a claim about the reference rather than about this port.
-    assert_eq!(ours.java_class(), "");
-    assert!(ours.message().contains("this port does not write yet"));
-    // And it is NOT the refusal the reference makes for a mismatched extension, which is what a
-    // covering array run against the binary caught: the two used to be the same variant, so a row
-    // where the reference writes an index and the port cannot read as agreement.
-    let theirs = Refusal::WrongIndexExtension {
-        path: format!("<dir>/{}", name("compressed")),
-    };
-    assert_ne!(ours.message(), theirs.message());
+    .expect("the tabix index");
+    assert_eq!(ours, bytes(&text, "index", "compressed"));
+    // The explicit-output case is the same index under another name, so the same bytes answer it.
+    assert_eq!(ours, bytes(&text, "index", "compressed-explicit"));
+}
+
+/// A file whose name promises BGZF and whose bytes are not, which is the one refusal here that is
+/// no `UserException`.
+#[test]
+fn a_stream_that_is_not_block_compressed_is_not_a_user_error() {
+    let refusal = build_tabix(
+        b"not a bgzf stream at all",
+        &source("compressed"),
+        name("compressed"),
+        Deflater::Gkl,
+    )
+    .expect_err("plain bytes are not a BGZF stream");
+    assert!(!refusal.is_user());
+    assert_eq!(refusal.java_class(), "htsjdk.samtools.SAMFormatException");
+    assert!(refusal.message().contains("is not a block compressed file"));
 }
 
 #[test]


### PR DESCRIPTION
`IndexFeatureFile`'s covering array has read **7 of 8 rows** since it was first run against the binary, and the row that differs is the same one every time: a block compressed input, where the reference writes a `.tbi` and the port refuses in a message whose own words say the refusal is the port's. The golden has carried those bytes all along.

Three things had to be true, and each was a different problem.

**The class.** `TabixIndexCreator` and `TabixIndex` are htsjdk's, and they are in `htsjdk-tribble::tabix` now, measured over nineteen feature streams (IPNP-BIPN/htsjdk-rs#217, IPNP-BIPN/htsjdk-rs#218). The pin moves with them.

**The positions.** A tabix index does not hold byte offsets into the text, it holds the pointers a BGZF reader reports — so `build_tabix` is handed the **file** rather than what is in it: it decompresses once, records where every block began on both sides, and maps each feature's offset back. That mapping is `getFilePointer`'s rule and not the obvious one: a pointer never dangles past the end of a block, so an offset sitting exactly on a boundary is the *next* block's address at offset zero, and the file's end is that rule reached at the terminator.

**The deflater.** A `.tbi` is a BGZF file, and `BlockCompressedOutputStream` deflates through a static factory GATK replaces. The golden's single block is **104** bytes: `java.util.zip` gives 101 at level 5 and matches at no level at all; Intel's GKL gives 104 and matches byte for byte. So the deflater is an argument (IPNP-BIPN/htsjdk-rs#219), and the runner reads it off `--use-jdk-deflater`, which is what the tool declares it for.

`Refusal::TabixIsNotWritten` is **deleted** rather than reworded. In its place is one the reference does make: bytes that promised BGZF and are not are a `SAMFormatException`, which is no `UserException`, so that path exits three rather than two.

## The row still differs, and the reason is not this code

The index **body** is now the reference's for both fixtures, byte for byte. What is left is the compression, and the golden and the array reach the reference by two different doors:

| path | how it runs the tool | `samjdk.compression_level` | GKL backend |
|---|---|---:|---|
| `index-feature-file` dump | `new IndexFeatureFile().instanceMain(...)` | unset, so htsjdk's **5** | zlib + `deflate_medium` |
| covering array | `Main IndexFeatureFile` | **2**, from `GATKConfig` | ISA-L igzip |

`GATKConfig` declares `samjdk.compression_level` with `@DefaultValue("2")` and `@SystemProperty`, and `Main.setupConfigAndExtractProgram` applies it before any tool runs. So every BGZF byte a real `gatk` invocation writes is level 2 — the one level pair GKL does not route through zlib. #1032 carries the measurement and closes the row; it is not specific to tabix and lands on every tool that writes a block-compressed file through the dispatcher.

Part of #1030.

`python3 tools/preflight.py`: every gate green on the pinned 1.97.1 toolchain.