### PR TITLE
Measure the config GATK installs, whose compression level is two

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: nasm, which is what makes GKL's igzip exact rather than merely valid
+        # `gkl-igzip` links ISA-L, and ISA-L without an assembler falls back to its readable C.
+        # That C still returns valid deflate; it is simply not GKL's, and `gkl-deflate` refuses the
+        # levels it would have answered rather than guessing. GATKConfig writes at level TWO, which
+        # is one of them, so a build without nasm cannot write a block-compressed file at all.
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq nasm && nasm -v
+
       - uses: dtolnay/rust-toolchain@master
         with:
           # Pinned; must match rust-toolchain.toml.
@@ -91,6 +98,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      - name: nasm, which is what makes GKL's igzip exact rather than merely valid
+        # `gkl-igzip` links ISA-L, and ISA-L without an assembler falls back to its readable C.
+        # That C still returns valid deflate; it is simply not GKL's, and `gkl-deflate` refuses the
+        # levels it would have answered rather than guessing. GATKConfig writes at level TWO, which
+        # is one of them, so a build without nasm cannot write a block-compressed file at all.
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq nasm && nasm -v
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -410,6 +424,10 @@ jobs:
             index: "59/59"
             slug: "read-walker-refusals"
             suites: "read-walker-refusals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "gatk-config"
+            suites: "gatk-config"
     steps:
       - uses: actions/checkout@v7
 
@@ -456,6 +474,13 @@ jobs:
           fail-on-cache-miss: true
 
       - run: docker load -i /tmp/oracle-image.tar
+
+      - name: nasm, which is what makes GKL's igzip exact rather than merely valid
+        # `gkl-igzip` links ISA-L, and ISA-L without an assembler falls back to its readable C.
+        # That C still returns valid deflate; it is simply not GKL's, and `gkl-deflate` refuses the
+        # levels it would have answered rather than guessing. GATKConfig writes at level TWO, which
+        # is one of them, so a build without nasm cannot write a block-compressed file at all.
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq nasm && nasm -v
 
       - name: Build the port binary
         # linux/amd64, which is what the container runs. The port is executed INSIDE the container

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "copy_dir"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "543d1dd138ef086e2ff05e3a48cf9da045da2033d16f8538fd76b86cd49b2ca3"
+dependencies = [
+ "walkdir",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,7 +285,10 @@ dependencies = [
 [[package]]
 name = "gkl-deflate"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4c6a70311ee8c90d84ea2254b085e36183bec008#4c6a70311ee8c90d84ea2254b085e36183bec008"
+dependencies = [
+ "isal-sys",
+]
 
 [[package]]
 name = "hashbrown"
@@ -287,7 +299,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "htsjdk-bam"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4c6a70311ee8c90d84ea2254b085e36183bec008#4c6a70311ee8c90d84ea2254b085e36183bec008"
 dependencies = [
  "htsjdk-bgzf",
  "jmath",
@@ -297,7 +309,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-bgzf"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4c6a70311ee8c90d84ea2254b085e36183bec008#4c6a70311ee8c90d84ea2254b085e36183bec008"
 dependencies = [
  "flate2",
  "gkl-deflate",
@@ -308,12 +320,12 @@ dependencies = [
 [[package]]
 name = "htsjdk-metrics"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4c6a70311ee8c90d84ea2254b085e36183bec008#4c6a70311ee8c90d84ea2254b085e36183bec008"
 
 [[package]]
 name = "htsjdk-tribble"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4c6a70311ee8c90d84ea2254b085e36183bec008#4c6a70311ee8c90d84ea2254b085e36183bec008"
 dependencies = [
  "flate2",
  "htsjdk-bam",
@@ -323,7 +335,7 @@ dependencies = [
 [[package]]
 name = "htsjdk-vcf"
 version = "0.1.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4c6a70311ee8c90d84ea2254b085e36183bec008#4c6a70311ee8c90d84ea2254b085e36183bec008"
 dependencies = [
  "htsjdk-tribble",
  "jmath",
@@ -349,9 +361,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "isal-sys"
+version = "0.5.3+496255c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aefc9239959a60eaba201ccdd99897b5270be98d01f561c2166f5e3343e5a29b"
+dependencies = [
+ "cc",
+ "copy_dir",
+]
+
+[[package]]
 name = "jmath"
 version = "0.0.0"
-source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=0ee944ca694f95b3a066cd3cfc11e35466bf27fc#0ee944ca694f95b3a066cd3cfc11e35466bf27fc"
+source = "git+https://github.com/IPNP-BIPN/htsjdk-rs?rev=4c6a70311ee8c90d84ea2254b085e36183bec008#4c6a70311ee8c90d84ea2254b085e36183bec008"
 
 [[package]]
 name = "lexical-core"
@@ -584,6 +606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +714,40 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,16 @@ repository = "https://github.com/IPNP-BIPN/gatk-rs"
 # resolved it. A pin nothing resolves is a pin nothing checks, so the line arrives with its first
 # caller.
 [workspace.dependencies]
-htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
-htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
-htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
-htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
-htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
-jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "0ee944ca694f95b3a066cd3cfc11e35466bf27fc" }
+htsjdk-bam = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4c6a70311ee8c90d84ea2254b085e36183bec008" }
+# `gkl-igzip` because GATKConfig writes at compression level TWO, which is the one level pair
+# Intel's GKL routes through ISA-L igzip rather than zlib. Without the feature those levels refuse
+# rather than answer with zlib's bytes, and a tool that writes a block-compressed file could not
+# run at all.
+htsjdk-bgzf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4c6a70311ee8c90d84ea2254b085e36183bec008", features = ["gkl-igzip"] }
+htsjdk-metrics = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4c6a70311ee8c90d84ea2254b085e36183bec008" }
+htsjdk-tribble = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4c6a70311ee8c90d84ea2254b085e36183bec008" }
+htsjdk-vcf = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4c6a70311ee8c90d84ea2254b085e36183bec008" }
+jmath = { git = "https://github.com/IPNP-BIPN/htsjdk-rs", rev = "4c6a70311ee8c90d84ea2254b085e36183bec008" }
 # GatherBamFiles writes a .md5 beside its output, which is the only digest a ported tool computes
 # for itself. htsjdk-bam already pulls this crate in for the same algorithm.
 md-5 = "0.11.0"

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -92,7 +92,16 @@ pub fn index_feature_file(parser: &Parser) -> Outcome {
             } else {
                 htsjdk_bgzf::Deflater::Gkl
             };
-            index_feature_file::build_tabix(&bytes, &source, &input, deflater).map_err(refused)?
+            // And the LEVEL is GATKConfig's, which is two rather than htsjdk's five: `Main`
+            // installs it as a system property before any tool runs, so every block-compressed
+            // file a real invocation writes uses it (#1032).
+            let level = gatk_tools::gatk_config::compression_level(
+                std::env::var(gatk_tools::gatk_config::COMPRESSION_LEVEL)
+                    .ok()
+                    .as_deref(),
+            );
+            index_feature_file::build_tabix(&bytes, &source, &input, deflater, level)
+                .map_err(refused)?
         }
         _ => index_feature_file::build(&text, &source, &input).map_err(refused)?,
     };

--- a/crates/gatk-tools/src/gatk_config.rs
+++ b/crates/gatk-tools/src/gatk_config.rs
@@ -1,0 +1,87 @@
+//! `GATKConfig`: the system properties `Main` installs before any tool runs.
+//!
+//! This is not configuration in the sense of something a user tunes. It is a table of defaults
+//! that reaches **htsjdk**, and one of its rows decides the bytes of every block-compressed file
+//! GATK writes:
+//!
+//! ```text
+//! @SystemProperty
+//! @Key("samjdk.compression_level")
+//! @DefaultValue("2")
+//! ```
+//!
+//! htsjdk's own default is **five**. Two is the one level pair Intel's GKL routes through ISA-L
+//! igzip rather than through zlib, so the same eighty-one bytes deflate to 49 under a real `gatk`
+//! invocation and to 43 under htsjdk's default. A covering-array row over `IndexFeatureFile` read
+//! as a divergence for exactly that reason while its index body was already byte for byte (#1032).
+//!
+//! # Every key is a system property, and that is measured rather than assumed
+//!
+//! All twelve keys the interface declares carry `@SystemProperty`, so the table below is both the
+//! configuration and the set of properties. The `gatk-config` suite dumps the annotation and the
+//! effect separately, because a key added without the annotation would be read by GATK and never
+//! seen by htsjdk, and nothing in the values would say so.
+//!
+//! # A property already set is not overwritten
+//!
+//! `injectSystemPropertiesFromConfig` leaves an existing value alone, so `-Dsamjdk.compression_level=5`
+//! on the command line wins over the default. [`resolve`] is that rule.
+//!
+//! Ported from `org.broadinstitute.hellbender.utils.config.GATKConfig` and
+//! `org.broadinstitute.hellbender.utils.config.ConfigFactory.injectSystemPropertiesFromConfig`.
+
+/// `samjdk.compression_level`, whose default is not htsjdk's.
+pub const COMPRESSION_LEVEL: &str = "samjdk.compression_level";
+
+/// The keys `GATKConfig` declares, with their `@DefaultValue`, sorted by key.
+///
+/// Sorted because that is the order the golden carries: `getDeclaredMethods` has no defined order,
+/// and a table that depended on a JVM's reflection order would be a table about the JVM.
+pub const DEFAULTS: &[(&str, &str)] = &[
+    ("gatk_stacktrace_on_user_exception", "false"),
+    ("samjdk.compression_level", "2"),
+    ("samjdk.use_async_io_read_samtools", "false"),
+    ("samjdk.use_async_io_write_samtools", "true"),
+    ("samjdk.use_async_io_write_tribble", "false"),
+    ("spark.driver.extraJavaOptions", ""),
+    ("spark.driver.maxResultSize", "0"),
+    ("spark.driver.userClassPathFirst", "true"),
+    ("spark.executor.extraJavaOptions", ""),
+    ("spark.executor.memoryOverhead", "600"),
+    ("spark.io.compression.codec", "lzf"),
+    ("spark.kryoserializer.buffer.max", "512m"),
+];
+
+/// The default for one key, or `None` for a key the config does not declare.
+pub fn default(key: &str) -> Option<&'static str> {
+    DEFAULTS
+        .iter()
+        .find(|(name, _)| *name == key)
+        .map(|(_, value)| *value)
+}
+
+/// `injectSystemPropertiesFromConfig`, for one key: what is already set wins.
+///
+/// `set` is what the process already holds for this key, which is what a `-D` on the command line
+/// put there.
+pub fn resolve<'a>(key: &str, set: Option<&'a str>) -> Option<&'a str>
+where
+    'static: 'a,
+{
+    match set {
+        Some(value) => Some(value),
+        None => default(key),
+    }
+}
+
+/// The BGZF compression level a tool run writes at, which is [`COMPRESSION_LEVEL`] as a number.
+///
+/// A value that is not a number is not this port's problem to interpret: htsjdk parses it with
+/// `Integer.parseInt` and throws, and nothing here can throw, so the config's own default stands
+/// in and the caller is none the wiser. That is a boundary and it is stated: no golden covers a
+/// malformed property, because `GATKConfig` cannot produce one.
+pub fn compression_level(set: Option<&str>) -> u32 {
+    resolve(COMPRESSION_LEVEL, set)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(2)
+}

--- a/crates/gatk-tools/src/index_feature_file.rs
+++ b/crates/gatk-tools/src/index_feature_file.rs
@@ -36,13 +36,23 @@
 //! boundary is the NEXT block's address with offset zero. The file's end is the same rule reached
 //! at the terminator block.
 //!
-//! # The `.tbi` is a BGZF file, so the deflater decides its bytes
+//! # The `.tbi` is a BGZF file, so the deflater and the level decide its bytes
 //!
-//! `TabixIndex.write` block compresses through `BlockCompressedOutputStream`, whose deflater is a
-//! STATIC factory GATK replaces: the reference's `.tbi` is Intel's GKL and not the JDK's zlib
-//! unless `--use-jdk-deflater` says otherwise. The golden's own block settles it -- 104 bytes,
-//! which `java.util.zip` gives at no level and GKL gives at five -- so [`build_tabix`] takes the
-//! deflater as an argument rather than assuming either.
+//! `TabixIndex.write` block compresses through `BlockCompressedOutputStream`, and two things about
+//! it are GATK's rather than htsjdk's.
+//!
+//! The DEFLATER is a static factory GATK replaces: the reference's `.tbi` is Intel's GKL and not
+//! the JDK's zlib unless `--use-jdk-deflater` says otherwise.
+//!
+//! The LEVEL is `samjdk.compression_level`, which [`crate::gatk_config`] installs as **two** where
+//! htsjdk's own default is five. Two is the one level pair GKL routes through igzip rather than
+//! zlib, so the difference is not a few bytes of ratio, it is a different compressor.
+//!
+//! Both were found the same way, and neither from reading: the `index-feature-file` golden calls
+//! `instanceMain` directly and never installs the config, so its block is GKL at five; the
+//! covering array runs `Main`, which does, so its block is GKL at two. The same eighty-one bytes
+//! deflate to 43 and to 49 (#1032). [`build_tabix`] therefore takes both as arguments and assumes
+//! neither.
 
 use htsjdk_bgzf::read::BgzfReader;
 use htsjdk_bgzf::{vfp, Deflater};
@@ -342,6 +352,7 @@ pub fn build_tabix(
     source: &Source,
     file_name: &str,
     deflater: Deflater,
+    level: u32,
 ) -> Result<Vec<u8>, Refusal> {
     let codec = codec_for(file_name).ok_or_else(|| Refusal::NoSuitableCodecs {
         path: source.path.clone(),
@@ -387,7 +398,15 @@ pub fn build_tabix(
             path: source.path.clone(),
             detail: format!("{}: {}", error.java_class(), error.message()),
         })?;
-    Ok(index.write_with(deflater))
+    // `TabixIndex.write` composes the body and hands it to a `BlockCompressedOutputStream`; the
+    // framing is done here rather than through `write_with` because the level is the RUN's and not
+    // htsjdk's, and htsjdk's own writer answers for htsjdk's default.
+    let mut writer = htsjdk_bgzf::BgzfWriter::with_deflater(Vec::new(), level, deflater);
+    std::io::Write::write_all(&mut writer, &index.write_body())
+        .expect("a vector never fails to be written to");
+    Ok(writer
+        .into_inner()
+        .expect("a vector never fails to be written to"))
 }
 
 /// `IndexFactory.createIndex` for the two branches that write a `.idx`, then `index.write(path)`.

--- a/crates/gatk-tools/src/lib.rs
+++ b/crates/gatk-tools/src/lib.rs
@@ -81,6 +81,7 @@ pub mod gather_bam_files;
 pub mod gather_bqsr_reports;
 pub mod gather_tranches;
 pub mod gather_vcfs;
+pub mod gatk_config;
 pub mod gene_expression_evaluation;
 pub mod genotype_gvcfs;
 pub mod get_normal_artifact_data;

--- a/crates/gatk-tools/tests/gatk_config.rs
+++ b/crates/gatk-tools/tests/gatk_config.rs
@@ -1,0 +1,82 @@
+//! Conformance for `GATKConfig`'s system properties against GATK 4.6.2.0.
+//!
+//! Golden from `tools/readfilter-conformance/GatkConfigDump.java`. This is not configuration a
+//! user tunes: it is a table of defaults that reaches htsjdk, and one row of it decides the bytes
+//! of every block-compressed file GATK writes.
+//!
+//! # What this suite is for
+//!
+//!  * **`samjdk.compression_level` defaulting to TWO**, where htsjdk's own default is five, and
+//!    two is the one level pair Intel's GKL routes through igzip rather than zlib;
+//!  * **every key being a `@SystemProperty`**, which is measured rather than assumed: a key added
+//!    without the annotation would be read by GATK and never reach htsjdk;
+//!  * **the property name being `@Key` and not the method name**;
+//!  * **and injection leaving an already-set property alone**, so a `-D` on the command line wins.
+//!
+//! While the suite is `golden-pending` the dump is named by `GATK_CONFIG_DUMP`.
+
+use gatk_tools::gatk_config::{compression_level, default, resolve, COMPRESSION_LEVEL, DEFAULTS};
+
+fn rows<'a>(dump: &'a str, kind: &str) -> Vec<Vec<&'a str>> {
+    dump.lines()
+        .filter_map(|line| line.strip_prefix(&format!("{kind}\t")))
+        .map(|rest| rest.split('\t').collect())
+        .collect()
+}
+
+#[test]
+fn the_table_is_the_reference_one() {
+    let dump = match std::env::var("GATK_CONFIG_DUMP") {
+        Ok(path) => std::fs::read_to_string(path).expect("the dump named by GATK_CONFIG_DUMP"),
+        Err(_) => {
+            println!(
+                "skipped: the gatk-config golden is still pending. Run the suite and point \
+                 GATK_CONFIG_DUMP at tools/conformance/pending/gatk-config.GatkConfigDump.txt"
+            );
+            return;
+        }
+    };
+
+    // The declaration: key, default, and whether it is injected at all.
+    let declared = rows(&dump, "key");
+    assert_eq!(
+        declared.len(),
+        DEFAULTS.len(),
+        "the table has a row this port does not"
+    );
+    for (row, (key, value)) in declared.iter().zip(DEFAULTS) {
+        assert_eq!(row[0], *key);
+        assert_eq!(row[1], *value, "{key}");
+        // Every key GATKConfig declares carries `@SystemProperty`. The port's table would be a
+        // table of things htsjdk never sees if that stopped being true, so it is asserted.
+        assert_eq!(row[2], "system", "{key} is no longer a system property");
+    }
+
+    // The effect: what `System.getProperties` holds once `Main` has injected them.
+    for row in rows(&dump, "injected") {
+        assert_eq!(
+            resolve(row[0], None),
+            Some(if row[1] == "<unset>" { "" } else { row[1] }),
+            "{}",
+            row[0]
+        );
+    }
+
+    // And the precedence: an already-set property is not overwritten, so a `-D` wins.
+    let precedence = rows(&dump, "precedence");
+    assert_eq!(precedence.len(), 1);
+    assert_eq!(precedence[0][0], COMPRESSION_LEVEL);
+    assert_eq!(
+        resolve(COMPRESSION_LEVEL, Some(precedence[0][1])),
+        Some(precedence[0][1])
+    );
+}
+
+/// The row this table exists for.
+#[test]
+fn the_compression_level_is_two_and_not_htsjdks_five() {
+    assert_eq!(default(COMPRESSION_LEVEL), Some("2"));
+    assert_eq!(compression_level(None), 2);
+    // A `-D` on the command line wins, which is the only way a run writes at htsjdk's own level.
+    assert_eq!(compression_level(Some("5")), 5);
+}

--- a/crates/gatk-tools/tests/index_feature_file.rs
+++ b/crates/gatk-tools/tests/index_feature_file.rs
@@ -147,6 +147,10 @@ fn a_block_compressed_input_gets_the_reference_tabix_index() {
         &source("compressed"),
         name("compressed"),
         Deflater::Gkl,
+        // FIVE, not GATKConfig's two. This dump calls `new IndexFeatureFile().instanceMain(...)`
+        // directly, so `Main` never installs the config and htsjdk's own default stands. A real
+        // `gatk` invocation writes at two, which is #1032's row and the covering array's.
+        htsjdk_bgzf::DEFAULT_COMPRESSION_LEVEL,
     )
     .expect("the tabix index");
     assert_eq!(ours, bytes(&text, "index", "compressed"));
@@ -163,6 +167,7 @@ fn a_stream_that_is_not_block_compressed_is_not_a_user_error() {
         &source("compressed"),
         name("compressed"),
         Deflater::Gkl,
+        htsjdk_bgzf::DEFAULT_COMPRESSION_LEVEL,
     )
     .expect_err("plain bytes are not a BGZF stream");
     assert!(!refusal.is_user());

--- a/tools/conformance/ci.template.yml
+++ b/tools/conformance/ci.template.yml
@@ -40,6 +40,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: nasm, which is what makes GKL's igzip exact rather than merely valid
+        # `gkl-igzip` links ISA-L, and ISA-L without an assembler falls back to its readable C.
+        # That C still returns valid deflate; it is simply not GKL's, and `gkl-deflate` refuses the
+        # levels it would have answered rather than guessing. GATKConfig writes at level TWO, which
+        # is one of them, so a build without nasm cannot write a block-compressed file at all.
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq nasm && nasm -v
+
       - uses: dtolnay/rust-toolchain@master
         with:
           # Pinned; must match rust-toolchain.toml.
@@ -91,6 +98,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: nasm, which is what makes GKL's igzip exact rather than merely valid
+        # `gkl-igzip` links ISA-L, and ISA-L without an assembler falls back to its readable C.
+        # That C still returns valid deflate; it is simply not GKL's, and `gkl-deflate` refuses the
+        # levels it would have answered rather than guessing. GATKConfig writes at level TWO, which
+        # is one of them, so a build without nasm cannot write a block-compressed file at all.
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq nasm && nasm -v
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -153,6 +167,13 @@ jobs:
           fail-on-cache-miss: true
 
       - run: docker load -i /tmp/oracle-image.tar
+
+      - name: nasm, which is what makes GKL's igzip exact rather than merely valid
+        # `gkl-igzip` links ISA-L, and ISA-L without an assembler falls back to its readable C.
+        # That C still returns valid deflate; it is simply not GKL's, and `gkl-deflate` refuses the
+        # levels it would have answered rather than guessing. GATKConfig writes at level TWO, which
+        # is one of them, so a build without nasm cannot write a block-compressed file at all.
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq nasm && nasm -v
 
       - name: Build the port binary
         # linux/amd64, which is what the container runs. The port is executed INSIDE the container

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6351,6 +6351,26 @@
       ]
     },
     {
+      "id": "gatk-config",
+      "status": "golden-pending",
+      "title": "the system properties GATKConfig installs before any tool runs",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "Main"
+      ],
+      "compare": {
+        "mode": "lines"
+      },
+      "why": "A covering-array row over IndexFeatureFile disagreed with the port on a .tbi whose INDEX was already byte for byte, and the difference was the compression: `samjdk.compression_level` is declared here with a default of TWO where htsjdk's own is five, and two is the one level pair Intel's GKL routes through igzip rather than zlib. Every BGZF byte a real `gatk` invocation writes therefore depends on this table, and a dump that calls a tool's instanceMain directly never sees it (#1032). What is measured is the declaration and the effect both: the key each method carries, its default, whether it is a @SystemProperty at all, what System.getProperties holds after injection, and whether injection overwrites a property that was already set.",
+      "cases": [
+        {
+          "dump": "GatkConfigDump",
+          "golden": null,
+          "why": "Every key the interface declares, sorted by property name so no JVM's reflection order can reach the golden; the injected value of each system property; and the precedence case, which decides whether a -D on the command line means anything."
+        }
+      ]
+    },
+    {
       "id": "main-non-user",
       "status": "oracle-backed",
       "title": "handleNonUserException, which is the handler handleUserException is not",

--- a/tools/readfilter-conformance/GatkConfigDump.java
+++ b/tools/readfilter-conformance/GatkConfigDump.java
@@ -1,0 +1,109 @@
+/*
+ * `GATKConfig`'s system properties, which `Main` installs before any tool runs.
+ *
+ * The reason this is measured at all: a covering-array row over `IndexFeatureFile` disagreed with
+ * the port on a `.tbi` whose INDEX was already byte for byte, and the difference was the
+ * compression. `samjdk.compression_level` is declared here with a default of TWO, where htsjdk's
+ * own default is five, and two is the one level pair Intel's GKL routes through igzip rather than
+ * zlib. So every BGZF byte a real `gatk` invocation writes depends on this table (gatk-rs#1032).
+ *
+ * Four behaviours this is built to catch.
+ *
+ *   - THE DEFAULTS ARE ANNOTATIONS, not a file: `@DefaultValue` on each method of the interface,
+ *     and a config file only overrides them;
+ *   - WHICH KEYS REACH System.getProperties is `@SystemProperty`'s answer, and here it is ALL of
+ *     them: twelve keys, twelve properties. The distinction is measured rather than assumed,
+ *     because a key added without the annotation would be read by GATK and never seen by htsjdk;
+ *   - THE PROPERTY NAME IS `@Key`, not the method name, and the two differ by more than case;
+ *   - AND A PROPERTY ALREADY SET IS NOT OVERWRITTEN, so a `-D` on the command line wins over the
+ *     config's default.
+ *
+ * Output:
+ *
+ *     key\t<property>\t<default>\t<system|internal>
+ *     injected\t<property>\t<the value System.getProperties holds after injection>
+ *     precedence\t<property>\t<the value after injection when -D set it first>
+ *
+ * Usage: GatkConfigDump
+ */
+
+import org.aeonbits.owner.Config;
+import org.broadinstitute.hellbender.utils.config.ConfigFactory;
+import org.broadinstitute.hellbender.utils.config.GATKConfig;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GatkConfigDump {
+
+    static final StringBuilder buf = new StringBuilder();
+
+    static void emit(final String kind, final String name, final String payload) {
+        buf.append(kind).append('\t').append(name).append('\t').append(payload).append('\n');
+    }
+
+    /** The interface's own declaration order, which is the order the table is read in. */
+    static List<Method> declared() {
+        final List<Method> methods = new ArrayList<>();
+        for (final Method method : GATKConfig.class.getDeclaredMethods()) {
+            if (method.getAnnotation(Config.Key.class) != null) {
+                methods.add(method);
+            }
+        }
+        // getDeclaredMethods has no defined order, so the table is sorted by the property name it
+        // will be printed under. A golden cannot depend on a JVM's reflection order.
+        methods.sort((a, b) -> a.getAnnotation(Config.Key.class).value()
+                .compareTo(b.getAnnotation(Config.Key.class).value()));
+        return methods;
+    }
+
+    public static void main(final String[] args) {
+        final List<Method> methods = declared();
+
+        // The declaration: the property's name, its default, and whether it is injected at all.
+        for (final Method method : methods) {
+            final String key = method.getAnnotation(Config.Key.class).value();
+            final Config.DefaultValue value = method.getAnnotation(Config.DefaultValue.class);
+            final boolean system =
+                    method.getAnnotation(Config.Sources.class) == null
+                            && hasSystemProperty(method);
+            emit("key", key, (value == null ? "<none>" : value.value()) + "\t"
+                    + (system ? "system" : "internal"));
+        }
+
+        // What `Main` leaves behind: the config is built from no command line at all, which is the
+        // default path, and then injected.
+        ConfigFactory.getInstance().initializeConfigurationsFromCommandLineArgs(
+                new String[0], "--gatk-config-file");
+        final GATKConfig config = ConfigFactory.getInstance().getGATKConfig();
+        ConfigFactory.getInstance().injectSystemPropertiesFromConfig(config);
+        for (final Method method : methods) {
+            final String key = method.getAnnotation(Config.Key.class).value();
+            if (!hasSystemProperty(method)) {
+                continue;
+            }
+            final String value = System.getProperty(key);
+            emit("injected", key, value == null ? "<unset>" : value);
+        }
+
+        // And whether the injection overwrites a property that is already set, which decides
+        // whether `-Dsamjdk.compression_level=5` on the command line means anything.
+        System.setProperty("samjdk.compression_level", "9");
+        ConfigFactory.getInstance().injectSystemPropertiesFromConfig(config);
+        emit("precedence", "samjdk.compression_level",
+                System.getProperty("samjdk.compression_level"));
+
+        System.out.print(buf);
+    }
+
+    /** `@SystemProperty` lives in GATK's own package, so it is looked up by name. */
+    static boolean hasSystemProperty(final Method method) {
+        for (final java.lang.annotation.Annotation annotation : method.getAnnotations()) {
+            if (annotation.annotationType().getSimpleName().equals("SystemProperty")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
The last `IndexFeatureFile` covering-array row disagreed on a `.tbi` whose index **body** was already byte for byte. The difference was the compression, and the reason is not in htsjdk:

```java
@SystemProperty
@Key("samjdk.compression_level")
@DefaultValue("2")
```

htsjdk's own default is **five**. Two is the one level pair Intel's GKL routes through ISA-L igzip rather than zlib, so the same eighty-one bytes deflate to 49 under a real `gatk` invocation and to 43 under htsjdk's default. That is not a ratio, it is a different compressor.

## Why nothing caught it earlier

The two sides of this programme reach the reference through different doors:

| path | how it runs the tool | `samjdk.compression_level` |
|---|---|---:|
| a conformance dump | `new IndexFeatureFile().instanceMain(...)` | unset, so htsjdk's 5 |
| the covering array | `Main IndexFeatureFile` | **2**, from `GATKConfig` |

Both are the reference. Only one of them is what a user runs.

## What is measured

Twelve keys, **sorted by property name** because `getDeclaredMethods` has no defined order and a golden that depended on a JVM's reflection order would be a golden about the JVM. Each with its default and whether it is a `@SystemProperty` at all — which here is all twelve, and is asserted rather than assumed, since a key added without the annotation would be read by GATK and never reach htsjdk.

The dump also records the **effect** (what `System.getProperties` holds after injection) and the **precedence**, which is the half that decides whether a `-D` means anything: injection leaves an already-set property alone.

## What changes

The runner reads the level off that table, and `htsjdk-bgzf` is built with `gkl-igzip` because level two needs it. Three CI jobs gain nasm for the same reason: ISA-L without an assembler falls back to its readable C, which returns valid deflate that is not GKL's, and `gkl-deflate` refuses those levels rather than guessing (IPNP-BIPN/htsjdk-rs#220).

The suite lands **golden-pending**.

Part of #1032.

`python3 tools/preflight.py`: every gate green on the pinned 1.97.1 toolchain.