### PR TITLE
Record the twenty rows CountVariants reproduces, and the four it does not

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -160,7 +160,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
 | `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, read-walker-refusals, tool-argument-declarations, tool-argument-enums, usage-text | 7 | t=2, 18/18 rows (100%), **1 distinct output** |
-| `CountVariants` | variant-walker | oracle-backed | count-variants, tool-argument-declarations, tool-argument-enums | 3 | not measured |
+| `CountVariants` | variant-walker | oracle-backed | count-variants, tool-argument-declarations, tool-argument-enums | 3 | t=2, 20/24 rows (83%) |
 | `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | not measured |
 | `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -36,6 +36,15 @@
       "matched": 18,
       "t": 2,
       "share": 1.0
+    },
+    "CountVariants": {
+      "rows": 24,
+      "accepted": 11,
+      "rejected": 13,
+      "distinct_outputs": 2,
+      "matched": 20,
+      "t": 2,
+      "share": 0.833
     }
   }
 }


### PR DESCRIPTION
The fourth tool measured against the port binary, and the first that does not read 100% on its first run: **20 of 24**, with **two** distinct outputs — one more than `CountReads`' array can observe.

| tool | rows | distinct outputs |
|---|---:|---:|
| `CountReads` | 18/18 | 1 |
| `CountVariants` | **20/24** | 2 |
| `IndexFeatureFile` | 8/8 | 5 |
| `PrintBGZFBlockInformation` | 4/4 | 2 |

The four are **one** refusal, not four:

```
Input files reads and features have incompatible contigs: No overlapping contigs found.
```

Every one of those rows passes `--input`, a BAM, alongside `--variant`. A variant walker still opens the reads when it is given any, and `GATKTool` validates the two sequence dictionaries against each other *before* the traversal; the corpus's `reads.bam` and `reads.vcf` share no contig name, so the run is refused whatever the intervals say. The port ignores `--input` for this tool entirely, which is why two of the rows answer a count and two answer the **interval** refusal — the port reaching a later check the reference never gets to.

That is #1038, and it is `GATKTool`'s rather than this tool's: it lands on every walker that accepts both a reads input and a feature input.

Part of #822.