### PR TITLE
Compare the two dictionaries before the traversal, as the reference does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,10 @@ jobs:
             index: "59/59"
             slug: "mutex-target-names-count-reads-plumbing-read-walker-refusals"
             suites: "mutex-target-names count-reads-plumbing read-walker-refusals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "sequence-dictionary-validation"
+            suites: "sequence-dictionary-validation"
     steps:
       - uses: actions/checkout@v7
 

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -465,6 +465,32 @@ pub fn count_variants(parser: &Parser) -> Outcome {
     };
 
     let header = vcf_dictionary(&text);
+
+    // `GATKTool.onStartup` validates the dictionaries against each other BEFORE the traversal, and
+    // a variant walker still opens the reads when a command line names any: the pair goes through
+    // `validateDictionaries("reads", readDict, "features", featureDict)`, whose four-argument
+    // overload requires no superset and does not check the contig ordering. A corpus whose BAM and
+    // VCF share no contig is therefore refused whatever the intervals say (#1038).
+    if !flag(parser, "disable-sequence-dictionary-validation") {
+        for reads in arguments(parser, "input") {
+            let source = ReadsDataSource::open_unindexed(std::path::Path::new(&reads))
+                .map_err(|error| Thrown::user(format!("{error:?}")))?;
+            gatk_tools::sequence_dictionary::validate(
+                "reads",
+                &source.header().sequences,
+                "features",
+                &header.sequences,
+                false,
+                false,
+            )
+            .map_err(|refusal| Thrown {
+                failure: Failure::User,
+                exception: refusal.java_class(),
+                message: Some(refusal.message()),
+            })?;
+        }
+    }
+
     let mut intervals = Vec::new();
     for query in arguments(parser, "intervals") {
         let interval = gatk_engine::interval::parse_interval(&query, &header)

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -473,11 +473,9 @@ pub fn count_variants(parser: &Parser) -> Outcome {
     // VCF share no contig is therefore refused whatever the intervals say (#1038).
     if !flag(parser, "disable-sequence-dictionary-validation") {
         for reads in arguments(parser, "input") {
-            let source = ReadsDataSource::open_unindexed(std::path::Path::new(&reads))
-                .map_err(|error| Thrown::user(format!("{error:?}")))?;
             gatk_tools::sequence_dictionary::validate(
                 "reads",
-                &source.header().sequences,
+                &reads_dictionary(&reads)?,
                 "features",
                 &header.sequences,
                 false,
@@ -529,6 +527,29 @@ pub fn count_variants(parser: &Parser) -> Outcome {
         })?;
     // The tool returns the count, which `handleResult` prints.
     Ok(Some(count.to_string()))
+}
+
+/// The sequence dictionary a reads input carries, which for a file that is not a BAM is EMPTY.
+///
+/// `ReadsPathDataSource` opens whatever it is given and asks for the header before it reads a
+/// record, so a VCF or a BED handed to `--input` is a stream with no `@SQ` line rather than a
+/// refusal: the dictionary comes back empty and the comparison against the features' dictionary
+/// finds no common contigs. The refusal a read WALKER makes for the same file is a later one, and
+/// it is the record parse rather than the header that makes it (`read-walker-refusals`).
+fn reads_dictionary(path: &str) -> Result<Vec<htsjdk_bam::header::SequenceRecord>, Thrown> {
+    let bytes = std::fs::read(path)
+        .map_err(|_| Thrown::user(gatk_tools::read_walker_refusal::cannot_read(path, false)))?;
+    let decompressed = if gatk_tools::read_walker_refusal::is_block_compressed(&bytes) {
+        htsjdk_bgzf::read::decompress_all(&bytes).unwrap_or_default()
+    } else {
+        bytes
+    };
+    if !decompressed.starts_with(&gatk_tools::read_walker_refusal::BAM_MAGIC) {
+        return Ok(Vec::new());
+    }
+    let source = ReadsDataSource::open_unindexed(std::path::Path::new(path))
+        .map_err(|error| Thrown::user(format!("{error:?}")))?;
+    Ok(source.header().sequences.clone())
 }
 
 /// One decoded locus, which is all the traversal looks at.

--- a/crates/gatk-cli/tests/count_variants_plumbing.rs
+++ b/crates/gatk-cli/tests/count_variants_plumbing.rs
@@ -349,6 +349,32 @@ fn a_bam_that_shares_no_contig_with_the_vcf_is_refused_before_the_traversal() {
     let run = gatk_cli::run(&argv);
     assert_eq!(run.status, 0, "{}", run.stderr);
 
+    // A reads input that is not a BAM at all has an EMPTY dictionary rather than a refusal: the
+    // header is asked for before any record is read, so a VCF handed to `--input` shares no contig
+    // with anything. That is four rows of the covering array, and the refusal a read walker makes
+    // for the same file is a later one.
+    let not_a_bam = dir.join("not-a-bam.vcf");
+    std::fs::write(&not_a_bam, "##fileformat=VCFv4.2\n#CHROM\tPOS\n").expect("the fixture");
+    let run = gatk_cli::run(&args(&[
+        "CountVariants",
+        "--variant",
+        &input.to_string_lossy(),
+        "--input",
+        &not_a_bam.to_string_lossy(),
+    ]));
+    assert_eq!(
+        run.status,
+        main_entry::exit_status(Failure::User),
+        "{}",
+        run.stdout
+    );
+    assert!(
+        run.stderr.contains("No overlapping contigs found."),
+        "{}",
+        run.stderr
+    );
+    assert!(run.stderr.contains("reads contigs = []"), "{}", run.stderr);
+
     // And the argument that turns the check off turns it off.
     let mut argv = args(&[
         "CountVariants",

--- a/crates/gatk-cli/tests/count_variants_plumbing.rs
+++ b/crates/gatk-cli/tests/count_variants_plumbing.rs
@@ -16,7 +16,9 @@
 //!  * **`-L` selecting by the record's whole SPAN**, so an interval reaches a record whose
 //!    position it does not hold, and a record over two intervals is counted once;
 //!  * **`-L` against an input with no index being refused before any record is read**;
-//!  * **and an unwritable `-O` carrying the path and nothing else.**
+//!  * **an unwritable `-O` carrying the path and nothing else**;
+//!  * **and the reads' dictionary being checked against the features' before the traversal**, so a
+//!    BAM that shares no contig with the VCF is refused rather than counted.
 
 use gatk_corpus as corpus;
 use gatk_tools::main_entry::{self, Failure};
@@ -271,5 +273,92 @@ fn the_refusals_are_the_reference_ones() {
         recorded.contains("is not valid for this input"),
         "{recorded}"
     );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A BAM with a header and no records, on the contigs named.
+fn empty_bam(path: &std::path::Path, contigs: &[(&str, i32)]) {
+    use htsjdk_bam::header::{SamHeader, SequenceRecord};
+    use htsjdk_bam::writer::BamWriter;
+
+    let mut header = SamHeader::default();
+    for (name, length) in contigs {
+        header.sequences.push(SequenceRecord::new(name, *length));
+    }
+    let writer = BamWriter::new(Vec::new(), &header).expect("a writer");
+    std::fs::write(path, writer.finish().expect("the bam")).expect("the fixture");
+}
+
+/// `GATKTool` compares the reads' dictionary with the features' before any record is read.
+///
+/// The rule is `SequenceDictionaryUtils.validateDictionaries`, measured in
+/// `sequence-dictionary-validation`; what this asserts is that the walker reaches it, that the
+/// refusal is a `UserException` and that `--disable-sequence-dictionary-validation` turns it off.
+/// It is the whole of what four rows of this tool's covering array used to disagree on (#1038).
+#[test]
+fn a_bam_that_shares_no_contig_with_the_vcf_is_refused_before_the_traversal() {
+    let text = golden();
+    let dir = scratch("dictionaries");
+    let input = fixture(&text, &dir, "plain", true);
+
+    let bam = dir.join("elsewhere.bam");
+    empty_bam(&bam, &[("chrOther", 1000)]);
+    let argv = args(&[
+        "CountVariants",
+        "--variant",
+        &input.to_string_lossy(),
+        "--input",
+        &bam.to_string_lossy(),
+    ]);
+
+    let run = gatk_cli::run(&argv);
+    assert_eq!(
+        run.status,
+        main_entry::exit_status(Failure::User),
+        "{}",
+        run.stdout
+    );
+    assert!(
+        run.stderr.contains(
+            "Input files reads and features have incompatible contigs: No overlapping contigs found."
+        ),
+        "{}",
+        run.stderr
+    );
+    // Both contig lists are named, which is what makes the refusal actionable.
+    assert!(
+        run.stderr.contains("reads contigs = [chrOther]"),
+        "{}",
+        run.stderr
+    );
+    assert!(
+        run.stderr.contains("features contigs = [chr1, chr2]"),
+        "{}",
+        run.stderr
+    );
+
+    // A BAM that DOES share a contig is not refused, so the check is about the dictionaries and
+    // not about `--input` being given at all. The length has to agree as well as the name: the
+    // fixture's header declares `##contig=<ID=chr1,length=1000>`, and a BAM saying anything else
+    // for chr1 is UNEQUAL_COMMON_CONTIGS rather than a subset.
+    let shared = dir.join("shared.bam");
+    empty_bam(&shared, &[("chr1", 1000)]);
+    let mut argv = args(&["CountVariants", "--variant", &input.to_string_lossy()]);
+    argv.push("--input".to_string());
+    argv.push(shared.to_string_lossy().to_string());
+    let run = gatk_cli::run(&argv);
+    assert_eq!(run.status, 0, "{}", run.stderr);
+
+    // And the argument that turns the check off turns it off.
+    let mut argv = args(&[
+        "CountVariants",
+        "--variant",
+        &input.to_string_lossy(),
+        "--input",
+        &bam.to_string_lossy(),
+    ]);
+    argv.push("--disable-sequence-dictionary-validation".to_string());
+    let run = gatk_cli::run(&argv);
+    assert_eq!(run.status, 0, "{}", run.stderr);
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/gatk-tools/src/lib.rs
+++ b/crates/gatk-tools/src/lib.rs
@@ -143,6 +143,7 @@ pub mod rename_sample_in_vcf;
 pub mod revert_base_quality_scores;
 pub mod sam_output;
 pub mod select_variants;
+pub mod sequence_dictionary;
 pub mod series_stats;
 pub mod set_nm_md_and_uq_tags;
 pub mod shift_fasta;

--- a/crates/gatk-tools/src/sequence_dictionary.rs
+++ b/crates/gatk-tools/src/sequence_dictionary.rs
@@ -1,0 +1,367 @@
+//! `SequenceDictionaryUtils`: whether two sequence dictionaries may be used together.
+//!
+//! A walker given both a reads input and a feature input compares their dictionaries **before the
+//! traversal**, so a pair that shares no contig is refused rather than counted. That is what four
+//! rows of `CountVariants`' covering array disagreed on, and nothing else in them (#1038).
+//!
+//! # Eight outcomes, three of which need to be asked for
+//!
+//! `NON_CANONICAL_HUMAN_ORDER`, `OUT_OF_ORDER` and `DIFFERENT_INDICES` are only ever returned when
+//! the caller passed `check_contig_ordering`. Without it the same pairs come back `SUPERSET`, so
+//! an argument decides whether a dictionary pair is accepted, not the dictionaries.
+//!
+//! # A length of zero is equivalent to any length
+//!
+//! `sequenceRecordsAreEquivalent` compares lengths only when both are non-zero, so a contig
+//! declared without one agrees with the same contig declared with one, and two dictionaries that
+//! differ in exactly that way are `IDENTICAL`.
+//!
+//! # Two empty dictionaries share no contigs
+//!
+//! `NO_COMMON_CONTIGS` is the empty intersection, and an empty set intersected with an empty set is
+//! empty. A tool handed two dictionaries with nothing in them refuses them as incompatible.
+//!
+//! # Two of the messages end in two full stops
+//!
+//! `IncompatibleSequenceDictionaries` appends `.` to whatever reason it is handed, and the reasons
+//! for `OUT_OF_ORDER` and `DIFFERENT_INDICES` already end in one. The reference prints `files..`
+//! and `dictionaries..`, and a port that tidied that up would differ from it on every such run.
+//!
+//! # The human check is a length as much as a name
+//!
+//! `nonCanonicalHumanContigOrder` looks for chr1, chr2 and chr10 by name **and** by length, under
+//! four assemblies' spellings. The same three names in the same wrong order with lengths that are
+//! not hg19's are not human at all, and come back `OUT_OF_ORDER` instead.
+//!
+//! Ported from `org.broadinstitute.hellbender.utils.SequenceDictionaryUtils`,
+//! `org.broadinstitute.hellbender.exceptions.UserException$IncompatibleSequenceDictionaries` and
+//! `org.broadinstitute.hellbender.utils.read.ReadUtils.prettyPrintSequenceRecords`.
+
+use htsjdk_bam::header::SequenceRecord;
+
+/// `SequenceDictionaryCompatibility`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Compatibility {
+    Identical,
+    CommonSubset,
+    Superset,
+    NoCommonContigs,
+    UnequalCommonContigs,
+    NonCanonicalHumanOrder,
+    OutOfOrder,
+    DifferentIndices,
+}
+
+impl Compatibility {
+    /// The enum constant's own name, which is what the golden carries.
+    pub fn name(self) -> &'static str {
+        match self {
+            Compatibility::Identical => "IDENTICAL",
+            Compatibility::CommonSubset => "COMMON_SUBSET",
+            Compatibility::Superset => "SUPERSET",
+            Compatibility::NoCommonContigs => "NO_COMMON_CONTIGS",
+            Compatibility::UnequalCommonContigs => "UNEQUAL_COMMON_CONTIGS",
+            Compatibility::NonCanonicalHumanOrder => "NON_CANONICAL_HUMAN_ORDER",
+            Compatibility::OutOfOrder => "OUT_OF_ORDER",
+            Compatibility::DifferentIndices => "DIFFERENT_INDICES",
+        }
+    }
+}
+
+/// What `validateDictionaries` throws.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DictionaryRefusal {
+    /// `UserException$IncompatibleSequenceDictionaries`, which wraps every message but one.
+    Incompatible { message: String },
+    /// `UserException$LexicographicallySortedSequenceDictionary`, which names one dictionary.
+    LexicographicallySorted { name: String, contigs: String },
+}
+
+impl DictionaryRefusal {
+    pub fn java_class(&self) -> &'static str {
+        match self {
+            DictionaryRefusal::Incompatible { .. } => {
+                "org.broadinstitute.hellbender.exceptions.UserException$IncompatibleSequenceDictionaries"
+            }
+            DictionaryRefusal::LexicographicallySorted { .. } => {
+                "org.broadinstitute.hellbender.exceptions.UserException$LexicographicallySortedSequenceDictionary"
+            }
+        }
+    }
+
+    pub fn message(&self) -> String {
+        match self {
+            DictionaryRefusal::Incompatible { message } => message.clone(),
+            DictionaryRefusal::LexicographicallySorted { name, contigs } => format!(
+                "Lexicographically sorted human genome sequence detected in {name}.\n\
+                 For safety's sake the GATK requires human contigs in karyotypic order: 1, 2, ..., \
+                 10, 11, ..., 20, 21, 22, X, Y with M either leading or trailing these contigs.\n\
+                 This is because all distributed GATK resources are sorted in karyotypic order, \
+                 and your processing will fail when you need to use these files.\n\
+                 You can use the ReorderSam utility to fix this problem: \
+                 http://gatkforums.broadinstitute.org/discussion/58/companion-utilities-reordersam\n  \
+                 {name} contigs = {contigs}"
+            ),
+        }
+    }
+}
+
+/// `ReadUtils.prettyPrintSequenceRecords`, which is `Arrays.deepToString` on the NAMES.
+pub fn pretty_print(dictionary: &[SequenceRecord]) -> String {
+    format!(
+        "[{}]",
+        dictionary
+            .iter()
+            .map(|record| record.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+/// `sequenceRecordsAreEquivalent`: the same name, and the same length unless one of them is zero.
+fn equivalent(a: &SequenceRecord, b: &SequenceRecord) -> bool {
+    a.name == b.name && (a.length == 0 || b.length == 0 || a.length == b.length)
+}
+
+fn find<'a>(dictionary: &'a [SequenceRecord], name: &str) -> Option<&'a SequenceRecord> {
+    dictionary.iter().find(|record| record.name == name)
+}
+
+/// `getCommonContigsByName`, in the FIRST dictionary's order.
+///
+/// The order matters for the message a disequal pair produces: the reference reports the first
+/// mismatch it walks into, and it walks the intersection the same way every time.
+fn common_contigs(a: &[SequenceRecord], b: &[SequenceRecord]) -> Vec<String> {
+    a.iter()
+        .filter(|record| find(b, &record.name).is_some())
+        .map(|record| record.name.clone())
+        .collect()
+}
+
+/// `hg18`, `hg19`, `b36` and `b37`'s chr1, chr2 and chr10, by the names and lengths the check uses.
+const HUMAN_CHR1: [(&str, i32); 4] = [
+    ("chr1", 247249719),
+    ("chr1", 249250621),
+    ("1", 247249719),
+    ("1", 249250621),
+];
+const HUMAN_CHR2: [(&str, i32); 4] = [
+    ("chr2", 242951149),
+    ("chr2", 243199373),
+    ("2", 242951149),
+    ("2", 243199373),
+];
+const HUMAN_CHR10: [(&str, i32); 4] = [
+    ("chr10", 135374737),
+    ("chr10", 135534747),
+    ("10", 135374737),
+    ("10", 135534747),
+];
+
+fn is_human(record: &SequenceRecord, candidates: &[(&str, i32); 4]) -> bool {
+    candidates
+        .iter()
+        .any(|(name, length)| record.name == *name && record.length == *length)
+}
+
+/// `nonCanonicalHumanContigOrder`: chr1 before chr2 before chr10, when all three are recognised.
+pub fn non_canonical_human_order(dictionary: &[SequenceRecord]) -> bool {
+    let index = |candidates: &[(&str, i32); 4]| {
+        dictionary
+            .iter()
+            .enumerate()
+            .filter(|(_, record)| is_human(record, candidates))
+            .map(|(index, _)| index)
+            .next_back()
+    };
+    match (index(&HUMAN_CHR1), index(&HUMAN_CHR2), index(&HUMAN_CHR10)) {
+        (Some(one), Some(two), Some(ten)) => !(one < two && two < ten),
+        // A dictionary missing any of the three is not judged: the check has nothing to go on.
+        _ => false,
+    }
+}
+
+/// Whether the first dictionary holds an equivalent record for every one of the second's.
+fn supersets(a: &[SequenceRecord], b: &[SequenceRecord]) -> bool {
+    b.iter()
+        .all(|record| find(a, &record.name).is_some_and(|theirs| equivalent(record, theirs)))
+}
+
+/// The first common contig whose lengths disagree, as the pair the message names.
+fn disequal_common_contig<'a>(
+    common: &[String],
+    a: &'a [SequenceRecord],
+    b: &'a [SequenceRecord],
+) -> Option<(&'a SequenceRecord, &'a SequenceRecord)> {
+    common.iter().find_map(|name| {
+        let (one, two) = (find(a, name)?, find(b, name)?);
+        (!equivalent(one, two)).then_some((one, two))
+    })
+}
+
+/// Whether the common contigs appear in the same relative order in both dictionaries.
+fn same_relative_order(common: &[String], a: &[SequenceRecord], b: &[SequenceRecord]) -> bool {
+    let order = |dictionary: &[SequenceRecord]| -> Vec<String> {
+        dictionary
+            .iter()
+            .filter(|record| common.contains(&record.name))
+            .map(|record| record.name.clone())
+            .collect()
+    };
+    order(a) == order(b)
+}
+
+/// Whether every common contig sits at the same absolute index in both dictionaries.
+fn same_indices(common: &[String], a: &[SequenceRecord], b: &[SequenceRecord]) -> bool {
+    let index = |dictionary: &[SequenceRecord], name: &str| {
+        dictionary.iter().position(|record| record.name == name)
+    };
+    common.iter().all(|name| index(a, name) == index(b, name))
+}
+
+/// `compareDictionaries`, whose branch order is what decides which of two true things is reported.
+pub fn compare(
+    a: &[SequenceRecord],
+    b: &[SequenceRecord],
+    check_contig_ordering: bool,
+) -> Compatibility {
+    if check_contig_ordering && (non_canonical_human_order(a) || non_canonical_human_order(b)) {
+        return Compatibility::NonCanonicalHumanOrder;
+    }
+
+    let common = common_contigs(a, b);
+    if common.is_empty() {
+        // Two EMPTY dictionaries land here as well: an empty intersection is an empty
+        // intersection, whether or not there was anything to intersect.
+        return Compatibility::NoCommonContigs;
+    }
+    if disequal_common_contig(&common, a, b).is_some() {
+        return Compatibility::UnequalCommonContigs;
+    }
+
+    let same_order = same_relative_order(&common, a, b);
+    if check_contig_ordering && !same_order {
+        Compatibility::OutOfOrder
+    } else if same_order && common.len() == a.len() && common.len() == b.len() {
+        Compatibility::Identical
+    } else if check_contig_ordering && !same_indices(&common, a, b) {
+        Compatibility::DifferentIndices
+    } else if supersets(a, b) {
+        Compatibility::Superset
+    } else {
+        Compatibility::CommonSubset
+    }
+}
+
+/// `IncompatibleSequenceDictionaries`, which wraps a reason in the names and both contig lists.
+fn incompatible(
+    reason: &str,
+    name1: &str,
+    a: &[SequenceRecord],
+    name2: &str,
+    b: &[SequenceRecord],
+) -> DictionaryRefusal {
+    DictionaryRefusal::Incompatible {
+        message: format!(
+            "Input files {name1} and {name2} have incompatible contigs: {reason}.\n  \
+             {name1} contigs = {}\n  {name2} contigs = {}",
+            pretty_print(a),
+            pretty_print(b)
+        ),
+    }
+}
+
+/// `validateDictionaries`: `Ok` where the reference returns, and the refusal where it throws.
+pub fn validate(
+    name1: &str,
+    a: &[SequenceRecord],
+    name2: &str,
+    b: &[SequenceRecord],
+    require_superset: bool,
+    check_contig_ordering: bool,
+) -> Result<(), DictionaryRefusal> {
+    match compare(a, b, check_contig_ordering) {
+        Compatibility::Identical | Compatibility::Superset => Ok(()),
+        Compatibility::CommonSubset => {
+            if !require_superset {
+                return Ok(());
+            }
+            let missing: Vec<&str> = b
+                .iter()
+                .filter(|record| find(a, &record.name).is_none())
+                .map(|record| record.name.as_str())
+                .collect();
+            // The two spaces after the full stop and the spaces around the newlines are the
+            // format string's, not a rendering choice.
+            Err(incompatible(
+                &format!(
+                    "Dictionary {name1} is missing contigs found in dictionary {name2}.  \
+                     Missing contigs: \n {} \n",
+                    missing.join(", ")
+                ),
+                name1,
+                a,
+                name2,
+                b,
+            ))
+        }
+        Compatibility::NoCommonContigs => Err(incompatible(
+            "No overlapping contigs found",
+            name1,
+            a,
+            name2,
+            b,
+        )),
+        Compatibility::UnequalCommonContigs => {
+            let common = common_contigs(a, b);
+            let (one, two) = disequal_common_contig(&common, a, b)
+                .expect("an unequal common contig, which is what this case is");
+            Err(incompatible(
+                &format!(
+                    "Found contigs with the same name but different lengths:\n  contig {name1} = \
+                     {} / {}\n  contig {name2} = {} / {}",
+                    one.name, one.length, two.name, two.length
+                ),
+                name1,
+                a,
+                name2,
+                b,
+            ))
+        }
+        Compatibility::NonCanonicalHumanOrder => {
+            // Whichever dictionary is the lexicographic one is the one named, and the first is
+            // tested first.
+            let (name, dictionary) = if non_canonical_human_order(a) {
+                (name1, a)
+            } else {
+                (name2, b)
+            };
+            Err(DictionaryRefusal::LexicographicallySorted {
+                name: name.to_string(),
+                contigs: pretty_print(dictionary),
+            })
+        }
+        Compatibility::OutOfOrder => Err(incompatible(
+            &format!(
+                "The relative ordering of the common contigs in {name1} and {name2} is not the \
+                 same; to fix this please see: \
+                 (https://www.broadinstitute.org/gatk/guide/article?id=1328),  which describes \
+                 reordering contigs in BAM and VCF files."
+            ),
+            name1,
+            a,
+            name2,
+            b,
+        )),
+        Compatibility::DifferentIndices => Err(incompatible(
+            "One or more contigs common to both dictionaries have different indices (ie., \
+             absolute positions) in each dictionary. Code that is sensitive to contig ordering \
+             can fail when this is the case. You should fix the sequence dictionaries so that all \
+             shared contigs occur at the same absolute positions in both dictionaries.",
+            name1,
+            a,
+            name2,
+            b,
+        )),
+    }
+}

--- a/crates/gatk-tools/tests/sequence_dictionary_validation.rs
+++ b/crates/gatk-tools/tests/sequence_dictionary_validation.rs
@@ -1,0 +1,150 @@
+//! Conformance for `SequenceDictionaryUtils` against GATK 4.6.2.0, over pairs of dictionaries.
+//!
+//! Golden from `tools/readfilter-conformance/SequenceDictionaryValidationDump.java`. Four rows of
+//! `CountVariants`' covering array disagreed on this and nothing else: they pass a BAM to
+//! `--input` alongside a VCF to `--variant`, and the two dictionaries are compared before the
+//! traversal (#1038).
+//!
+//! # What this suite is for
+//!
+//!  * **three of the eight outcomes needing to be asked for**, so an argument decides whether the
+//!    same pair is accepted;
+//!  * **a length of zero being equivalent to any length**;
+//!  * **two EMPTY dictionaries having no common contigs**, which is a refusal;
+//!  * **reversing the common contigs being a SUPERSET without the ordering check**;
+//!  * **the same relative order at different absolute positions being its own case**;
+//!  * **a common subset being accepted unless a superset was required**, the refusal then naming
+//!    the missing contigs;
+//!  * **and the human-order check needing chr1, chr2 and chr10 by name AND by length.**
+//!
+//! While the suite is `golden-pending` the dump is named by `SEQUENCE_DICTIONARY_DUMP`.
+
+use gatk_tools::sequence_dictionary::{compare, validate};
+use htsjdk_bam::header::SequenceRecord;
+
+/// The pairs the harness runs, as `name:length` lists in its own order.
+const CASES: &[(&str, &[&str], &[&str])] = &[
+    (
+        "identical",
+        &["chr1:100", "chr2:200"],
+        &["chr1:100", "chr2:200"],
+    ),
+    (
+        "superset",
+        &["chr1:100", "chr2:200", "chr3:300"],
+        &["chr1:100", "chr2:200"],
+    ),
+    ("common-subset", &["chr1:100"], &["chr1:100", "chr2:200"]),
+    ("no-common-contigs", &["chr1:100"], &["chrA:100"]),
+    ("unequal-lengths", &["chr1:100"], &["chr1:200"]),
+    ("zero-length", &["chr1:0"], &["chr1:200"]),
+    ("zero-length-both-sides", &["chr1:0"], &["chr1:0"]),
+    (
+        "reversed",
+        &["chr1:100", "chr2:200"],
+        &["chr2:200", "chr1:100"],
+    ),
+    (
+        "different-indices",
+        &["chrX:10", "chr1:100", "chr2:200"],
+        &["chr1:100", "chr2:200"],
+    ),
+    ("empty-first", &[], &["chr1:100"]),
+    ("empty-both", &[], &[]),
+    (
+        "lexicographic-human-first",
+        &["chr1:249250621", "chr10:135534747", "chr2:243199373"],
+        &["chr1:249250621", "chr2:243199373", "chr10:135534747"],
+    ),
+    (
+        "lexicographic-human-second",
+        &["chr1:249250621", "chr2:243199373", "chr10:135534747"],
+        &["chr1:249250621", "chr10:135534747", "chr2:243199373"],
+    ),
+    (
+        "lexicographic-not-human",
+        &["chr1:100", "chr10:300", "chr2:200"],
+        &["chr1:100", "chr2:200", "chr10:300"],
+    ),
+];
+
+fn dictionary(records: &[&str]) -> Vec<SequenceRecord> {
+    records
+        .iter()
+        .map(|record| {
+            let (name, length) = record.rsplit_once(':').expect("a name and a length");
+            SequenceRecord::new(name, length.parse().expect("a length"))
+        })
+        .collect()
+}
+
+fn unescape(text: &str) -> String {
+    text.replace("\\t", "\t")
+        .replace("\\n", "\n")
+        .replace("\\\\", "\\")
+}
+
+fn field(dump: &str, kind: &str, key: &str) -> String {
+    let prefix = format!("{kind}\t{key}\t");
+    dump.lines()
+        .find(|line| line.starts_with(&prefix))
+        .map(|line| unescape(&line[prefix.len()..]))
+        .unwrap_or_else(|| panic!("{kind}/{key} is not in the dump"))
+}
+
+#[test]
+fn every_pair_compares_as_the_reference_compares_it() {
+    let dump = match std::env::var("SEQUENCE_DICTIONARY_DUMP") {
+        Ok(path) => {
+            std::fs::read_to_string(path).expect("the dump named by SEQUENCE_DICTIONARY_DUMP")
+        }
+        Err(_) => {
+            println!(
+                "skipped: the sequence-dictionary-validation golden is still pending. Run the \
+                 suite and point SEQUENCE_DICTIONARY_DUMP at \
+                 tools/conformance/pending/sequence-dictionary-validation.SequenceDictionaryValidationDump.txt"
+            );
+            return;
+        }
+    };
+
+    let mut compared = 0;
+    for (case, a, b) in CASES {
+        let (a, b) = (dictionary(a), dictionary(b));
+        for ordering in [false, true] {
+            assert_eq!(
+                compare(&a, &b, ordering).name(),
+                field(&dump, "compare", &format!("{case}\t{ordering}")),
+                "{case}, ordering checked: {ordering}"
+            );
+            compared += 1;
+        }
+        for superset in [false, true] {
+            for ordering in [false, true] {
+                let ours = match validate("reads", &a, "features", &b, superset, ordering) {
+                    Ok(()) => "ok".to_string(),
+                    Err(refusal) => format!("{}: {}", refusal.java_class(), refusal.message()),
+                };
+                assert_eq!(
+                    ours,
+                    field(
+                        &dump,
+                        "validate",
+                        &format!("{case}\t{superset}\t{ordering}")
+                    ),
+                    "{case}, superset required: {superset}, ordering checked: {ordering}"
+                );
+                compared += 1;
+            }
+        }
+    }
+    assert_eq!(compared, CASES.len() * 6);
+
+    // Every row of the dump is answered: a pair added to the harness and not here would pass.
+    let rows = dump
+        .lines()
+        .filter(|line| line.starts_with("compare\t") || line.starts_with("validate\t"))
+        .count();
+    assert_eq!(rows, compared, "the dump carries a case this test does not");
+    println!("rows={compared}");
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -160,7 +160,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
 | `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, read-walker-refusals, tool-argument-declarations, tool-argument-enums, usage-text | 7 | t=2, 18/18 rows (100%), **1 distinct output** |
-| `CountVariants` | variant-walker | oracle-backed | count-variants, tool-argument-declarations, tool-argument-enums | 3 | t=2, 20/24 rows (83%) |
+| `CountVariants` | variant-walker | oracle-backed | count-variants, sequence-dictionary-validation, tool-argument-declarations, tool-argument-enums | 4 | t=2, 20/24 rows (83%) |
 | `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | not measured |
 | `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6391,6 +6391,26 @@
       ]
     },
     {
+      "id": "sequence-dictionary-validation",
+      "status": "golden-pending",
+      "title": "whether two sequence dictionaries may be used together, and what the refusal says",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "CountVariants"
+      ],
+      "compare": {
+        "mode": "lines"
+      },
+      "why": "Four rows of CountVariants' covering array disagreed on this and nothing else: they pass a BAM to --input alongside a VCF to --variant, and GATKTool validates the two dictionaries against each other BEFORE the traversal, where the port counted (#1038). The outcome is one of eight named cases and the rules behind them are not guessable: a length of ZERO is equivalent to any length; reversing the common contigs is a SUPERSET without the ordering check and OUT_OF_ORDER with it, so an argument decides whether the same pair is accepted; the same relative order at different absolute positions is DIFFERENT_INDICES, a case of its own; a common subset is accepted unless a superset was required, and the refusal then names the MISSING contigs; and the human-order check needs chr1, chr2 and chr10 by name AND by length, firing on whichever dictionary is lexicographic.",
+      "cases": [
+        {
+          "dump": "SequenceDictionaryValidationDump",
+          "golden": null,
+          "why": "Fourteen pairs, each compared under both settings of the ordering flag and validated under all four combinations of the two flags."
+        }
+      ]
+    },
+    {
       "id": "main-non-user",
       "status": "oracle-backed",
       "title": "handleNonUserException, which is the handler handleUserException is not",

--- a/tools/readfilter-conformance/SequenceDictionaryValidationDump.java
+++ b/tools/readfilter-conformance/SequenceDictionaryValidationDump.java
@@ -1,0 +1,120 @@
+/*
+ * `SequenceDictionaryUtils.compareDictionaries` and `validateDictionaries`: whether two sequence
+ * dictionaries may be used together, and what the refusal says when they may not.
+ *
+ * Measured because a CountVariants covering-array row disagreed on it and nothing else: four rows
+ * pass a BAM to --input alongside a VCF to --variant, and the reference refuses the pair before
+ * any record is read, where the port counted (gatk-rs#1038).
+ *
+ * Seven behaviours this is built to catch.
+ *
+ *   - THE OUTCOME IS ONE OF EIGHT NAMED CASES, and three of them are only ever reached when the
+ *     caller asked for the ordering to be checked;
+ *   - A LENGTH OF ZERO IS EQUIVALENT TO ANY LENGTH, so a dictionary that declares a contig without
+ *     one agrees with a dictionary that does;
+ *   - REVERSING THE COMMON CONTIGS IS A SUPERSET without the ordering check and OUT_OF_ORDER with
+ *     it, so the same pair is accepted or refused by an argument;
+ *   - THE SAME CONTIGS AT DIFFERENT ABSOLUTE INDICES are DIFFERENT_INDICES, which is a case of its
+ *     own and not OUT_OF_ORDER: the relative order can be right while the positions are not;
+ *   - A COMMON SUBSET IS ACCEPTED unless the caller required a superset, and the refusal then
+ *     names the contigs that are MISSING;
+ *   - THE HUMAN ORDER CHECK NEEDS CHR1, CHR2 AND CHR10 by name AND by length, and it fires on
+ *     either dictionary, naming whichever one is lexicographic;
+ *   - AND AN EMPTY DICTIONARY HAS NO COMMON CONTIGS, which is the same refusal as two dictionaries
+ *     that simply disagree.
+ *
+ * Output:
+ *
+ *     compare\t<case>\t<ordering checked>\t<the enum constant>
+ *     validate\t<case>\t<superset required>\t<ordering checked>\t<ok, or class: message>
+ *
+ * Usage: SequenceDictionaryValidationDump
+ */
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import org.broadinstitute.hellbender.utils.SequenceDictionaryUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SequenceDictionaryValidationDump {
+
+    static final StringBuilder buf = new StringBuilder();
+
+    static void emit(final String kind, final String name, final String payload) {
+        buf.append(kind).append('\t').append(name).append('\t')
+                .append(payload.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n"))
+                .append('\n');
+    }
+
+    /** A dictionary from `name:length` pairs, in the order they are given. */
+    static SAMSequenceDictionary dict(final String... records) {
+        final List<SAMSequenceRecord> sequences = new ArrayList<>();
+        for (final String record : records) {
+            final int colon = record.lastIndexOf(':');
+            sequences.add(new SAMSequenceRecord(record.substring(0, colon),
+                    Integer.parseInt(record.substring(colon + 1))));
+        }
+        return new SAMSequenceDictionary(sequences);
+    }
+
+    /** One pair, compared and validated under every combination of the two flags. */
+    static void run(final String name, final SAMSequenceDictionary a, final SAMSequenceDictionary b) {
+        for (final boolean ordering : new boolean[] {false, true}) {
+            emit("compare", name + "\t" + ordering,
+                    SequenceDictionaryUtils.compareDictionaries(a, b, ordering).name());
+        }
+        for (final boolean superset : new boolean[] {false, true}) {
+            for (final boolean ordering : new boolean[] {false, true}) {
+                String answer;
+                try {
+                    SequenceDictionaryUtils.validateDictionaries("reads", a, "features", b,
+                            superset, ordering);
+                    answer = "ok";
+                } catch (final Exception e) {
+                    answer = e.getClass().getName() + ": " + e.getMessage();
+                }
+                emit("validate", name + "\t" + superset + "\t" + ordering, answer);
+            }
+        }
+    }
+
+    /** hg19's chr1, chr2 and chr10, whose LENGTHS are what the human check recognises. */
+    static final String CHR1 = "chr1:249250621";
+    static final String CHR2 = "chr2:243199373";
+    static final String CHR10 = "chr10:135534747";
+
+    public static void main(final String[] args) {
+        run("identical", dict("chr1:100", "chr2:200"), dict("chr1:100", "chr2:200"));
+        // The first dictionary holds everything the second does, and more.
+        run("superset", dict("chr1:100", "chr2:200", "chr3:300"), dict("chr1:100", "chr2:200"));
+        // And the other way round, which is a common subset rather than a superset.
+        run("common-subset", dict("chr1:100"), dict("chr1:100", "chr2:200"));
+        // The row that started this: nothing in common at all.
+        run("no-common-contigs", dict("chr1:100"), dict("chrA:100"));
+        // A name they share and a length they do not.
+        run("unequal-lengths", dict("chr1:100"), dict("chr1:200"));
+        // A length of zero, which is "unknown" and equivalent to anything.
+        run("zero-length", dict("chr1:0"), dict("chr1:200"));
+        run("zero-length-both-sides", dict("chr1:0"), dict("chr1:0"));
+        // The same contigs in the other order: a superset without the ordering check.
+        run("reversed", dict("chr1:100", "chr2:200"), dict("chr2:200", "chr1:100"));
+        // The same relative order at different absolute positions.
+        run("different-indices", dict("chrX:10", "chr1:100", "chr2:200"), dict("chr1:100", "chr2:200"));
+        // An empty dictionary, which shares nothing with anything.
+        run("empty-first", dict(), dict("chr1:100"));
+        run("empty-both", dict(), dict());
+        // The human check: chr1, chr2 and chr10 by name AND by length, out of karyotypic order.
+        run("lexicographic-human-first",
+                dict(CHR1, CHR10, CHR2), dict(CHR1, CHR2, CHR10));
+        run("lexicographic-human-second",
+                dict(CHR1, CHR2, CHR10), dict(CHR1, CHR10, CHR2));
+        // The same names in the same wrong order with the WRONG lengths, which the check does not
+        // recognise as human at all.
+        run("lexicographic-not-human",
+                dict("chr1:100", "chr10:300", "chr2:200"), dict("chr1:100", "chr2:200", "chr10:300"));
+
+        System.out.print(buf);
+    }
+}


### PR DESCRIPTION
The four rows `CountVariants`' covering array does not reproduce are **one** refusal, and it is not this tool's: a walker given both a reads input and a feature input compares their sequence dictionaries in `onStartup`, and the corpus's BAM and VCF share no contig (#1038).

Eight outcomes, and the rules behind them are not guessable.

**Three of them must be asked for.** `NON_CANONICAL_HUMAN_ORDER`, `OUT_OF_ORDER` and `DIFFERENT_INDICES` are returned only when the caller passed `checkContigOrdering`; without it the same pairs come back `SUPERSET`. So the same two dictionaries are accepted or refused by an argument — and the four-argument overload a walker reaches passes `false`.

**A length of zero is equivalent to any length.** `sequenceRecordsAreEquivalent` compares lengths only when both are non-zero, so a contig declared without one agrees with the same contig declared with one, and two dictionaries differing in exactly that way are `IDENTICAL`.

**Two empty dictionaries share no contigs.** An empty intersection is an empty intersection whether or not there was anything to intersect, so a tool handed two empty dictionaries refuses them as incompatible.

**The same relative order at different absolute positions** is `DIFFERENT_INDICES`, a case of its own rather than `OUT_OF_ORDER`.

**The human check is a length as much as a name**: chr1, chr2 and chr10 under four assemblies' spellings *and* their lengths. The same three names in the same wrong order with other lengths are not human, and come back `OUT_OF_ORDER`.

**And two messages end in two full stops**, because `IncompatibleSequenceDictionaries` appends one to a reason that already carries it. A port that tidied that up would differ from the reference on every such run.

## The measurement

Fourteen pairs, each compared under both settings of the ordering flag and validated under all four combinations of the two flags: **84 rows**, every one agreeing locally.

`CountVariants` calls it now, for every `--input` a command line names, and `--disable-sequence-dictionary-validation` turns it off. The array's four rows should follow; the number is CI's to produce.

The suite lands **golden-pending**.

Part of #1038.

`python3 tools/preflight.py`: every gate green on the pinned 1.97.1 toolchain.