### PR TITLE
Record the four arguments that were held at their defaults

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -159,8 +159,8 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountBases` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
 | `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
-| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, filter-resolution, interval-arguments, read-walker-refusals, tool-argument-declarations, tool-argument-enums, usage-text | 9 | t=2, 19/19 rows (100%) |
-| `CountVariants` | variant-walker | oracle-backed | count-variants, interval-arguments, sequence-dictionary-validation, tool-argument-declarations, tool-argument-enums | 5 | t=2, 25/25 rows (100%) |
+| `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, filter-resolution, interval-arguments, read-walker-refusals, tool-argument-declarations, tool-argument-enums, usage-text | 9 | t=2, 23/23 rows (100%) |
+| `CountVariants` | variant-walker | oracle-backed | count-variants, interval-arguments, sequence-dictionary-validation, tool-argument-declarations, tool-argument-enums | 5 | t=2, 31/31 rows (100%) |
 | `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | not measured |
 | `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -29,20 +29,20 @@
       "share": 1.0
     },
     "CountReads": {
-      "rows": 19,
+      "rows": 23,
       "accepted": 3,
-      "rejected": 16,
+      "rejected": 20,
       "distinct_outputs": 3,
-      "matched": 19,
+      "matched": 23,
       "t": 2,
       "share": 1.0
     },
     "CountVariants": {
-      "rows": 25,
-      "accepted": 13,
+      "rows": 31,
+      "accepted": 19,
       "rejected": 12,
       "distinct_outputs": 3,
-      "matched": 25,
+      "matched": 31,
       "t": 2,
       "share": 1.0
     }


### PR DESCRIPTION
Every tool still reads 100% of its array, over four more arguments each than before:

| tool | rows | arguments covered |
|---|---:|---|
| `CountReads` | 23/23 | 24 → **28** of 42 |
| `CountVariants` | 31/31 | 25 → **29** of 44 |
| `IndexFeatureFile` | 8/8 | 2 → **3** of 14 |
| `PrintBGZFBlockInformation` | 4/4 | 2 → **3** of 14 |

None of the four was expected to change an answer, and now that is measured rather than assumed.

Part of #69 and #822.