### PR TITLE
Record the rows the master dictionary added

### DIFF
--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -39,8 +39,8 @@
     },
     "CountVariants": {
       "rows": 31,
-      "accepted": 19,
-      "rejected": 12,
+      "accepted": 17,
+      "rejected": 14,
       "distinct_outputs": 3,
       "matched": 31,
       "t": 2,


### PR DESCRIPTION
Both walkers read 100% of their arrays again, with `--sequence-dictionary` covered:

| tool | rows | arguments covered |
|---|---:|---|
| `CountReads` | 23/23 | **29** of 42 |
| `CountVariants` | 31/31 | **30** of 44 |

Part of #69 and #822.