### PR TITLE
Record the rows --read-index added

### DIFF
--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -30,18 +30,18 @@
     },
     "CountReads": {
       "rows": 23,
-      "accepted": 3,
-      "rejected": 20,
-      "distinct_outputs": 3,
+      "accepted": 2,
+      "rejected": 21,
+      "distinct_outputs": 2,
       "matched": 23,
       "t": 2,
       "share": 1.0
     },
     "CountVariants": {
       "rows": 31,
-      "accepted": 17,
-      "rejected": 14,
-      "distinct_outputs": 3,
+      "accepted": 8,
+      "rejected": 23,
+      "distinct_outputs": 2,
       "matched": 31,
       "t": 2,
       "share": 1.0


### PR DESCRIPTION
Both walkers read 100% of their arrays again, with `--read-index` covered:

| tool | rows | arguments covered |
|---|---:|---|
| `CountReads` | 23/23 | **30** of 42 |
| `CountVariants` | 31/31 | **31** of 44 |

Part of #69 and #822.