### PR TITLE
Record the rows --reference added

### DIFF
--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -41,7 +41,7 @@
       "rows": 31,
       "accepted": 8,
       "rejected": 23,
-      "distinct_outputs": 2,
+      "distinct_outputs": 3,
       "matched": 31,
       "t": 2,
       "share": 1.0


### PR DESCRIPTION
Both walkers read 100% of their arrays again, with `--reference` covered:

| tool | rows | arguments covered |
|---|---:|---|
| `CountReads` | 23/23 | **31** of 42 |
| `CountVariants` | 31/31 | **32** of 44 |

Part of #69 and #822.