### PR TITLE
Record the argument surface as it stands

### DIFF
--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -39,9 +39,9 @@
     },
     "CountVariants": {
       "rows": 31,
-      "accepted": 8,
-      "rejected": 23,
-      "distinct_outputs": 3,
+      "accepted": 9,
+      "rejected": 22,
+      "distinct_outputs": 5,
       "matched": 31,
       "t": 2,
       "share": 1.0


### PR DESCRIPTION
Both walkers read 100% of their arrays.

| tool | rows | covered | excluded |
|---|---:|---|---|
| `CountReads` | 23/23 | **31** of 42 | 11, every one by a written reason |
| `CountVariants` | 31/31 | **33** of 44 | the same 11 |
| `IndexFeatureFile` | 8/8 | 3 of 14 | |
| `PrintBGZFBlockInformation` | 4/4 | 3 of 14 | |

`CountVariants`' distinct outputs go from three to **five**, because `--output` now has a second name and a row can notice where the count was written.

Part of #69 and #822.