### PR TITLE
Record the deflater row, on all four tools

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -220,7 +220,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `Pileup` | locus-walker | oracle-backed | pileup-tool | 1 | not measured |
 | `PostProcessReadsForRSEM` | record-transform | oracle-backed | post-process-reads-for-rsem | 1 | not measured |
 | `PreprocessIntervals` | interval-utility | oracle-backed | preprocess-intervals | 1 | not measured |
-| `PrintBGZFBlockInformation` | unclassified | oracle-backed | print-bgzf-block-information | 1 | t=2, 4/4 rows (100%) |
+| `PrintBGZFBlockInformation` | unclassified | oracle-backed | print-bgzf-block-information | 1 | t=2, 6/6 rows (100%) |
 | `PrintDistantMates` | record-transform | oracle-backed | print-distant-mates | 1 | not measured |
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |
 | `PrintReadCounts` | sv-caller | oracle-backed | print-read-counts | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -20,11 +20,11 @@
       "share": 1.0
     },
     "PrintBGZFBlockInformation": {
-      "rows": 4,
-      "accepted": 2,
+      "rows": 6,
+      "accepted": 4,
       "rejected": 2,
       "distinct_outputs": 2,
-      "matched": 4,
+      "matched": 6,
       "t": 2,
       "share": 1.0
     },
@@ -39,9 +39,9 @@
     },
     "CountVariants": {
       "rows": 31,
-      "accepted": 9,
-      "rejected": 22,
-      "distinct_outputs": 5,
+      "accepted": 7,
+      "rejected": 24,
+      "distinct_outputs": 3,
       "matched": 31,
       "t": 2,
       "share": 1.0


### PR DESCRIPTION
Every one of the four reads 100% of its array, and every one now varies the deflater that decides a BGZF file's bytes:

| tool | rows | arguments covered |
|---|---:|---|
| `IndexFeatureFile` | 8/8 | **4** of 14 |
| `PrintBGZFBlockInformation` | 6/6 | **4** of 14 |
| `CountReads` | 23/23 | **32** of 42 |
| `CountVariants` | 31/31 | **34** of 44 |

**Ten** arguments are excluded on each — the same ten, every one by a reason written down rather than by a gap in the port.

Part of #69 and #822.