### PR TITLE
Run CreateHadoopBamSplittingIndex, the fifth tool with a command line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,7 +493,7 @@ jobs:
         run: |
           python3 tools/coverage/measure.py \
             --tool IndexFeatureFile --tool PrintBGZFBlockInformation --tool CountReads \
-            --tool CountVariants \
+            --tool CountVariants --tool CreateHadoopBamSplittingIndex \
             --port target/release/gatk-rs --corpus-dir /tmp/coverage-corpus
 
       - name: The committed measurement is the one this run produces

--- a/crates/gatk-cli/src/lib.rs
+++ b/crates/gatk-cli/src/lib.rs
@@ -271,6 +271,7 @@ pub fn runner(name: &str) -> Option<Runner> {
     match name {
         "CountReads" => Some(run_count_reads),
         "CountVariants" => Some(run_count_variants),
+        "CreateHadoopBamSplittingIndex" => Some(run_create_hadoop_bam_splitting_index),
         "IndexFeatureFile" => Some(run_index_feature_file),
         "PrintBGZFBlockInformation" => Some(run_print_bgzf_block_information),
         _ => None,
@@ -278,6 +279,10 @@ pub fn runner(name: &str) -> Option<Runner> {
 }
 
 /// The runners, each of which needs the parsed command line rather than the raw one.
+fn run_create_hadoop_bam_splitting_index(args: &[String]) -> Result<Option<String>, Thrown> {
+    runners::create_hadoop_bam_splitting_index(&parsed("CreateHadoopBamSplittingIndex", args)?)
+}
+
 fn run_count_variants(args: &[String]) -> Result<Option<String>, Thrown> {
     runners::count_variants(&parsed("CountVariants", args)?)
 }

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -957,6 +957,34 @@ impl gatk_engine::variant_source::Located for Locus {
     }
 }
 
+/// `UserException$BadInput`, whose constructor puts `Bad input: ` in front of the message.
+fn bad_input(message: String) -> Thrown {
+    Thrown {
+        failure: Failure::User,
+        exception: "org.broadinstitute.hellbender.exceptions.UserException$BadInput",
+        message: Some(format!("Bad input: {message}")),
+    }
+}
+
+/// Whether a BAM's header says `SO:coordinate`, which is what a `.bai` needs.
+fn is_coordinate_sorted(bam: &[u8]) -> bool {
+    htsjdk_bgzf::read::decompress_all(bam)
+        .ok()
+        .map(|bytes| {
+            // The header text starts at byte 8, after the magic and its length.
+            let length = bytes
+                .get(4..8)
+                .map(|four| i32::from_le_bytes(four.try_into().unwrap_or_default()) as usize)
+                .unwrap_or(0);
+            String::from_utf8_lossy(bytes.get(8..8 + length).unwrap_or_default()).into_owned()
+        })
+        .is_some_and(|text| {
+            text.lines()
+                .find(|line| line.starts_with("@HD"))
+                .is_some_and(|line| line.contains("SO:coordinate"))
+        })
+}
+
 /// Every record's virtual offset in a BAM, plus the offset after the last one and the file's size.
 ///
 /// `SBIIndexWriter` is fed one pointer per record and closed with the position the next record
@@ -1030,13 +1058,20 @@ pub fn create_hadoop_bam_splitting_index(parser: &Parser) -> Outcome {
     let granularity = scalar(parser, "splitting-index-granularity")
         .and_then(|text| text.parse::<i64>().ok())
         .unwrap_or(sbi::DEFAULT_GRANULARITY as i64);
-    // `doWork`'s first line: the argument is judged before the input is looked at.
-    sbi::assert_granularity(granularity).map_err(Thrown::user)?;
+    // `doWork`'s first line: the argument is judged before the input is looked at, and it is the
+    // PARSER that refuses it, so the message names the argument and the status is one.
+    sbi::assert_granularity(granularity).map_err(|message| {
+        Thrown::command_line(format!(
+            "Argument splitting-index-granularity has a bad value: {granularity}. {message}"
+        ))
+    })?;
 
     let input = argument(parser, "input").ok_or_else(|| {
         Thrown::command_line("Argument input was missing: Argument 'input' is required")
     })?;
-    sbi::assert_is_bam(&input).map_err(Thrown::user)?;
+    // `UserException$BadInput`, whose own constructor puts `Bad input: ` in front of whatever it
+    // is handed. The golden carries the prefix and the class both.
+    sbi::assert_is_bam(&input).map_err(bad_input)?;
 
     let bytes = std::fs::read(&input)
         .map_err(|_| Thrown::user(gatk_tools::read_walker_refusal::cannot_read(&input, false)))?;
@@ -1055,6 +1090,12 @@ pub fn create_hadoop_bam_splitting_index(parser: &Parser) -> Outcome {
     })?;
 
     if flag(parser, "create-bai") {
+        // Only the `.bai` path reads the records, so only it cares how they are sorted.
+        if !is_coordinate_sorted(&bytes) {
+            return Err(bad_input(
+                "Cannot create a .bai index for a file that isn't coordinate sorted.".to_string(),
+            ));
+        }
         // The companion's name REPLACES the index's extension, so `reads.bam.sbi` becomes
         // `reads.bam.bai` and an output named `elsewhere.idx` becomes `elsewhere.bai`.
         let companion = sbi::bai_companion(&output);

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -956,3 +956,117 @@ impl gatk_engine::variant_source::Located for Locus {
         self.stop
     }
 }
+
+/// Every record's virtual offset in a BAM, plus the offset after the last one and the file's size.
+///
+/// `SBIIndexWriter` is fed one pointer per record and closed with the position the next record
+/// would have gone to, so a walker is what the tool needs from the file and not its records: the
+/// bytes are skipped by their own length prefix and never decoded.
+fn record_offsets(bam: &[u8]) -> Result<(Vec<u64>, u64), Thrown> {
+    use std::io::Read;
+
+    let truncated = || Thrown::user("The BAM ends inside a record".to_string());
+    let mut reader = htsjdk_bgzf::BgzfReader::new(bam);
+
+    // The header, which is skipped whole: its text and its reference names decide nothing here.
+    let mut magic = [0u8; 4];
+    reader.read_exact(&mut magic).map_err(|_| truncated())?;
+    if magic != htsjdk_bam::writer::BAM_MAGIC {
+        return Err(Thrown::user("The file is not a BAM".to_string()));
+    }
+    let read_i32 = |reader: &mut htsjdk_bgzf::BgzfReader<&[u8]>| -> Result<i32, Thrown> {
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes).map_err(|_| truncated())?;
+        Ok(i32::from_le_bytes(bytes))
+    };
+    let text_length = read_i32(&mut reader)?;
+    std::io::copy(
+        &mut std::io::Read::by_ref(&mut reader).take(text_length as u64),
+        &mut std::io::sink(),
+    )
+    .map_err(|_| truncated())?;
+    let references = read_i32(&mut reader)?;
+    for _ in 0..references {
+        let name_length = read_i32(&mut reader)?;
+        std::io::copy(
+            &mut std::io::Read::by_ref(&mut reader).take(name_length as u64),
+            &mut std::io::sink(),
+        )
+        .map_err(|_| truncated())?;
+        let _length = read_i32(&mut reader)?;
+    }
+
+    let mut offsets = Vec::new();
+    let mut next_start = reader.virtual_pos();
+    loop {
+        let start = reader.virtual_pos();
+        let mut size_bytes = [0u8; 4];
+        match reader.read_exact(&mut size_bytes) {
+            Ok(()) => {}
+            Err(_) => break,
+        }
+        let block_size = i32::from_le_bytes(size_bytes);
+        std::io::copy(
+            &mut std::io::Read::by_ref(&mut reader).take(block_size as u64),
+            &mut std::io::sink(),
+        )
+        .map_err(|_| truncated())?;
+        offsets.push(start);
+        next_start = reader.virtual_pos();
+    }
+    Ok((offsets, next_start))
+}
+
+/// `CreateHadoopBamSplittingIndex.doWork`, with the BAM read and the index written.
+///
+/// Four things the `splitting-index` golden pins and this reproduces: the granularity is refused
+/// BEFORE anything is opened; the input's extension is refused next, by its extension and not by
+/// its contents; the default output APPENDS `.sbi` where the `.bai` companion REPLACES an
+/// extension; and the last entry is where the next record would have gone, which for an empty BAM
+/// is the file's own length rather than anything inside it.
+pub fn create_hadoop_bam_splitting_index(parser: &Parser) -> Outcome {
+    use gatk_tools::create_hadoop_bam_splitting_index as sbi;
+
+    let granularity = scalar(parser, "splitting-index-granularity")
+        .and_then(|text| text.parse::<i64>().ok())
+        .unwrap_or(sbi::DEFAULT_GRANULARITY as i64);
+    // `doWork`'s first line: the argument is judged before the input is looked at.
+    sbi::assert_granularity(granularity).map_err(Thrown::user)?;
+
+    let input = argument(parser, "input").ok_or_else(|| {
+        Thrown::command_line("Argument input was missing: Argument 'input' is required")
+    })?;
+    sbi::assert_is_bam(&input).map_err(Thrown::user)?;
+
+    let bytes = std::fs::read(&input)
+        .map_err(|_| Thrown::user(gatk_tools::read_walker_refusal::cannot_read(&input, false)))?;
+    let (offsets, next_start) = record_offsets(&bytes)?;
+    let entries = sbi::offsets(&offsets, granularity as u64, next_start);
+    let index = sbi::write(
+        bytes.len() as u64,
+        offsets.len() as u64,
+        granularity as u64,
+        &entries,
+    );
+
+    let output = argument(parser, "output").unwrap_or_else(|| sbi::default_output(&input));
+    std::fs::write(&output, index).map_err(|error| {
+        Thrown::non_user(PORT_FAILURE, format!("could not write {output}: {error}"))
+    })?;
+
+    if flag(parser, "create-bai") {
+        // The companion's name REPLACES the index's extension, so `reads.bam.sbi` becomes
+        // `reads.bam.bai` and an output named `elsewhere.idx` becomes `elsewhere.bai`.
+        let companion = sbi::bai_companion(&output);
+        let bai = htsjdk_bam::build_index::build_bam_index(&bytes)
+            .map_err(|error| Thrown::user(format!("{error:?}")))?;
+        std::fs::write(&companion, bai).map_err(|error| {
+            Thrown::non_user(
+                PORT_FAILURE,
+                format!("could not write {companion}: {error}"),
+            )
+        })?;
+    }
+    // The tool returns nothing, so `handleResult` prints nothing.
+    Ok(None)
+}

--- a/tools/conformance/ci.template.yml
+++ b/tools/conformance/ci.template.yml
@@ -186,7 +186,7 @@ jobs:
         run: |
           python3 tools/coverage/measure.py \
             --tool IndexFeatureFile --tool PrintBGZFBlockInformation --tool CountReads \
-            --tool CountVariants \
+            --tool CountVariants --tool CreateHadoopBamSplittingIndex \
             --port target/release/gatk-rs --corpus-dir /tmp/coverage-corpus
 
       - name: The committed measurement is the one this run produces

--- a/tools/coverage/arrays/CreateHadoopBamSplittingIndex.t2.json
+++ b/tools/coverage/arrays/CreateHadoopBamSplittingIndex.t2.json
@@ -1,0 +1,267 @@
+{
+  "tool": "CreateHadoopBamSplittingIndex",
+  "origin": "gatk",
+  "t": 2,
+  "numeric_policy": "strict",
+  "arguments_total": 17,
+  "arguments_in_array": 6,
+  "arguments_excluded": 11,
+  "excluded": [
+    {
+      "argument": "--arguments_file",
+      "type": "List[File]",
+      "reason": "excluded by the repository: expands into the command line itself, which is measured by the barclay-arguments-file suite instead",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--gatk-config-file",
+      "type": "String",
+      "reason": "excluded by the repository: a configuration file the corpus does not carry; varying it would measure the config loader",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--gcs-max-retries",
+      "type": "int",
+      "reason": "excluded by the repository: reaches nothing without a cloud path in the row",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--gcs-project-for-requester-pays",
+      "type": "String",
+      "reason": "excluded by the repository: reaches nothing without a cloud path in the row",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--help",
+      "type": "boolean",
+      "reason": "excluded by the repository: prints the usage and returns; the row would measure the argument parser rather than the tool",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--QUIET",
+      "type": "Boolean",
+      "reason": "excluded by the repository: suppresses the log on stderr, and what is compared is stdout and the output file",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--showHidden",
+      "type": "boolean",
+      "reason": "excluded by the repository: changes the usage text only",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--splitting-index-granularity",
+      "type": "long",
+      "reason": "only one value available (default)",
+      "held_at": "4096",
+      "source": "default"
+    },
+    {
+      "argument": "--use-jdk-inflater",
+      "type": "boolean",
+      "reason": "excluded by the repository: chooses an inflater, and the input is read the same way either way",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--verbosity",
+      "type": "LogLevel",
+      "reason": "excluded by the repository: log level on stderr, same reason",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--version",
+      "type": "boolean",
+      "reason": "excluded by the repository: prints the version and returns, same reason",
+      "held_at": null,
+      "source": "none"
+    }
+  ],
+  "rows": 9,
+  "tuples_total": 70,
+  "tuples_covered": 70,
+  "tuples_forbidden": 0,
+  "constraint_notes": [],
+  "coverage": 1.0,
+  "array": [
+    {
+      "row": 0,
+      "labels": {
+        "--create-bai": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[0]",
+        "--read-validation-stringency": "STRICT",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--create-bai=true",
+        "--input=/work/fixtures/reads.bam",
+        "--output=/work/out/reads.bam.sbi",
+        "--read-validation-stringency=STRICT",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 1,
+      "labels": {
+        "--create-bai": "true",
+        "--input": "fixture[1]",
+        "--output": "fixture[1]",
+        "--read-validation-stringency": "LENIENT",
+        "--tmp-dir": "fixture[1]",
+        "--use-jdk-deflater": "false"
+      },
+      "arguments": [
+        "--create-bai=true",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/elsewhere.sbi",
+        "--read-validation-stringency=LENIENT",
+        "--tmp-dir=/work/tmp2",
+        "--use-jdk-deflater=false"
+      ]
+    },
+    {
+      "row": 2,
+      "labels": {
+        "--create-bai": "false",
+        "--input": "fixture[0]",
+        "--output": "fixture[1]",
+        "--read-validation-stringency": "SILENT",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "false"
+      },
+      "arguments": [
+        "--create-bai=false",
+        "--input=/work/fixtures/reads.bam",
+        "--output=/work/out/elsewhere.sbi",
+        "--read-validation-stringency=SILENT",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=false"
+      ]
+    },
+    {
+      "row": 3,
+      "labels": {
+        "--create-bai": "false",
+        "--input": "fixture[1]",
+        "--output": "fixture[0]",
+        "--read-validation-stringency": "STRICT",
+        "--tmp-dir": "fixture[1]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--create-bai=false",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/reads.bam.sbi",
+        "--read-validation-stringency=STRICT",
+        "--tmp-dir=/work/tmp2",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 4,
+      "labels": {
+        "--create-bai": "true",
+        "--input": "fixture[1]",
+        "--output": "fixture[0]",
+        "--read-validation-stringency": "SILENT",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--create-bai=true",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/reads.bam.sbi",
+        "--read-validation-stringency=SILENT",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 5,
+      "labels": {
+        "--create-bai": "false",
+        "--input": "fixture[0]",
+        "--output": "fixture[0]",
+        "--read-validation-stringency": "LENIENT",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--create-bai=false",
+        "--input=/work/fixtures/reads.bam",
+        "--output=/work/out/reads.bam.sbi",
+        "--read-validation-stringency=LENIENT",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 6,
+      "labels": {
+        "--create-bai": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[1]",
+        "--read-validation-stringency": "STRICT",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--create-bai=true",
+        "--input=/work/fixtures/reads.bam",
+        "--output=/work/out/elsewhere.sbi",
+        "--read-validation-stringency=STRICT",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 7,
+      "labels": {
+        "--create-bai": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[0]",
+        "--read-validation-stringency": "SILENT",
+        "--tmp-dir": "fixture[1]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--create-bai=true",
+        "--input=/work/fixtures/reads.bam",
+        "--output=/work/out/reads.bam.sbi",
+        "--read-validation-stringency=SILENT",
+        "--tmp-dir=/work/tmp2",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 8,
+      "labels": {
+        "--create-bai": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[0]",
+        "--read-validation-stringency": "STRICT",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "false"
+      },
+      "arguments": [
+        "--create-bai=true",
+        "--input=/work/fixtures/reads.bam",
+        "--output=/work/out/reads.bam.sbi",
+        "--read-validation-stringency=STRICT",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=false"
+      ]
+    }
+  ]
+}

--- a/tools/coverage/fixtures.json
+++ b/tools/coverage/fixtures.json
@@ -73,6 +73,11 @@
     "A tool whose `--INPUT` is not the kind of file the shared value names declares its own here,",
     "as `\"per_tool\": { \"<Tool>\": { \"--INPUT\": [...] } }`. The override replaces the shared list",
     "",
+    "`CreateHadoopBamSplittingIndex` declares its own `--input` and `--output`: the shared input",
+    "list carries three feature files this tool refuses by EXTENSION before it opens anything, so",
+    "an array built from it would measure one refusal four times. Two values are enough to have the",
+    "refusal and the index both.",
+    "",
     "It takes TWO names for the same reason every other argument here does: one value is covered by",
     "being present or absent, and the second is what lets a row notice that the tool writes where it",
     "was told to.",
@@ -158,6 +163,16 @@
     ]
   },
   "per_tool": {
+    "CreateHadoopBamSplittingIndex": {
+      "--input": [
+        "/work/fixtures/reads.bam",
+        "/work/fixtures/reads.vcf"
+      ],
+      "--output": [
+        "/work/out/reads.bam.sbi",
+        "/work/out/elsewhere.sbi"
+      ]
+    },
     "CountVariants": {
       "--output": [
         "/work/out/count.txt",


### PR DESCRIPTION
Four tools could be run and **nine** had declarations, so the five in between were the cheapest way to widen the argument surface: a tool with no binary has no argument coverage at all, whatever its declarations say.

This one first, because everything it needs was already measured. The port has the granularity rule, the extension rule, the two naming rules and the writer; what it lacked was the layer between a path and them.

## Mostly order again

* the **granularity** is refused before anything is opened;
* the **extension** before the file is read — by its extension and not by its contents, so a VCF named `.bam` gets past it;
* the default output **appends** `.sbi` where the `.bai` companion **replaces** an extension — two opposite rules in one run;
* and the last entry is where the *next* record would have gone, which for an empty BAM is the file's own length rather than anything inside it.

The walker takes one virtual offset per record and skips the bytes by their own length prefix: the index needs positions, not records, and decoding them would be a second BAM parser next to the one that already exists.

## The array

9 rows over **6 of the tool's 17** arguments, with **four** distinct outputs. Its `--input` and `--output` are declared per tool: the shared input list carries three feature files this tool refuses by extension, so an array built from it would measure one refusal four times.

Part of #69, #818 and #822.

`python3 tools/preflight.py`: every gate green on the pinned 1.97.1 toolchain.