### PR TITLE
Record the fifth tool's array

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -161,7 +161,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
 | `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, filter-resolution, interval-arguments, read-walker-refusals, tool-argument-declarations, tool-argument-enums, usage-text | 9 | t=2, 23/23 rows (100%) |
 | `CountVariants` | variant-walker | oracle-backed | count-variants, interval-arguments, sequence-dictionary-validation, tool-argument-declarations, tool-argument-enums | 5 | t=2, 31/31 rows (100%) |
-| `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | not measured |
+| `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | t=2, 9/9 rows (100%) |
 | `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |
 | `DenoiseReadCounts` | cnv-segmentation | oracle-backed | denoise-read-counts | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -45,6 +45,15 @@
       "matched": 31,
       "t": 2,
       "share": 1.0
+    },
+    "CreateHadoopBamSplittingIndex": {
+      "rows": 9,
+      "accepted": 6,
+      "rejected": 3,
+      "distinct_outputs": 4,
+      "matched": 9,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
`CreateHadoopBamSplittingIndex` reads **9 of 9** rows over 6 of its 17 arguments, with four distinct outputs, and the five tools with a command line all read 100% of theirs.

| tool | rows | arguments covered |
|---|---:|---|
| `CountReads` | 23/23 | 32 of 42 |
| `CountVariants` | 31/31 | 34 of 44 |
| `CreateHadoopBamSplittingIndex` | **9/9** | **6** of 17 |
| `IndexFeatureFile` | 8/8 | 4 of 14 |
| `PrintBGZFBlockInformation` | 6/6 | 4 of 14 |

Part of #69, #818 and #822.