### PR TITLE
Build the command line a tool records in every file it writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,10 @@ jobs:
             index: "60/60"
             slug: "read-walker-refusals"
             suites: "read-walker-refusals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "expanded-command-line"
+            suites: "expanded-command-line"
     steps:
       - uses: actions/checkout@v7
 

--- a/crates/gatk-cli/src/command_line.rs
+++ b/crates/gatk-cli/src/command_line.rs
@@ -1,0 +1,113 @@
+//! `CommandLineArgumentParser.getCommandLine()`: the string a tool records in every file it writes.
+//!
+//! A BAM's `@PG` carries it in `CL` and a VCF's `##GATKCommandLine` carries it in `CommandLine`,
+//! so it is a byte of the output for every record-transform and variant-transform tool there is.
+//! `sam_output::Options` takes it as an INPUT because no port could invent it, and that is what
+//! kept `PrintReads` from having a runner.
+//!
+//! # Two groups, and neither is the order the user typed
+//!
+//! The arguments the user SET come first, in the parser's own declaration order, and then the ones
+//! that were not set but have a non-null default, in that same order. So `-I` then `-O` on the
+//! command line comes back as `--output` then `--input` when the tool declares the output first.
+//!
+//! # Everything is the long form
+//!
+//! A short alias is expanded and a value is separated from its name by a space. (`--name=value` is
+//! not a form the parser accepts at all: it refuses with `Can't parse option name containing an
+//! embedded '='`.)
+//!
+//! # A collection is one pair per element
+//!
+//! Two `-I` become two `--input` pairs rather than one with a list after it.
+//!
+//! # A plugin's own argument is not a default
+//!
+//! The read-filter descriptor registers every filter it discovers, so an unselected one's
+//! arguments sit in the parser with their defaults. None of them reaches the line: it stops at
+//! `--disable-tool-default-read-filters`, which is the descriptor's own argument rather than a
+//! plugin's. One that was SET is printed, because setting it is what selects the plugin.
+//!
+//! # A default of null is omitted, and an EMPTY default is not
+//!
+//! The filter is on the string `null`, so a collection whose default renders that way disappears
+//! while `--gcs-project-for-requester-pays` is printed with nothing after it.
+//!
+//! Ported from `org.broadinstitute.barclay.argparser.CommandLineArgumentParser.getCommandLine` and
+//! `NamedArgumentDefinition.getCommandLineDisplayString`.
+
+use gatk_barclay::{Parser, Value};
+
+/// `NULL_ARGUMENT_STRING`, which is what a default has to differ from to be printed.
+pub const NULL_ARGUMENT_STRING: &str = "null";
+
+/// The values one argument contributes, each of which becomes its own `--name value` pair.
+fn display_values(value: &Value) -> Vec<String> {
+    match value {
+        Value::Null => Vec::new(),
+        Value::List(values) => values.iter().map(display_one).collect(),
+        other => vec![display_one(other)],
+    }
+}
+
+fn display_one(value: &Value) -> String {
+    match value {
+        // A tagged value prints its own string; the tag itself belongs to the NAME, and none of
+        // the tools that reach this carry one on a set argument.
+        Value::Tagged { value, .. } => value.clone(),
+        other => other.to_java_string(),
+    }
+}
+
+/// `getCommandLine()`: the class's simple name, then the set arguments, then the defaulted ones.
+///
+/// `class_name` is `callerArguments.getClass().getSimpleName()`, which for every tool here is the
+/// tool's own name.
+pub fn expanded(class_name: &str, parser: &Parser) -> String {
+    let mut line = String::from(class_name);
+
+    let push = |line: &mut String, name: &str, values: Vec<String>| {
+        for value in values {
+            line.push_str(" --");
+            line.push_str(name);
+            line.push(' ');
+            line.push_str(&value);
+        }
+    };
+
+    for definition in parser.definitions() {
+        if definition.has_been_set() {
+            push(
+                &mut line,
+                definition.long_name(),
+                display_values(&definition.value),
+            );
+        }
+    }
+    for definition in parser.definitions() {
+        if definition.has_been_set() {
+            continue;
+        }
+        if definition.default_value_as_string() == NULL_ARGUMENT_STRING {
+            continue;
+        }
+        // A PLUGIN's own argument does not reach the line unless somebody set it. The descriptor
+        // registers every read filter it discovers, so an unselected one's arguments are in the
+        // parser with their defaults and in no command line the reference records: the line stops
+        // at `--disable-tool-default-read-filters`, which is the descriptor's own.
+        if definition.controlled_by.is_some() {
+            continue;
+        }
+        // The DEFAULT is what is printed, and the parser left it in the value, so the two agree.
+        // A default that renders as the empty string still prints its name and a trailing space.
+        let values = display_values(&definition.value);
+        if values.is_empty() {
+            line.push_str(" --");
+            line.push_str(definition.long_name());
+            line.push(' ');
+        } else {
+            push(&mut line, definition.long_name(), values);
+        }
+    }
+    line
+}

--- a/crates/gatk-cli/src/lib.rs
+++ b/crates/gatk-cli/src/lib.rs
@@ -20,6 +20,7 @@
 //!
 //! Ported from `org.broadinstitute.hellbender.Main`.
 
+pub mod command_line;
 pub mod definitions;
 pub mod runners;
 
@@ -297,6 +298,14 @@ fn run_index_feature_file(args: &[String]) -> Result<Option<String>, Thrown> {
 
 fn run_print_bgzf_block_information(args: &[String]) -> Result<Option<String>, Thrown> {
     runners::print_bgzf_block_information(&parsed("PrintBGZFBlockInformation", args)?)
+}
+
+/// The tool's own parser over a command line, for a caller that wants the parse and not the run.
+///
+/// The dispatcher reaches this through [`parsed`]; the suite that compares the expanded command
+/// line reaches it directly, because what it measures is the parser's state and not a tool's work.
+pub fn parse_for(tool: &str, args: &[String]) -> Result<gatk_barclay::Parser, String> {
+    parsed(tool, args).map_err(|thrown| thrown.message.unwrap_or_default())
 }
 
 /// The tool's own parser, over the command line the dispatcher was handed.

--- a/crates/gatk-cli/tests/expanded_command_line.rs
+++ b/crates/gatk-cli/tests/expanded_command_line.rs
@@ -1,0 +1,139 @@
+//! Conformance for `getCommandLine()` against GATK 4.6.2.0, over command lines the dump parsed.
+//!
+//! Golden from `tools/argument-conformance/ExpandedCommandLineDump.java`. A BAM's `@PG` carries
+//! this string in `CL` and a VCF's `##GATKCommandLine` carries it in `CommandLine`, so it is a
+//! byte of the output for every tool that writes either.
+//!
+//! # What this suite is for
+//!
+//!  * **the two groups**: the arguments the user set, in the parser's declaration order, then
+//!    those that were not set but have a non-null default, in that same order;
+//!  * **the long form always**, so a short alias is expanded;
+//!  * **`--name=value` not being a form the parser accepts at all**;
+//!  * **a collection being one pair per element**;
+//!  * **an argument set to its own default moving to the FIRST group**, which changes where it
+//!    appears;
+//!  * **a flag given with no value printing one**;
+//!  * **and a default of `null` being omitted where an EMPTY default is printed with a trailing
+//!    space.**
+//!
+//! While the suite is `golden-pending` the dump is named by `EXPANDED_COMMAND_LINE_DUMP`.
+
+use gatk_cli::command_line::expanded;
+
+/// The command lines the harness ran, in its own order.
+const CASES: &[(&str, &str, &[&str])] = &[
+    (
+        "PrintReads",
+        "input-and-output",
+        &["-I", "/dev/null", "-O", "/dev/null"],
+    ),
+    (
+        "PrintReads",
+        "long-names",
+        &["--input", "/dev/null", "--output", "/dev/null"],
+    ),
+    (
+        "PrintReads",
+        "equals-form",
+        &["--input=/dev/null", "--output=/dev/null"],
+    ),
+    (
+        "PrintReads",
+        "two-inputs",
+        &["-I", "/dev/null", "-I", "/dev/null", "-O", "/dev/null"],
+    ),
+    (
+        "PrintReads",
+        "default-set-explicitly",
+        &[
+            "-I",
+            "/dev/null",
+            "-O",
+            "/dev/null",
+            "--create-output-bam-index",
+            "true",
+        ],
+    ),
+    (
+        "PrintReads",
+        "flag-without-a-value",
+        &[
+            "-I",
+            "/dev/null",
+            "-O",
+            "/dev/null",
+            "--add-output-sam-program-record",
+        ],
+    ),
+    (
+        "PrintReads",
+        "with-an-interval",
+        &["-I", "/dev/null", "-O", "/dev/null", "-L", "chr1:1-100"],
+    ),
+    ("CountReads", "one-input", &["-I", "/dev/null"]),
+    ("CountVariants", "one-variant", &["-V", "/dev/null"]),
+    ("IndexFeatureFile", "one-input", &["-I", "/dev/null"]),
+    (
+        "CreateHadoopBamSplittingIndex",
+        "one-input",
+        &["-I", "/dev/null"],
+    ),
+];
+
+fn unescape(text: &str) -> String {
+    text.replace("\\t", "\t")
+        .replace("\\n", "\n")
+        .replace("\\\\", "\\")
+}
+
+fn field(dump: &str, kind: &str, tool: &str, label: &str) -> Option<String> {
+    let prefix = format!("{kind}\t{tool}\t{label}\t");
+    dump.lines()
+        .find(|line| line.starts_with(&prefix))
+        .map(|line| unescape(&line[prefix.len()..]))
+}
+
+#[test]
+fn every_command_line_expands_as_the_reference_expands_it() {
+    let dump = match std::env::var("EXPANDED_COMMAND_LINE_DUMP") {
+        Ok(path) => {
+            std::fs::read_to_string(path).expect("the dump named by EXPANDED_COMMAND_LINE_DUMP")
+        }
+        Err(_) => {
+            println!(
+                "skipped: the expanded-command-line golden is still pending. Run the suite and \
+                 point EXPANDED_COMMAND_LINE_DUMP at \
+                 tools/conformance/pending/expanded-command-line.ExpandedCommandLineDump.txt"
+            );
+            return;
+        }
+    };
+
+    for (tool, label, argv) in CASES {
+        let args: Vec<String> = argv.iter().map(|arg| (*arg).to_string()).collect();
+        let parsed = gatk_cli::parse_for(tool, &args);
+        match parsed {
+            Ok(parser) => {
+                let ours = expanded(tool, &parser);
+                assert_eq!(
+                    ours,
+                    field(&dump, "line", tool, label)
+                        .unwrap_or_else(|| panic!("{tool}/{label}: the golden refused")),
+                    "{tool}/{label}"
+                );
+            }
+            Err(message) => {
+                let theirs = field(&dump, "error", tool, label).unwrap_or_else(|| {
+                    panic!("{tool}/{label}: the port refused, the golden did not")
+                });
+                // The golden carries the exception class and this carries the message, so what is
+                // compared is that the reference refused with THIS wording.
+                assert!(
+                    theirs.contains(&message),
+                    "{tool}/{label}: {theirs} vs {message}"
+                );
+            }
+        }
+    }
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -224,7 +224,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `PrintDistantMates` | record-transform | oracle-backed | print-distant-mates | 1 | not measured |
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |
 | `PrintReadCounts` | sv-caller | oracle-backed | print-read-counts | 1 | not measured |
-| `PrintReads` | record-transform | oracle-backed | printreads, tool-argument-declarations, tool-argument-enums | 3 | not measured |
+| `PrintReads` | record-transform | oracle-backed | expanded-command-line, printreads, tool-argument-declarations, tool-argument-enums | 4 | not measured |
 | `PrintReadsHeader` | record-transform | oracle-backed | print-reads-header | 1 | not measured |
 | `PrintSVEvidence` | unclassified | oracle-backed | print-sv-evidence | 1 | not measured |
 | `RampedHaplotypeCaller` | assembly-caller | oracle-backed | ramped-haplotype-caller | 1 | not measured |

--- a/tools/argument-conformance/ExpandedCommandLineDump.java
+++ b/tools/argument-conformance/ExpandedCommandLineDump.java
@@ -1,0 +1,100 @@
+/*
+ * `CommandLineArgumentParser.getCommandLine()`: the string a tool records in every file it writes.
+ *
+ * A BAM's @PG carries it in CL and a VCF's ##GATKCommandLine carries it in CommandLine, so it is a
+ * byte of the output for every record-transform and variant-transform tool there is. A port that
+ * could not build it could not write any of their files (gatk-rs#69).
+ *
+ * Five behaviours this is built to catch.
+ *
+ *   - IT OPENS WITH THE CLASS'S SIMPLE NAME, which is the TOOL's and not the command line's: it is
+ *     `PrintReads`, never `gatk PrintReads` and never the display name a Picard tool carries;
+ *   - THE ARGUMENTS COME IN TWO GROUPS: those the user SET, in the parser's own declaration order,
+ *     and then those that were not set but have a non-null default, in that same order. Not the
+ *     order they were typed in;
+ *   - EVERY ONE IS PRINTED AS `--longName value`, whatever the user typed: a short alias is
+ *     expanded and a value given with `=` is separated;
+ *   - A COLLECTION BECOMES ONE `--name value` PER ELEMENT rather than one with a list after it;
+ *   - AND A DEFAULT OF NULL IS OMITTED while a default of anything else is printed, which is why
+ *     the line is long even for a command line that set two arguments.
+ *
+ * Output:
+ *
+ *     line\t<tool>\t<case>\t<the expanded command line>
+ *     error\t<tool>\t<case>\t<exception class>: <message>
+ *
+ * Usage: ExpandedCommandLineDump
+ */
+
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class ExpandedCommandLineDump {
+
+    static final StringBuilder buf = new StringBuilder();
+
+    static void emit(final String kind, final String tool, final String label, final String payload) {
+        buf.append(kind).append('\t').append(tool).append('\t').append(label).append('\t')
+                .append(payload.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n"))
+                .append('\n');
+    }
+
+    static CommandLineProgram instance(final String tool) {
+        return switch (tool) {
+            case "CountReads" -> new org.broadinstitute.hellbender.tools.CountReads();
+            case "CountVariants" -> new org.broadinstitute.hellbender.tools.walkers.CountVariants();
+            case "IndexFeatureFile" -> new org.broadinstitute.hellbender.tools.IndexFeatureFile();
+            case "CreateHadoopBamSplittingIndex" ->
+                    new org.broadinstitute.hellbender.tools.spark.CreateHadoopBamSplittingIndex();
+            default -> new org.broadinstitute.hellbender.tools.PrintReads();
+        };
+    }
+
+    /** One command line, parsed and then asked what it expanded to. */
+    static void run(final String tool, final String label, final String... argv) {
+        try {
+            final CommandLineProgram target = instance(tool);
+            final PrintStream sink = new PrintStream(new ByteArrayOutputStream());
+            if (!target.getCommandLineParser().parseArguments(sink, argv)) {
+                emit("error", tool, label, "not-parsed");
+                return;
+            }
+            emit("line", tool, label, target.getCommandLineParser().getCommandLine());
+        } catch (final Exception | AssertionError e) {
+            emit("error", tool, label, e.getClass().getName() + ": " + e.getMessage());
+        }
+    }
+
+    public static void main(final String[] args) {
+        // The shortest line there is: one required argument and every default behind it.
+        run("PrintReads", "input-and-output", "-I", "/dev/null", "-O", "/dev/null");
+        // The same two arguments under their long names, which changes nothing: the line is always
+        // the long form.
+        run("PrintReads", "long-names", "--input", "/dev/null", "--output", "/dev/null");
+        // And with `=`, which the line separates again.
+        run("PrintReads", "equals-form", "--input=/dev/null", "--output=/dev/null");
+        // A collection with two values, which becomes two `--input` pairs rather than one.
+        run("PrintReads", "two-inputs", "-I", "/dev/null", "-I", "/dev/null", "-O", "/dev/null");
+        // An argument set to the value it already had by default, which moves it from the second
+        // group to the FIRST and therefore changes where it appears in the line.
+        run("PrintReads", "default-set-explicitly",
+                "-I", "/dev/null", "-O", "/dev/null", "--create-output-bam-index", "true");
+        // A boolean flag with no value, which the line prints with one.
+        run("PrintReads", "flag-without-a-value",
+                "-I", "/dev/null", "-O", "/dev/null", "--add-output-sam-program-record");
+        // An interval, which is a collection of a different type.
+        run("PrintReads", "with-an-interval",
+                "-I", "/dev/null", "-O", "/dev/null", "-L", "chr1:1-100");
+
+        // The other four tools, so the opening name and the defaults behind it are measured for
+        // each rather than assumed to follow one pattern.
+        run("CountReads", "one-input", "-I", "/dev/null");
+        run("CountVariants", "one-variant", "-V", "/dev/null");
+        run("IndexFeatureFile", "one-input", "-I", "/dev/null");
+        run("CreateHadoopBamSplittingIndex", "one-input", "-I", "/dev/null");
+
+        System.out.print(buf);
+    }
+}

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6452,6 +6452,26 @@
       ]
     },
     {
+      "id": "expanded-command-line",
+      "status": "golden-pending",
+      "title": "the command line a tool records in every file it writes",
+      "harness": "tools/argument-conformance",
+      "tools": [
+        "PrintReads"
+      ],
+      "compare": {
+        "mode": "lines"
+      },
+      "why": "A BAM's @PG carries it in CL and a VCF's ##GATKCommandLine carries it in CommandLine, so it is a byte of the output for every record-transform and variant-transform tool there is: `sam_output::Options` takes it as an INPUT because no port could invent it, which is what stops PrintReads from having a runner (#69). The rule is not guessable from the string. It opens with the tool CLASS's simple name; the arguments come in two groups, those the user SET in the parser's declaration order and then those that were not set but have a non-null default, in that same order rather than the order they were typed; every one is printed as `--longName value` whatever the user typed, so a short alias is expanded and an `=` is separated; a collection becomes one pair PER ELEMENT; and a default of null is omitted where any other default is printed, which is why the line is long for a command line that set two arguments.",
+      "cases": [
+        {
+          "dump": "ExpandedCommandLineDump",
+          "golden": null,
+          "why": "Seven command lines over PrintReads covering each rule, and one over each of the other four declared tools so the opening name and the defaults behind it are measured rather than assumed to follow one pattern."
+        }
+      ]
+    },
+    {
       "id": "main-non-user",
       "status": "oracle-backed",
       "title": "handleNonUserException, which is the handler handleUserException is not",


### PR DESCRIPTION
`sam_output::Options` takes `command_line` as an **input**, with a comment saying no port could invent it — and that is what has kept every *writing* tool from having a runner: a BAM's `@PG` carries the string in `CL` and a VCF's `##GATKCommandLine` carries it in `CommandLine`.

It can be invented, and the rule is not the one the string suggests.

**It opens with the tool class's simple name.** Not `gatk PrintReads`, not the display name a Picard tool carries: `PrintReads`.

**The arguments come in two groups**, and neither is the order they were typed: those the user *set*, in the parser's own declaration order, and then those that were not set but have a non-null default, in that same order. So `-I` then `-O` comes back as `--output` then `--input` — and setting an argument to the value it already had moves it from the second group to the first.

**Everything is the long form**, with the value separated by a space. And `--name=value` is not a form the parser accepts at all: it refuses with `Can't parse option name containing an embedded '='`.

**A collection is one pair per element** rather than one name and a list.

**A default of `null` is omitted and an empty default is not**, so `--gcs-project-for-requester-pays` appears with nothing after it while every collection disappears.

**And a plugin's own argument does not reach the line** unless somebody set it. The read-filter descriptor registers every filter it discovers, so an unselected one's arguments sit in the parser with their defaults and in no line the reference records: it stops at `--disable-tool-default-read-filters`, which is the descriptor's own.

Eleven command lines over the five declared tools, every one agreeing locally. The suite lands **golden-pending**.

Part of #69 and #820.

`python3 tools/preflight.py`: every gate green on the pinned 1.97.1 toolchain.