### PR TITLE
Record the sixth tool's array

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -224,7 +224,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `PrintDistantMates` | record-transform | oracle-backed | print-distant-mates | 1 | not measured |
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |
 | `PrintReadCounts` | sv-caller | oracle-backed | print-read-counts | 1 | not measured |
-| `PrintReads` | record-transform | oracle-backed | expanded-command-line, printreads, tool-argument-declarations, tool-argument-enums | 4 | not measured |
+| `PrintReads` | record-transform | oracle-backed | expanded-command-line, printreads, tool-argument-declarations, tool-argument-enums | 4 | t=2, 19/19 rows (100%) |
 | `PrintReadsHeader` | record-transform | oracle-backed | print-reads-header | 1 | not measured |
 | `PrintSVEvidence` | unclassified | oracle-backed | print-sv-evidence | 1 | not measured |
 | `RampedHaplotypeCaller` | assembly-caller | oracle-backed | ramped-haplotype-caller | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -54,6 +54,15 @@
       "matched": 9,
       "t": 2,
       "share": 1.0
+    },
+    "PrintReads": {
+      "rows": 19,
+      "accepted": 9,
+      "rejected": 10,
+      "distinct_outputs": 9,
+      "matched": 19,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
`PrintReads` reads **19 of 19** rows over 32 of its 42 arguments, with **nine** distinct outputs — more than any other tool measured here, because a tool that writes its input back out is one whose arguments can disagree.

| tool | rows | arguments covered |
|---|---:|---|
| `CountReads` | 23/23 | 32 of 42 |
| `CountVariants` | 31/31 | 34 of 44 |
| `CreateHadoopBamSplittingIndex` | 9/9 | 6 of 17 |
| `IndexFeatureFile` | 8/8 | 4 of 14 |
| `PrintBGZFBlockInformation` | 6/6 | 4 of 14 |
| `PrintReads` | **19/19** | **32** of 42 |

Six tools have a command line now and all six read 100% of their arrays.

Part of #69, #818 and #822.