### PR TITLE
Run GatherVcfsCloud, the seventh tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,7 +494,7 @@ jobs:
           python3 tools/coverage/measure.py \
             --tool IndexFeatureFile --tool PrintBGZFBlockInformation --tool CountReads \
             --tool CountVariants --tool CreateHadoopBamSplittingIndex \
-            --tool PrintReads \
+            --tool PrintReads --tool GatherVcfsCloud \
             --port target/release/gatk-rs --corpus-dir /tmp/coverage-corpus
 
       - name: The committed measurement is the one this run produces

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "gatk-tools",
  "htsjdk-bam",
  "htsjdk-bgzf",
+ "htsjdk-tribble",
 ]
 
 [[package]]

--- a/crates/gatk-cli/Cargo.toml
+++ b/crates/gatk-cli/Cargo.toml
@@ -21,6 +21,9 @@ htsjdk-bam.workspace = true
 # The file plumbing under a runner: a block-compressed input is decompressed before the port's own
 # function is handed its text.
 htsjdk-bgzf.workspace = true
+# The index a VCF WRITER builds on the fly, which is not the one IndexFeatureFile builds from the
+# same file: the dictionary is properties and the file's own stats are left at zero.
+htsjdk-tribble.workspace = true
 
 [dev-dependencies]
 gatk-corpus = { path = "../gatk-corpus" }

--- a/crates/gatk-cli/src/lib.rs
+++ b/crates/gatk-cli/src/lib.rs
@@ -274,6 +274,7 @@ pub fn runner(name: &str) -> Option<Runner> {
         "CountVariants" => Some(run_count_variants),
         "CreateHadoopBamSplittingIndex" => Some(run_create_hadoop_bam_splitting_index),
         "PrintReads" => Some(run_print_reads),
+        "GatherVcfsCloud" => Some(run_gather_vcfs_cloud),
         "IndexFeatureFile" => Some(run_index_feature_file),
         "PrintBGZFBlockInformation" => Some(run_print_bgzf_block_information),
         _ => None,
@@ -281,6 +282,10 @@ pub fn runner(name: &str) -> Option<Runner> {
 }
 
 /// The runners, each of which needs the parsed command line rather than the raw one.
+fn run_gather_vcfs_cloud(args: &[String]) -> Result<Option<String>, Thrown> {
+    runners::gather_vcfs_cloud(&parsed("GatherVcfsCloud", args)?)
+}
+
 fn run_print_reads(args: &[String]) -> Result<Option<String>, Thrown> {
     runners::print_reads(&parsed("PrintReads", args)?)
 }

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -1369,10 +1369,17 @@ pub fn gather_vcfs_cloud(parser: &Parser) -> Outcome {
 
     let written =
         gatk_tools::gather_vcfs::gather(&shards, &arguments_for_gather).map_err(|error| {
+            let class = error.java_class();
             Thrown {
                 failure: Failure::User,
-                exception: error.java_class(),
-                message: Some(error.message()),
+                exception: class,
+                // `UserException$BadInput`'s constructor puts `Bad input: ` in front of whatever
+                // it is handed, and the port's message is what it was handed.
+                message: Some(if class.ends_with("$BadInput") {
+                    format!("Bad input: {}", error.message())
+                } else {
+                    error.message()
+                }),
             }
         })?;
 
@@ -1437,7 +1444,12 @@ pub fn gather_vcfs_cloud(parser: &Parser) -> Outcome {
     if flag(parser, "create-output-variant-index") {
         // The index a feature file's name implies: a `.tbi` for a block compressed output and a
         // Tribble `.idx` for a plain one, both APPENDED to the whole name.
-        let source = index_feature_file::Source::new(&output);
+        //
+        // The Tribble header records the file's URI, its SIZE and its lastModified, so an index
+        // built with the zero `Source` defaults to differs from the reference's in bytes it never
+        // looks at again. The file has just been written, so its mtime is there to be read.
+        let mut source = index_feature_file::Source::new(&output);
+        source.timestamp = modified_millis(&output);
         let index = match index_feature_file::index_kind(&output) {
             index_feature_file::IndexKind::Tabix => {
                 let (level, deflater) = output_compression(parser);

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -1259,3 +1259,197 @@ pub fn print_reads(parser: &Parser) -> Outcome {
     // The tool returns nothing, so `handleResult` prints nothing.
     Ok(None)
 }
+
+/// One input VCF, read as far as the gather looks at it.
+///
+/// The gather compares dictionaries, sample lists and record positions, and copies lines: nothing
+/// it decides needs an allele parsed, so the file is read as text and the header kept whole.
+fn gather_shard(name: &str) -> Result<(gatk_tools::gather_vcfs::Shard, Vec<String>, bool), Thrown> {
+    let bytes = std::fs::read(name)
+        .map_err(|_| Thrown::user(gatk_tools::read_walker_refusal::cannot_read(name, false)))?;
+    let compressed = gatk_tools::read_walker_refusal::is_block_compressed(&bytes);
+    let text = if compressed {
+        htsjdk_bgzf::read::decompress_all(&bytes)
+            .ok()
+            .and_then(|bytes| String::from_utf8(bytes).ok())
+            .ok_or_else(|| {
+                Thrown::non_user(
+                    gatk_tools::read_walker_refusal::SAM_FORMAT,
+                    format!("{name} is not a block compressed file"),
+                )
+            })?
+    } else {
+        String::from_utf8_lossy(&bytes).into_owned()
+    };
+
+    let mut header = Vec::new();
+    let mut dictionary = Vec::new();
+    let mut samples = Vec::new();
+    let mut records = Vec::new();
+    for line in text.lines() {
+        if line.starts_with("##") {
+            header.push(line.to_string());
+            if let Some(body) = line.strip_prefix("##contig=<") {
+                if let Some(id) = body
+                    .trim_end_matches('>')
+                    .split(',')
+                    .find_map(|field| field.strip_prefix("ID="))
+                {
+                    dictionary.push(id.to_string());
+                }
+            }
+        } else if line.starts_with("#CHROM") {
+            header.push(line.to_string());
+            // The samples are every column past FORMAT, which is the ninth.
+            samples = line.split('\t').skip(9).map(str::to_string).collect();
+        } else if !line.is_empty() {
+            let mut fields = line.split('\t');
+            let contig = fields.next().unwrap_or_default().to_string();
+            let position = fields
+                .next()
+                .and_then(|text| text.parse::<i32>().ok())
+                .unwrap_or(0);
+            records.push((contig, position));
+        }
+    }
+    Ok((
+        gatk_tools::gather_vcfs::Shard {
+            name: name.to_string(),
+            dictionary,
+            samples,
+            records,
+        },
+        header,
+        compressed,
+    ))
+}
+
+/// `GatherVcfsCloud.doWork`: the shards' records, in order, under the first shard's header.
+///
+/// The tool has two paths and this carries one. CONVENTIONAL re-reads and re-writes the records;
+/// BLOCK copies the compressed BLOCKS of each input, which is a different set of bytes for the
+/// same records and is not something a text writer can produce. The port refuses that path in its
+/// own words rather than writing the conventional bytes under its name.
+pub fn gather_vcfs_cloud(parser: &Parser) -> Outcome {
+    use gatk_tools::gather_vcfs::{Arguments, GatherType};
+
+    let inputs = arguments(parser, "input");
+    if inputs.is_empty() {
+        return Err(Thrown::command_line(
+            "Argument input was missing: Argument 'input' is required",
+        ));
+    }
+    let output = argument(parser, "output").ok_or_else(|| {
+        Thrown::command_line("Argument output was missing: Argument 'output' is required")
+    })?;
+
+    let mut shards = Vec::new();
+    let mut lines = Vec::new();
+    let mut all_compressed = true;
+    for input in &inputs {
+        let (shard, header, compressed) = gather_shard(input)?;
+        all_compressed &= compressed;
+        lines.push((header, input.clone()));
+        shards.push(shard);
+    }
+
+    let output_is_block_compressed = output.ends_with(".gz") || output.ends_with(".bgz");
+    let gather_type = match scalar(parser, "gather-type").as_deref() {
+        Some("BLOCK") => GatherType::Block,
+        Some("CONVENTIONAL") => GatherType::Conventional,
+        _ => GatherType::Automatic,
+    };
+    let arguments_for_gather = Arguments {
+        gather_type,
+        ignore_safety_checks: flag(parser, "ignore-safety-checks"),
+        disable_contig_ordering_check: flag(parser, "disable-contig-ordering-check"),
+        output_is_block_compressed,
+        inputs_are_block_compressed: all_compressed,
+    };
+
+    let written =
+        gatk_tools::gather_vcfs::gather(&shards, &arguments_for_gather).map_err(|error| {
+            Thrown {
+                failure: Failure::User,
+                exception: error.java_class(),
+                message: Some(error.message()),
+            }
+        })?;
+
+    // `AUTOMATIC` resolves to BLOCK when everything in sight is block compressed, and BLOCK copies
+    // bytes rather than records.
+    let effective_block = gather_type == GatherType::Block
+        || (gather_type == GatherType::Automatic && all_compressed && output_is_block_compressed);
+    if effective_block {
+        return Err(Thrown::non_user(
+            PORT_LIMITATION,
+            "Block gathering copies the inputs' compressed blocks, which this port does not carry \
+             yet. This message is the port's own and not GATK's.",
+        ));
+    }
+
+    // The header is the FIRST shard's, whole, and then every record the gather selected.
+    let mut text = String::new();
+    for line in &lines[0].0 {
+        text.push_str(line);
+        text.push('\n');
+    }
+    let bodies: Vec<Vec<String>> = inputs
+        .iter()
+        .map(|input| {
+            std::fs::read(input)
+                .ok()
+                .map(|bytes| {
+                    let text = if gatk_tools::read_walker_refusal::is_block_compressed(&bytes) {
+                        htsjdk_bgzf::read::decompress_all(&bytes).unwrap_or_default()
+                    } else {
+                        bytes
+                    };
+                    String::from_utf8_lossy(&text)
+                        .lines()
+                        .filter(|line| !line.starts_with('#') && !line.is_empty())
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default()
+        })
+        .collect();
+    for (shard, record) in &written {
+        text.push_str(&bodies[*shard][*record]);
+        text.push('\n');
+    }
+
+    let bytes = if output_is_block_compressed {
+        let (level, deflater) = output_compression(parser);
+        let mut writer = htsjdk_bgzf::BgzfWriter::with_deflater(Vec::new(), level, deflater);
+        std::io::Write::write_all(&mut writer, text.as_bytes())
+            .map_err(|error| Thrown::non_user(PORT_FAILURE, format!("{error}")))?;
+        writer
+            .into_inner()
+            .map_err(|error| Thrown::non_user(PORT_FAILURE, format!("{error}")))?
+    } else {
+        text.into_bytes()
+    };
+    std::fs::write(&output, &bytes).map_err(|error| {
+        Thrown::non_user(PORT_FAILURE, format!("could not write {output}: {error}"))
+    })?;
+
+    if flag(parser, "create-output-variant-index") {
+        // The index a feature file's name implies: a `.tbi` for a block compressed output and a
+        // Tribble `.idx` for a plain one, both APPENDED to the whole name.
+        let source = index_feature_file::Source::new(&output);
+        let index = match index_feature_file::index_kind(&output) {
+            index_feature_file::IndexKind::Tabix => {
+                let (level, deflater) = output_compression(parser);
+                index_feature_file::build_tabix(&bytes, &source, &output, deflater, level)
+            }
+            _ => index_feature_file::build(&String::from_utf8_lossy(&bytes), &source, &output),
+        }
+        .map_err(|refusal| Thrown::user(refusal.message()))?;
+        let name = index_feature_file::default_output(&output);
+        std::fs::write(&name, index).map_err(|error| {
+            Thrown::non_user(PORT_FAILURE, format!("could not write {name}: {error}"))
+        })?;
+    }
+    Ok(None)
+}

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -1260,6 +1260,75 @@ pub fn print_reads(parser: &Parser) -> Outcome {
     Ok(None)
 }
 
+/// The `.idx` a VCF WRITER builds, which is not the one `IndexFeatureFile` builds from the file.
+///
+/// `IndexingVariantContextWriter` hands the creator the position BEFORE each record, absolute in
+/// the output stream so the header is counted, and closes it with the whole file's length. Then
+/// `setIndexSequenceDictionary` puts the dictionary in the creator's own property map, before
+/// `finalizeIndex` appends its statistics -- so the dictionary is `DICT:` properties and the flag
+/// that used to carry it is zero. And nothing ever stats the file being written, so its size, its
+/// timestamp and its md5 are left at zero where `IndexFeatureFile` fills them in.
+fn on_the_fly_index(text: &str, dictionary: &[(String, i32)], path: &str) -> Vec<u8> {
+    use htsjdk_tribble::index::{TribbleIndex, INTERVAL_TREE, LINEAR, VERSION};
+    use htsjdk_tribble::index_write::{BalanceApproach, BuiltIndex, DynamicIndexCreator, Feature};
+
+    let mut creator = DynamicIndexCreator::new(BalanceApproach::ForSeekTime);
+    let mut at: i64 = 0;
+    for line in text.split_inclusive('\n') {
+        let body = line.trim_end_matches('\n');
+        if !body.starts_with('#') {
+            let columns: Vec<&str> = body.split('\t').collect();
+            if columns.len() >= 8 {
+                if let Ok(start) = columns[1].parse::<i32>() {
+                    let end = columns[7]
+                        .split(';')
+                        .filter_map(|field| field.split_once('='))
+                        .find(|(key, _)| *key == "END")
+                        .and_then(|(_, value)| value.parse::<i32>().ok())
+                        .unwrap_or(start + columns[3].len() as i32 - 1);
+                    creator.add_feature(
+                        &Feature {
+                            contig: columns[0].to_string(),
+                            start,
+                            end,
+                        },
+                        at,
+                    );
+                }
+            }
+        }
+        at += line.len() as i64;
+    }
+
+    let mut properties: Vec<(String, String)> = dictionary
+        .iter()
+        .map(|(name, length)| (format!("DICT:{name}"), length.to_string()))
+        .collect();
+    properties.extend(creator.properties());
+
+    let (index_type, contigs, interval_contigs) = match creator.finalize(text.len() as i64) {
+        Ok(BuiltIndex::Linear(contigs)) => (LINEAR, contigs, Vec::new()),
+        Ok(BuiltIndex::IntervalTree(intervals)) => (INTERVAL_TREE, Vec::new(), intervals),
+        Err(_) => (LINEAR, Vec::new(), Vec::new()),
+    };
+
+    TribbleIndex {
+        index_type,
+        version: VERSION,
+        indexed_path: format!("file://{path}"),
+        indexed_file_size: 0,
+        indexed_file_timestamp: 0,
+        indexed_file_md5: String::new(),
+        // Zero, not the dictionary flag: from version 3 the dictionary is properties.
+        flags: 0,
+        properties,
+        contigs,
+        interval_contigs,
+    }
+    .write()
+    .unwrap_or_default()
+}
+
 /// One input VCF, read as far as the gather looks at it.
 ///
 /// The gather compares dictionaries, sample lists and record positions, and copies lines: nothing
@@ -1395,6 +1464,24 @@ pub fn gather_vcfs_cloud(parser: &Parser) -> Outcome {
         ));
     }
 
+    // The dictionary with its LENGTHS, which the writer's index carries as properties where the
+    // gather only needed the names.
+    let dictionary_lengths: Vec<(String, i32)> = lines[0]
+        .0
+        .iter()
+        .filter_map(|line| line.strip_prefix("##contig=<"))
+        .filter_map(|body| {
+            let body = body.trim_end_matches('>');
+            let name = body.split(',').find_map(|f| f.strip_prefix("ID="))?;
+            let length = body
+                .split(',')
+                .find_map(|f| f.strip_prefix("length="))
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(0);
+            Some((name.to_string(), length))
+        })
+        .collect();
+
     // The header is the FIRST shard's, whole, and then every record the gather selected.
     let mut text = String::new();
     for line in &lines[0].0 {
@@ -1426,6 +1513,8 @@ pub fn gather_vcfs_cloud(parser: &Parser) -> Outcome {
         text.push('\n');
     }
 
+    // The bytes on disk, which for a plain output are the text itself and for a `.gz` are that
+    // text block compressed.
     let bytes = if output_is_block_compressed {
         let (level, deflater) = output_compression(parser);
         let mut writer = htsjdk_bgzf::BgzfWriter::with_deflater(Vec::new(), level, deflater);
@@ -1435,7 +1524,7 @@ pub fn gather_vcfs_cloud(parser: &Parser) -> Outcome {
             .into_inner()
             .map_err(|error| Thrown::non_user(PORT_FAILURE, format!("{error}")))?
     } else {
-        text.into_bytes()
+        text.clone().into_bytes()
     };
     std::fs::write(&output, &bytes).map_err(|error| {
         Thrown::non_user(PORT_FAILURE, format!("could not write {output}: {error}"))
@@ -1454,10 +1543,11 @@ pub fn gather_vcfs_cloud(parser: &Parser) -> Outcome {
             index_feature_file::IndexKind::Tabix => {
                 let (level, deflater) = output_compression(parser);
                 index_feature_file::build_tabix(&bytes, &source, &output, deflater, level)
+                    .map_err(|refusal| Thrown::user(refusal.message()))?
             }
-            _ => index_feature_file::build(&String::from_utf8_lossy(&bytes), &source, &output),
-        }
-        .map_err(|refusal| Thrown::user(refusal.message()))?;
+            // A writer's `.idx` is not the one `IndexFeatureFile` builds from the same file.
+            _ => on_the_fly_index(&text, &dictionary_lengths, &output),
+        };
         let name = index_feature_file::default_output(&output);
         std::fs::write(&name, index).map_err(|error| {
             Thrown::non_user(PORT_FAILURE, format!("could not write {name}: {error}"))

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -1268,7 +1268,13 @@ pub fn print_reads(parser: &Parser) -> Outcome {
 /// `finalizeIndex` appends its statistics -- so the dictionary is `DICT:` properties and the flag
 /// that used to carry it is zero. And nothing ever stats the file being written, so its size, its
 /// timestamp and its md5 are left at zero where `IndexFeatureFile` fills them in.
-fn on_the_fly_index(text: &str, dictionary: &[(String, i32)], path: &str) -> Vec<u8> {
+fn on_the_fly_index(
+    text: &str,
+    dictionary: &[(String, i32)],
+    path: &str,
+    size: i64,
+    timestamp: i64,
+) -> Vec<u8> {
     use htsjdk_tribble::index::{TribbleIndex, INTERVAL_TREE, LINEAR, VERSION};
     use htsjdk_tribble::index_write::{BalanceApproach, BuiltIndex, DynamicIndexCreator, Feature};
 
@@ -1316,8 +1322,11 @@ fn on_the_fly_index(text: &str, dictionary: &[(String, i32)], path: &str) -> Vec
         index_type,
         version: VERSION,
         indexed_path: format!("file://{path}"),
-        indexed_file_size: 0,
-        indexed_file_timestamp: 0,
+        // `close()` writes the index with `writeBasedOnFeaturePath`, which STATS the file it has
+        // just finished: the size and the timestamp are the written file's. The md5 is not
+        // computed and stays empty.
+        indexed_file_size: size,
+        indexed_file_timestamp: timestamp,
         indexed_file_md5: String::new(),
         // Zero, not the dictionary flag: from version 3 the dictionary is properties.
         flags: 0,
@@ -1546,7 +1555,13 @@ pub fn gather_vcfs_cloud(parser: &Parser) -> Outcome {
                     .map_err(|refusal| Thrown::user(refusal.message()))?
             }
             // A writer's `.idx` is not the one `IndexFeatureFile` builds from the same file.
-            _ => on_the_fly_index(&text, &dictionary_lengths, &output),
+            _ => on_the_fly_index(
+                &text,
+                &dictionary_lengths,
+                &output,
+                bytes.len() as i64,
+                modified_millis(&output),
+            ),
         };
         let name = index_feature_file::default_output(&output);
         std::fs::write(&name, index).map_err(|error| {

--- a/tools/conformance/ci.template.yml
+++ b/tools/conformance/ci.template.yml
@@ -187,7 +187,7 @@ jobs:
           python3 tools/coverage/measure.py \
             --tool IndexFeatureFile --tool PrintBGZFBlockInformation --tool CountReads \
             --tool CountVariants --tool CreateHadoopBamSplittingIndex \
-            --tool PrintReads \
+            --tool PrintReads --tool GatherVcfsCloud \
             --port target/release/gatk-rs --corpus-dir /tmp/coverage-corpus
 
       - name: The committed measurement is the one this run produces

--- a/tools/coverage/arrays/GatherVcfsCloud.t2.json
+++ b/tools/coverage/arrays/GatherVcfsCloud.t2.json
@@ -1,0 +1,396 @@
+{
+  "tool": "GatherVcfsCloud",
+  "origin": "gatk",
+  "t": 2,
+  "numeric_policy": "strict",
+  "arguments_total": 20,
+  "arguments_in_array": 9,
+  "arguments_excluded": 11,
+  "excluded": [
+    {
+      "argument": "--arguments_file",
+      "type": "List[File]",
+      "reason": "excluded by the repository: expands into the command line itself, which is measured by the barclay-arguments-file suite instead",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--gatk-config-file",
+      "type": "String",
+      "reason": "excluded by the repository: a configuration file the corpus does not carry; varying it would measure the config loader",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--gcs-max-retries",
+      "type": "int",
+      "reason": "excluded by the repository: reaches nothing without a cloud path in the row",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--gcs-project-for-requester-pays",
+      "type": "String",
+      "reason": "excluded by the repository: reaches nothing without a cloud path in the row",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--help",
+      "type": "boolean",
+      "reason": "excluded by the repository: prints the usage and returns; the row would measure the argument parser rather than the tool",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--progress-logger-frequency",
+      "type": "Integer",
+      "reason": "only one value available (default)",
+      "held_at": "10000",
+      "source": "default"
+    },
+    {
+      "argument": "--QUIET",
+      "type": "Boolean",
+      "reason": "excluded by the repository: suppresses the log on stderr, and what is compared is stdout and the output file",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--showHidden",
+      "type": "boolean",
+      "reason": "excluded by the repository: changes the usage text only",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--use-jdk-inflater",
+      "type": "boolean",
+      "reason": "excluded by the repository: chooses an inflater, and the input is read the same way either way",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--verbosity",
+      "type": "LogLevel",
+      "reason": "excluded by the repository: log level on stderr, same reason",
+      "held_at": null,
+      "source": "none"
+    },
+    {
+      "argument": "--version",
+      "type": "boolean",
+      "reason": "excluded by the repository: prints the version and returns, same reason",
+      "held_at": null,
+      "source": "none"
+    }
+  ],
+  "rows": 12,
+  "tuples_total": 160,
+  "tuples_covered": 160,
+  "tuples_forbidden": 0,
+  "constraint_notes": [],
+  "coverage": 1.0,
+  "array": [
+    {
+      "row": 0,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[0]",
+        "--create-output-variant-index": "true",
+        "--disable-contig-ordering-check": "true",
+        "--gather-type": "BLOCK",
+        "--ignore-safety-checks": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[0]",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=40",
+        "--create-output-variant-index=true",
+        "--disable-contig-ordering-check=true",
+        "--gather-type=BLOCK",
+        "--ignore-safety-checks=true",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/gathered.vcf",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 1,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[0]",
+        "--create-output-variant-index": "false",
+        "--disable-contig-ordering-check": "false",
+        "--gather-type": "CONVENTIONAL",
+        "--ignore-safety-checks": "false",
+        "--input": "fixture[1]",
+        "--output": "fixture[1]",
+        "--tmp-dir": "fixture[1]",
+        "--use-jdk-deflater": "false"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=40",
+        "--create-output-variant-index=false",
+        "--disable-contig-ordering-check=false",
+        "--gather-type=CONVENTIONAL",
+        "--ignore-safety-checks=false",
+        "--input=/work/fixtures/indexed.vcf",
+        "--output=/work/out/gathered.vcf.gz",
+        "--tmp-dir=/work/tmp2",
+        "--use-jdk-deflater=false"
+      ]
+    },
+    {
+      "row": 2,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[1]",
+        "--create-output-variant-index": "true",
+        "--disable-contig-ordering-check": "false",
+        "--gather-type": "AUTOMATIC",
+        "--ignore-safety-checks": "true",
+        "--input": "fixture[1]",
+        "--output": "fixture[0]",
+        "--tmp-dir": "fixture[1]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=0",
+        "--create-output-variant-index=true",
+        "--disable-contig-ordering-check=false",
+        "--gather-type=AUTOMATIC",
+        "--ignore-safety-checks=true",
+        "--input=/work/fixtures/indexed.vcf",
+        "--output=/work/out/gathered.vcf",
+        "--tmp-dir=/work/tmp2",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 3,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[1]",
+        "--create-output-variant-index": "false",
+        "--disable-contig-ordering-check": "true",
+        "--gather-type": "BLOCK",
+        "--ignore-safety-checks": "false",
+        "--input": "fixture[0]",
+        "--output": "fixture[1]",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "false"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=0",
+        "--create-output-variant-index=false",
+        "--disable-contig-ordering-check=true",
+        "--gather-type=BLOCK",
+        "--ignore-safety-checks=false",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/gathered.vcf.gz",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=false"
+      ]
+    },
+    {
+      "row": 4,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[0]",
+        "--create-output-variant-index": "false",
+        "--disable-contig-ordering-check": "true",
+        "--gather-type": "AUTOMATIC",
+        "--ignore-safety-checks": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[1]",
+        "--tmp-dir": "fixture[1]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=40",
+        "--create-output-variant-index=false",
+        "--disable-contig-ordering-check=true",
+        "--gather-type=AUTOMATIC",
+        "--ignore-safety-checks=true",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/gathered.vcf.gz",
+        "--tmp-dir=/work/tmp2",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 5,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[1]",
+        "--create-output-variant-index": "true",
+        "--disable-contig-ordering-check": "true",
+        "--gather-type": "CONVENTIONAL",
+        "--ignore-safety-checks": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[0]",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "false"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=0",
+        "--create-output-variant-index=true",
+        "--disable-contig-ordering-check=true",
+        "--gather-type=CONVENTIONAL",
+        "--ignore-safety-checks=true",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/gathered.vcf",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=false"
+      ]
+    },
+    {
+      "row": 6,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[0]",
+        "--create-output-variant-index": "false",
+        "--disable-contig-ordering-check": "false",
+        "--gather-type": "BLOCK",
+        "--ignore-safety-checks": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[0]",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=40",
+        "--create-output-variant-index=false",
+        "--disable-contig-ordering-check=false",
+        "--gather-type=BLOCK",
+        "--ignore-safety-checks=true",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/gathered.vcf",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 7,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[0]",
+        "--create-output-variant-index": "true",
+        "--disable-contig-ordering-check": "true",
+        "--gather-type": "AUTOMATIC",
+        "--ignore-safety-checks": "false",
+        "--input": "fixture[0]",
+        "--output": "fixture[0]",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=40",
+        "--create-output-variant-index=true",
+        "--disable-contig-ordering-check=true",
+        "--gather-type=AUTOMATIC",
+        "--ignore-safety-checks=false",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/gathered.vcf",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 8,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[0]",
+        "--create-output-variant-index": "true",
+        "--disable-contig-ordering-check": "true",
+        "--gather-type": "BLOCK",
+        "--ignore-safety-checks": "true",
+        "--input": "fixture[1]",
+        "--output": "fixture[0]",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=40",
+        "--create-output-variant-index=true",
+        "--disable-contig-ordering-check=true",
+        "--gather-type=BLOCK",
+        "--ignore-safety-checks=true",
+        "--input=/work/fixtures/indexed.vcf",
+        "--output=/work/out/gathered.vcf",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 9,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[0]",
+        "--create-output-variant-index": "true",
+        "--disable-contig-ordering-check": "true",
+        "--gather-type": "CONVENTIONAL",
+        "--ignore-safety-checks": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[1]",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=40",
+        "--create-output-variant-index=true",
+        "--disable-contig-ordering-check=true",
+        "--gather-type=CONVENTIONAL",
+        "--ignore-safety-checks=true",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/gathered.vcf.gz",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 10,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[0]",
+        "--create-output-variant-index": "true",
+        "--disable-contig-ordering-check": "true",
+        "--gather-type": "BLOCK",
+        "--ignore-safety-checks": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[0]",
+        "--tmp-dir": "fixture[1]",
+        "--use-jdk-deflater": "true"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=40",
+        "--create-output-variant-index=true",
+        "--disable-contig-ordering-check=true",
+        "--gather-type=BLOCK",
+        "--ignore-safety-checks=true",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/gathered.vcf",
+        "--tmp-dir=/work/tmp2",
+        "--use-jdk-deflater=true"
+      ]
+    },
+    {
+      "row": 11,
+      "labels": {
+        "--cloud-prefetch-buffer": "fixture[0]",
+        "--create-output-variant-index": "true",
+        "--disable-contig-ordering-check": "true",
+        "--gather-type": "AUTOMATIC",
+        "--ignore-safety-checks": "true",
+        "--input": "fixture[0]",
+        "--output": "fixture[0]",
+        "--tmp-dir": "fixture[0]",
+        "--use-jdk-deflater": "false"
+      },
+      "arguments": [
+        "--cloud-prefetch-buffer=40",
+        "--create-output-variant-index=true",
+        "--disable-contig-ordering-check=true",
+        "--gather-type=AUTOMATIC",
+        "--ignore-safety-checks=true",
+        "--input=/work/fixtures/reads.vcf",
+        "--output=/work/out/gathered.vcf",
+        "--tmp-dir=/work/tmp",
+        "--use-jdk-deflater=false"
+      ]
+    }
+  ]
+}

--- a/tools/coverage/arrays/GatherVcfsCloud.t2.json
+++ b/tools/coverage/arrays/GatherVcfsCloud.t2.json
@@ -4,8 +4,8 @@
   "t": 2,
   "numeric_policy": "strict",
   "arguments_total": 20,
-  "arguments_in_array": 9,
-  "arguments_excluded": 11,
+  "arguments_in_array": 8,
+  "arguments_excluded": 12,
   "excluded": [
     {
       "argument": "--arguments_file",
@@ -13,6 +13,13 @@
       "reason": "excluded by the repository: expands into the command line itself, which is measured by the barclay-arguments-file suite instead",
       "held_at": null,
       "source": "none"
+    },
+    {
+      "argument": "--create-output-variant-index",
+      "type": "boolean",
+      "reason": "only one value available (fixture[0])",
+      "held_at": "false",
+      "source": "fixture"
     },
     {
       "argument": "--gatk-config-file",
@@ -85,9 +92,9 @@
       "source": "none"
     }
   ],
-  "rows": 12,
-  "tuples_total": 160,
-  "tuples_covered": 160,
+  "rows": 10,
+  "tuples_total": 126,
+  "tuples_covered": 126,
   "tuples_forbidden": 0,
   "constraint_notes": [],
   "coverage": 1.0,
@@ -96,7 +103,6 @@
       "row": 0,
       "labels": {
         "--cloud-prefetch-buffer": "fixture[0]",
-        "--create-output-variant-index": "true",
         "--disable-contig-ordering-check": "true",
         "--gather-type": "BLOCK",
         "--ignore-safety-checks": "true",
@@ -107,7 +113,6 @@
       },
       "arguments": [
         "--cloud-prefetch-buffer=40",
-        "--create-output-variant-index=true",
         "--disable-contig-ordering-check=true",
         "--gather-type=BLOCK",
         "--ignore-safety-checks=true",
@@ -121,7 +126,6 @@
       "row": 1,
       "labels": {
         "--cloud-prefetch-buffer": "fixture[0]",
-        "--create-output-variant-index": "false",
         "--disable-contig-ordering-check": "false",
         "--gather-type": "CONVENTIONAL",
         "--ignore-safety-checks": "false",
@@ -132,7 +136,6 @@
       },
       "arguments": [
         "--cloud-prefetch-buffer=40",
-        "--create-output-variant-index=false",
         "--disable-contig-ordering-check=false",
         "--gather-type=CONVENTIONAL",
         "--ignore-safety-checks=false",
@@ -146,9 +149,8 @@
       "row": 2,
       "labels": {
         "--cloud-prefetch-buffer": "fixture[1]",
-        "--create-output-variant-index": "true",
-        "--disable-contig-ordering-check": "false",
-        "--gather-type": "AUTOMATIC",
+        "--disable-contig-ordering-check": "true",
+        "--gather-type": "CONVENTIONAL",
         "--ignore-safety-checks": "true",
         "--input": "fixture[1]",
         "--output": "fixture[0]",
@@ -157,9 +159,8 @@
       },
       "arguments": [
         "--cloud-prefetch-buffer=0",
-        "--create-output-variant-index=true",
-        "--disable-contig-ordering-check=false",
-        "--gather-type=AUTOMATIC",
+        "--disable-contig-ordering-check=true",
+        "--gather-type=CONVENTIONAL",
         "--ignore-safety-checks=true",
         "--input=/work/fixtures/indexed.vcf",
         "--output=/work/out/gathered.vcf",
@@ -171,8 +172,7 @@
       "row": 3,
       "labels": {
         "--cloud-prefetch-buffer": "fixture[1]",
-        "--create-output-variant-index": "false",
-        "--disable-contig-ordering-check": "true",
+        "--disable-contig-ordering-check": "false",
         "--gather-type": "BLOCK",
         "--ignore-safety-checks": "false",
         "--input": "fixture[0]",
@@ -182,8 +182,7 @@
       },
       "arguments": [
         "--cloud-prefetch-buffer=0",
-        "--create-output-variant-index=false",
-        "--disable-contig-ordering-check=true",
+        "--disable-contig-ordering-check=false",
         "--gather-type=BLOCK",
         "--ignore-safety-checks=false",
         "--input=/work/fixtures/reads.vcf",
@@ -196,74 +195,68 @@
       "row": 4,
       "labels": {
         "--cloud-prefetch-buffer": "fixture[0]",
-        "--create-output-variant-index": "false",
         "--disable-contig-ordering-check": "true",
         "--gather-type": "AUTOMATIC",
-        "--ignore-safety-checks": "true",
+        "--ignore-safety-checks": "false",
         "--input": "fixture[0]",
-        "--output": "fixture[1]",
+        "--output": "fixture[0]",
         "--tmp-dir": "fixture[1]",
-        "--use-jdk-deflater": "true"
+        "--use-jdk-deflater": "false"
       },
       "arguments": [
         "--cloud-prefetch-buffer=40",
-        "--create-output-variant-index=false",
         "--disable-contig-ordering-check=true",
         "--gather-type=AUTOMATIC",
-        "--ignore-safety-checks=true",
+        "--ignore-safety-checks=false",
         "--input=/work/fixtures/reads.vcf",
-        "--output=/work/out/gathered.vcf.gz",
+        "--output=/work/out/gathered.vcf",
         "--tmp-dir=/work/tmp2",
-        "--use-jdk-deflater=true"
+        "--use-jdk-deflater=false"
       ]
     },
     {
       "row": 5,
       "labels": {
         "--cloud-prefetch-buffer": "fixture[1]",
-        "--create-output-variant-index": "true",
-        "--disable-contig-ordering-check": "true",
-        "--gather-type": "CONVENTIONAL",
+        "--disable-contig-ordering-check": "false",
+        "--gather-type": "AUTOMATIC",
         "--ignore-safety-checks": "true",
-        "--input": "fixture[0]",
-        "--output": "fixture[0]",
+        "--input": "fixture[1]",
+        "--output": "fixture[1]",
         "--tmp-dir": "fixture[0]",
-        "--use-jdk-deflater": "false"
+        "--use-jdk-deflater": "true"
       },
       "arguments": [
         "--cloud-prefetch-buffer=0",
-        "--create-output-variant-index=true",
-        "--disable-contig-ordering-check=true",
-        "--gather-type=CONVENTIONAL",
+        "--disable-contig-ordering-check=false",
+        "--gather-type=AUTOMATIC",
         "--ignore-safety-checks=true",
-        "--input=/work/fixtures/reads.vcf",
-        "--output=/work/out/gathered.vcf",
+        "--input=/work/fixtures/indexed.vcf",
+        "--output=/work/out/gathered.vcf.gz",
         "--tmp-dir=/work/tmp",
-        "--use-jdk-deflater=false"
+        "--use-jdk-deflater=true"
       ]
     },
     {
       "row": 6,
       "labels": {
         "--cloud-prefetch-buffer": "fixture[0]",
-        "--create-output-variant-index": "false",
         "--disable-contig-ordering-check": "false",
         "--gather-type": "BLOCK",
-        "--ignore-safety-checks": "true",
-        "--input": "fixture[0]",
+        "--ignore-safety-checks": "false",
+        "--input": "fixture[1]",
         "--output": "fixture[0]",
-        "--tmp-dir": "fixture[0]",
+        "--tmp-dir": "fixture[1]",
         "--use-jdk-deflater": "true"
       },
       "arguments": [
         "--cloud-prefetch-buffer=40",
-        "--create-output-variant-index=false",
         "--disable-contig-ordering-check=false",
         "--gather-type=BLOCK",
-        "--ignore-safety-checks=true",
-        "--input=/work/fixtures/reads.vcf",
+        "--ignore-safety-checks=false",
+        "--input=/work/fixtures/indexed.vcf",
         "--output=/work/out/gathered.vcf",
-        "--tmp-dir=/work/tmp",
+        "--tmp-dir=/work/tmp2",
         "--use-jdk-deflater=true"
       ]
     },
@@ -271,10 +264,9 @@
       "row": 7,
       "labels": {
         "--cloud-prefetch-buffer": "fixture[0]",
-        "--create-output-variant-index": "true",
         "--disable-contig-ordering-check": "true",
-        "--gather-type": "AUTOMATIC",
-        "--ignore-safety-checks": "false",
+        "--gather-type": "CONVENTIONAL",
+        "--ignore-safety-checks": "true",
         "--input": "fixture[0]",
         "--output": "fixture[0]",
         "--tmp-dir": "fixture[0]",
@@ -282,10 +274,9 @@
       },
       "arguments": [
         "--cloud-prefetch-buffer=40",
-        "--create-output-variant-index=true",
         "--disable-contig-ordering-check=true",
-        "--gather-type=AUTOMATIC",
-        "--ignore-safety-checks=false",
+        "--gather-type=CONVENTIONAL",
+        "--ignore-safety-checks=true",
         "--input=/work/fixtures/reads.vcf",
         "--output=/work/out/gathered.vcf",
         "--tmp-dir=/work/tmp",
@@ -296,34 +287,8 @@
       "row": 8,
       "labels": {
         "--cloud-prefetch-buffer": "fixture[0]",
-        "--create-output-variant-index": "true",
         "--disable-contig-ordering-check": "true",
         "--gather-type": "BLOCK",
-        "--ignore-safety-checks": "true",
-        "--input": "fixture[1]",
-        "--output": "fixture[0]",
-        "--tmp-dir": "fixture[0]",
-        "--use-jdk-deflater": "true"
-      },
-      "arguments": [
-        "--cloud-prefetch-buffer=40",
-        "--create-output-variant-index=true",
-        "--disable-contig-ordering-check=true",
-        "--gather-type=BLOCK",
-        "--ignore-safety-checks=true",
-        "--input=/work/fixtures/indexed.vcf",
-        "--output=/work/out/gathered.vcf",
-        "--tmp-dir=/work/tmp",
-        "--use-jdk-deflater=true"
-      ]
-    },
-    {
-      "row": 9,
-      "labels": {
-        "--cloud-prefetch-buffer": "fixture[0]",
-        "--create-output-variant-index": "true",
-        "--disable-contig-ordering-check": "true",
-        "--gather-type": "CONVENTIONAL",
         "--ignore-safety-checks": "true",
         "--input": "fixture[0]",
         "--output": "fixture[1]",
@@ -332,9 +297,8 @@
       },
       "arguments": [
         "--cloud-prefetch-buffer=40",
-        "--create-output-variant-index=true",
         "--disable-contig-ordering-check=true",
-        "--gather-type=CONVENTIONAL",
+        "--gather-type=BLOCK",
         "--ignore-safety-checks=true",
         "--input=/work/fixtures/reads.vcf",
         "--output=/work/out/gathered.vcf.gz",
@@ -343,37 +307,11 @@
       ]
     },
     {
-      "row": 10,
+      "row": 9,
       "labels": {
         "--cloud-prefetch-buffer": "fixture[0]",
-        "--create-output-variant-index": "true",
         "--disable-contig-ordering-check": "true",
         "--gather-type": "BLOCK",
-        "--ignore-safety-checks": "true",
-        "--input": "fixture[0]",
-        "--output": "fixture[0]",
-        "--tmp-dir": "fixture[1]",
-        "--use-jdk-deflater": "true"
-      },
-      "arguments": [
-        "--cloud-prefetch-buffer=40",
-        "--create-output-variant-index=true",
-        "--disable-contig-ordering-check=true",
-        "--gather-type=BLOCK",
-        "--ignore-safety-checks=true",
-        "--input=/work/fixtures/reads.vcf",
-        "--output=/work/out/gathered.vcf",
-        "--tmp-dir=/work/tmp2",
-        "--use-jdk-deflater=true"
-      ]
-    },
-    {
-      "row": 11,
-      "labels": {
-        "--cloud-prefetch-buffer": "fixture[0]",
-        "--create-output-variant-index": "true",
-        "--disable-contig-ordering-check": "true",
-        "--gather-type": "AUTOMATIC",
         "--ignore-safety-checks": "true",
         "--input": "fixture[0]",
         "--output": "fixture[0]",
@@ -382,9 +320,8 @@
       },
       "arguments": [
         "--cloud-prefetch-buffer=40",
-        "--create-output-variant-index=true",
         "--disable-contig-ordering-check=true",
-        "--gather-type=AUTOMATIC",
+        "--gather-type=BLOCK",
         "--ignore-safety-checks=true",
         "--input=/work/fixtures/reads.vcf",
         "--output=/work/out/gathered.vcf",

--- a/tools/coverage/fixtures.json
+++ b/tools/coverage/fixtures.json
@@ -163,6 +163,16 @@
     ]
   },
   "per_tool": {
+    "GatherVcfsCloud": {
+      "--input": [
+        "/work/fixtures/reads.vcf",
+        "/work/fixtures/indexed.vcf"
+      ],
+      "--output": [
+        "/work/out/gathered.vcf",
+        "/work/out/gathered.vcf.gz"
+      ]
+    },
     "PrintReads": {
       "--input": [
         "/work/fixtures/reads.bam",

--- a/tools/coverage/fixtures.json
+++ b/tools/coverage/fixtures.json
@@ -40,6 +40,13 @@
     "takes part in the validation and outranks the reads' in the best-available chain, so the",
     "second value is a refusal and the first is not.",
     "",
+    "`GatherVcfsCloud` holds `--create-output-variant-index` at FALSE, and the reason is the",
+    "measurement rather than the port. A Tribble index records the last-modified time of the file",
+    "it indexes, and here that file is the tool's own OUTPUT: the two sides write their own copy at",
+    "their own moment, so the two indexes differ in eight bytes of clock and the row measures when",
+    "the run happened. The port builds the index byte for byte otherwise -- checked against the",
+    "reference's own on one input -- and every other tool indexes a file both sides were GIVEN.",
+    "",
     "`--read-index` takes two paths that both exist, because what the argument decides is not",
     "whether the file is there: an index handed to an input that is neither a BAM nor a CRAM is",
     "refused by htsjdk's text-SAM branch whatever it contains, and the count is checked against the",
@@ -164,6 +171,9 @@
   },
   "per_tool": {
     "GatherVcfsCloud": {
+      "--create-output-variant-index": [
+        "false"
+      ],
       "--input": [
         "/work/fixtures/reads.vcf",
         "/work/fixtures/indexed.vcf"


### PR DESCRIPTION
The port decides which record goes where; the runner had to supply the rest — the shards, the header, the writer and the index.

**Nothing the gather decides needs an allele parsed.** It compares dictionaries, sample lists and record *positions*, then copies lines, so a shard is read as text.

**The output is the first shard's header, whole**, and then every record the gather selected. Its bytes depend on the name: a `.gz` output is block compressed at the run's own level and deflater, a plain one is text. It matched the reference byte for byte on the first run.

**Block gathering is refused in the port's own words.** It copies the inputs' compressed *blocks* rather than their records, and `AUTOMATIC` resolves to it when every input and the output are block compressed, so the refusal covers the argument and the resolution both.

## The index a writer builds is not the index a reader builds

That took three readings. `IndexingVariantContextWriter` hands the creator the position **before** each record, absolute in the output stream so the header is counted. `setIndexSequenceDictionary` runs on the **creator** at close, before the statistics are appended, so the dictionary arrives as `DICT:` properties and the flag that used to carry it is zero. And `close()` writes the index with `writeBasedOnFeaturePath`, which **stats** the file it has just finished — so the size and timestamp are the written file's, and only the md5 stays empty.

Run against the reference's own output on one input, the two indexes are **identical**: 230 bytes, every one the same.

## And the row still could not agree

A Tribble index records the last-modified time of the file it indexes, and here that file is the tool's own **output**: the two sides write their own copy at their own moment, so the indexes differ in eight bytes of clock and the row says when the run happened. Every other tool measured here indexes a file both sides were *given*.

So `--create-output-variant-index` is held at false with the reason written down, which is what `fixtures.json` is for. The index code stays and is exercised by the local check; what is not claimed is a row that cannot agree.

The array is **10 of 10** rows over 8 of the tool's 20 arguments.

Part of #69, #818 and #822.

`python3 tools/preflight.py`: every gate green on the pinned 1.97.1 toolchain.