### PR TITLE
Record the seventh tool's array

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -189,7 +189,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GatherNormalArtifactData` | unclassified | oracle-backed | mutect-gathers | 1 | not measured |
 | `GatherPileupSummaries` | unclassified | oracle-backed | mutect-gathers | 1 | not measured |
 | `GatherTranches` | unclassified | oracle-backed | gather-tranches | 1 | not measured |
-| `GatherVcfsCloud` | variant-transform | oracle-backed | gather-vcfs, tool-argument-declarations, tool-argument-enums, usage-text | 4 | not measured |
+| `GatherVcfsCloud` | variant-transform | oracle-backed | gather-vcfs, tool-argument-declarations, tool-argument-enums, usage-text | 4 | t=2, 10/10 rows (100%) |
 | `GeneExpressionEvaluation` | locus-walker | oracle-backed | gene-expression-evaluation | 1 | not measured |
 | `GenotypeGVCFs` | assembly-caller | oracle-backed | genotype-gvcfs | 1 | not measured |
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -63,6 +63,15 @@
       "matched": 19,
       "t": 2,
       "share": 1.0
+    },
+    "GatherVcfsCloud": {
+      "rows": 10,
+      "accepted": 5,
+      "rejected": 5,
+      "distinct_outputs": 3,
+      "matched": 10,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
`GatherVcfsCloud` reads **10 of 10** rows over 8 of its 20 arguments, and the seven tools with a command line all read 100% of theirs — **105 rows** in total.

| tool | rows | arguments covered |
|---|---:|---|
| `CountReads` | 23/23 | 32 of 42 |
| `CountVariants` | 31/31 | 34 of 44 |
| `PrintReads` | 19/19 | 32 of 42 |
| `GatherVcfsCloud` | **10/10** | **8** of 20 |
| `CreateHadoopBamSplittingIndex` | 9/9 | 6 of 17 |
| `IndexFeatureFile` | 8/8 | 4 of 14 |
| `PrintBGZFBlockInformation` | 6/6 | 4 of 14 |

Part of #69, #818 and #822.