### PR TITLE
Record the eighth tool's array

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -128,7 +128,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `AnnotateIntervals` | cnv-segmentation | oracle-backed | annotate-intervals | 1 | not measured |
 | `AnnotateVcfWithBamDepth` | variant-walker | oracle-backed | annotate-vcf-with-bam-depth | 1 | not measured |
 | `AnnotateVcfWithExpectedAlleleFraction` | variant-walker | oracle-backed | annotate-vcf-with-expected-allele-fraction | 1 | not measured |
-| `ApplyBQSR` | record-transform | oracle-backed | apply-bqsr, tool-argument-declarations, tool-argument-enums | 3 | not measured |
+| `ApplyBQSR` | record-transform | oracle-backed | apply-bqsr, tool-argument-declarations, tool-argument-enums | 3 | t=2, 21/21 rows (100%) |
 | `ApplyVQSR` | variant-transform | oracle-backed | apply-vqsr-allele-specific, apply-vqsr-site-filtering, apply-vqsr-tranches, apply-vqsr-two-modes | 4 | not measured |
 | `BaseRecalibrator` | record-transform | oracle-backed | base-recalibrator | 1 | not measured |
 | `BwaMemIndexImageCreator` | reference-utility | oracle-backed | bwa-index-image | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -72,6 +72,15 @@
       "matched": 10,
       "t": 2,
       "share": 1.0
+    },
+    "ApplyBQSR": {
+      "rows": 21,
+      "accepted": 9,
+      "rejected": 12,
+      "distinct_outputs": 9,
+      "matched": 21,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
`ApplyBQSR` reads **21 of 21** rows over 36 of its 51 arguments, and the eight tools with a command line all read 100% of theirs — **127 rows** in total.

| tool | rows | arguments covered |
|---|---:|---|
| `ApplyBQSR` | **21/21** | **36** of 51 |
| `CountVariants` | 31/31 | 34 of 44 |
| `CountReads` | 23/23 | 32 of 42 |
| `PrintReads` | 19/19 | 32 of 42 |
| `GatherVcfsCloud` | 10/10 | 8 of 20 |
| `CreateHadoopBamSplittingIndex` | 9/9 | 6 of 17 |
| `IndexFeatureFile` | 8/8 | 4 of 14 |
| `PrintBGZFBlockInformation` | 6/6 | 4 of 14 |

Part of #69, #818 and #822.