### PR TITLE
Record the mutex target list in the order it holds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,245 +189,245 @@ jobs:
       matrix:
         include:
           - group: oracle-backed
-            index: "1/60"
+            index: "1/59"
             slug: "annotation-original-alignment-annotation-per-allele-variant-getters-annotation-likelihood-counts-genotyper-allele-likelihoods"
             suites: "annotation-original-alignment annotation-per-allele variant-getters annotation-likelihood-counts genotyper-allele-likelihoods"
           - group: oracle-backed
-            index: "2/60"
+            index: "2/59"
             slug: "genotyper-allele-list-annotation-counting-readfilters-readsdatasource-referencecontext"
             suites: "genotyper-allele-list annotation-counting readfilters readsdatasource referencecontext"
           - group: oracle-backed
-            index: "3/60"
+            index: "3/59"
             slug: "reference-walker-count-reads-and-bases-fasta-reference-maker-shift-fasta-fasta-alternate-reference-maker"
             suites: "reference-walker count-reads-and-bases fasta-reference-maker shift-fasta fasta-alternate-reference-maker"
           - group: oracle-backed
-            index: "4/60"
+            index: "4/59"
             slug: "get-pileup-summaries-pileup-tool-ase-read-counter-collect-allelic-counts-normal-artifact-data"
             suites: "get-pileup-summaries pileup-tool ase-read-counter collect-allelic-counts normal-artifact-data"
           - group: oracle-backed
-            index: "5/60"
+            index: "5/59"
             slug: "call-copy-ratio-segments-annotate-intervals-collect-read-counts-denoise-read-counts-filter-intervals"
             suites: "call-copy-ratio-segments annotate-intervals collect-read-counts denoise-read-counts filter-intervals"
           - group: oracle-backed
-            index: "6/60"
+            index: "6/59"
             slug: "readwalker-printreads-record-transform-fix-misencoded-add-oa-tags"
             suites: "readwalker printreads record-transform fix-misencoded add-oa-tags"
           - group: oracle-backed
-            index: "7/60"
+            index: "7/59"
             slug: "print-distant-mates-split-reads-left-align-indels-left-align-indels-tool-clip-reads"
             suites: "print-distant-mates split-reads left-align-indels left-align-indels-tool clip-reads"
           - group: oracle-backed
-            index: "8/60"
+            index: "8/59"
             slug: "transfer-read-tags-print-reads-header-post-process-reads-for-rsem-convert-headerless-shard-gatk-report"
             suites: "transfer-read-tags print-reads-header post-process-reads-for-rsem convert-headerless-shard gatk-report"
           - group: oracle-backed
-            index: "9/60"
+            index: "9/59"
             slug: "recal-datum-covariates-qual-quantizer-recalibration-tables-gatk-report-reader"
             suites: "recal-datum covariates qual-quantizer recalibration-tables gatk-report-reader"
           - group: oracle-backed
-            index: "10/60"
+            index: "10/59"
             slug: "bqsr-transformer-recalibration-report-apply-bqsr-baq-base-recalibration-engine"
             suites: "bqsr-transformer recalibration-report apply-bqsr baq base-recalibration-engine"
           - group: oracle-backed
-            index: "11/60"
+            index: "11/59"
             slug: "base-recalibrator-read-anonymizer-intervalwalker-alignmentstate-pileupelement"
             suites: "base-recalibrator read-anonymizer intervalwalker alignmentstate pileupelement"
           - group: oracle-backed
-            index: "12/60"
+            index: "12/59"
             slug: "intervalfile-jexlfilter-featurecache-readpileup-readstates"
             suites: "intervalfile jexlfilter featurecache readpileup readstates"
           - group: oracle-backed
-            index: "13/60"
+            index: "13/59"
             slug: "locusiterator-acbuilder-locuswalker-javarandom-reservoir"
             suites: "locusiterator acbuilder locuswalker javarandom reservoir"
           - group: oracle-backed
-            index: "14/60"
+            index: "14/59"
             slug: "well19937c-leveling-variantwalker-activityprofile-assemblyregion"
             suites: "well19937c leveling variantwalker activityprofile assemblyregion"
           - group: oracle-backed
-            index: "15/60"
+            index: "15/59"
             slug: "intervaliterators-assemblyregioniterator-assemblyregionwalker-mann-whitney-annotation-rank-sum"
             suites: "intervaliterators assemblyregioniterator assemblyregionwalker mann-whitney annotation-rank-sum"
           - group: oracle-backed
-            index: "16/60"
+            index: "16/59"
             slug: "annotation-strand-bias-annotation-read-grouping-annotation-depth-per-allele-annotation-flow-annotation-site-statistics"
             suites: "annotation-strand-bias annotation-read-grouping annotation-depth-per-allele annotation-flow annotation-site-statistics"
           - group: oracle-backed
-            index: "17/60"
+            index: "17/59"
             slug: "annotation-heterozygosity-and-mq-annotation-allele-specific-rank-sum-annotation-allele-specific-strand-bias-annotation-allele-specific-site-statistics-annotation-pedigree"
             suites: "annotation-heterozygosity-and-mq annotation-allele-specific-rank-sum annotation-allele-specific-strand-bias annotation-allele-specific-site-statistics annotation-pedigree"
           - group: oracle-backed
-            index: "18/60"
+            index: "18/59"
             slug: "annotation-fragment-counts-annotation-haplotype-filtering-multipasswalker-barclay-value-model-barclay-tagged-arguments"
             suites: "annotation-fragment-counts annotation-haplotype-filtering multipasswalker barclay-value-model barclay-tagged-arguments"
           - group: oracle-backed
-            index: "19/60"
+            index: "19/59"
             slug: "barclay-argument-collections-barclay-arguments-file-barclay-plugin-descriptors-natural-log-utils-somatic-likelihoods"
             suites: "barclay-argument-collections barclay-arguments-file barclay-plugin-descriptors natural-log-utils somatic-likelihoods"
           - group: oracle-backed
-            index: "20/60"
+            index: "20/59"
             slug: "decimal-format-string-format-double-to-string-allele-pseudo-depth-counting-walkers"
             suites: "decimal-format string-format double-to-string allele-pseudo-depth counting-walkers"
           - group: oracle-backed
-            index: "21/60"
+            index: "21/59"
             slug: "sa-tag-builder-overhang-fixing-manager-split-n-cigar-reads-methylation-type-caller-get-sample-name"
             suites: "sa-tag-builder overhang-fixing-manager split-n-cigar-reads methylation-type-caller get-sample-name"
           - group: oracle-backed
-            index: "22/60"
+            index: "22/59"
             slug: "compare-base-qualities-sam-pileup-codec-check-pileup-dump-tabix-index-tsv-table"
             suites: "compare-base-qualities sam-pileup-codec check-pileup dump-tabix-index tsv-table"
           - group: oracle-backed
-            index: "23/60"
+            index: "23/59"
             slug: "pileup-summary-contamination-tables-persistence-optimizer-analyze-covariates-remove-nearby-indels"
             suites: "pileup-summary contamination-tables persistence-optimizer analyze-covariates remove-nearby-indels"
           - group: oracle-backed
-            index: "24/60"
+            index: "24/59"
             slug: "update-vcf-sequence-dictionary-left-align-and-trim-trim-alleles-split-biallelics-left-align-and-trim-variants"
             suites: "update-vcf-sequence-dictionary left-align-and-trim trim-alleles split-biallelics left-align-and-trim-variants"
           - group: oracle-backed
-            index: "25/60"
+            index: "25/59"
             slug: "genotype-index-subset-alleles-split-with-likelihoods-variant-filtration-gather-vcfs"
             suites: "genotype-index subset-alleles split-with-likelihoods variant-filtration gather-vcfs"
           - group: oracle-backed
-            index: "26/60"
+            index: "26/59"
             slug: "select-variants-samples-java-regex-select-variants-subset-select-variants-filters-select-variants-output"
             suites: "select-variants-samples java-regex select-variants-subset select-variants-filters select-variants-output"
           - group: oracle-backed
-            index: "27/60"
+            index: "27/59"
             slug: "select-variants-concordance-variants-to-table-validate-variants-count-variants-count-false-positives"
             suites: "select-variants-concordance variants-to-table validate-variants count-variants count-false-positives"
           - group: oracle-backed
-            index: "28/60"
+            index: "28/59"
             slug: "calculate-mixing-fractions-annotate-vcf-with-bam-depth-annotate-vcf-with-expected-allele-fraction-concordance-walker-evaluate-info-field-concordance"
             suites: "calculate-mixing-fractions annotate-vcf-with-bam-depth annotate-vcf-with-expected-allele-fraction concordance-walker evaluate-info-field-concordance"
           - group: oracle-backed
-            index: "29/60"
+            index: "29/59"
             slug: "concordance-summary-concordance-filter-analysis-concordance-annotated-vcfs-apply-vqsr-tranches-apply-vqsr-site-filtering"
             suites: "concordance-summary concordance-filter-analysis concordance-annotated-vcfs apply-vqsr-tranches apply-vqsr-site-filtering"
           - group: oracle-backed
-            index: "30/60"
+            index: "30/59"
             slug: "apply-vqsr-allele-specific-apply-vqsr-two-modes-filter-variant-tranches-threshold-calculator-filter-stats"
             suites: "apply-vqsr-allele-specific apply-vqsr-two-modes filter-variant-tranches threshold-calculator filter-stats"
           - group: oracle-backed
-            index: "31/60"
+            index: "31/59"
             slug: "mutect-hard-filters-mutect-engine-arithmetic-germline-probability-mutect-engine-construction-mutect-error-probabilities"
             suites: "mutect-hard-filters mutect-engine-arithmetic germline-probability mutect-engine-construction mutect-error-probabilities"
           - group: oracle-backed
-            index: "32/60"
+            index: "32/59"
             slug: "beta-binomial-somatic-validation-power-allele-fraction-cluster-somatic-clustering-model-somatic-clustering-learn"
             suites: "beta-binomial somatic-validation-power allele-fraction-cluster somatic-clustering-model somatic-clustering-learn"
           - group: oracle-backed
-            index: "33/60"
+            index: "33/59"
             slug: "mutect-filter-list-filter-mutect-calls-allele-filter-base-normal-artifact-filter-remaining-hard-filters"
             suites: "mutect-filter-list filter-mutect-calls allele-filter-base normal-artifact-filter remaining-hard-filters"
           - group: oracle-backed
-            index: "34/60"
+            index: "34/59"
             slug: "slippage-filter-contamination-filter-haplotype-filter-strand-artifact-estep-strand-artifact-mstep"
             suites: "slippage-filter contamination-filter haplotype-filter strand-artifact-estep strand-artifact-mstep"
           - group: oracle-backed
-            index: "35/60"
+            index: "35/59"
             slug: "filter-list-by-mode-apply-filters-accumulate-data-engine-assembly-germline-wrapper"
             suites: "filter-list-by-mode apply-filters accumulate-data engine-assembly germline-wrapper"
           - group: oracle-backed
-            index: "36/60"
+            index: "36/59"
             slug: "pair-hmm-kernel-segmentation-contamination-model-allele-pileup-counter-validate-basic-somatic-short-mutations"
             suites: "pair-hmm kernel-segmentation contamination-model allele-pileup-counter validate-basic-somatic-short-mutations"
           - group: oracle-backed
-            index: "37/60"
+            index: "37/59"
             slug: "preprocess-intervals-interval-list-scatter-split-intervals-compare-interval-lists-callable-loci"
             suites: "preprocess-intervals interval-list-scatter split-intervals compare-interval-lists callable-loci"
           - group: oracle-backed
-            index: "38/60"
+            index: "38/59"
             slug: "merge-annotated-regions-tag-germline-events-merge-annotated-regions-by-annotation-combine-segment-breakpoints-mutect-gathers"
             suites: "merge-annotated-regions tag-germline-events merge-annotated-regions-by-annotation combine-segment-breakpoints mutect-gathers"
           - group: oracle-backed
-            index: "39/60"
+            index: "39/59"
             slug: "gather-bqsr-reports-gather-tranches-check-terminator-block-rename-sample-in-vcf-make-sites-only-vcf"
             suites: "gather-bqsr-reports gather-tranches check-terminator-block rename-sample-in-vcf make-sites-only-vcf"
           - group: oracle-backed
-            index: "40/60"
+            index: "40/59"
             slug: "split-vcfs-sort-vcf-merge-vcfs-fix-vcf-header-filter-vcf"
             suites: "split-vcfs sort-vcf merge-vcfs fix-vcf-header filter-vcf"
           - group: oracle-backed
-            index: "41/60"
+            index: "41/59"
             slug: "picard-update-vcf-dictionary-vcf-to-interval-list-picard-gather-vcfs-vcf-format-converter-build-bam-index"
             suites: "picard-update-vcf-dictionary vcf-to-interval-list picard-gather-vcfs vcf-format-converter build-bam-index"
           - group: oracle-backed
-            index: "42/60"
+            index: "42/59"
             slug: "print-bgzf-block-information-index-feature-file-set-nm-md-uq-tags-gather-bam-files-add-comments-to-bam"
             suites: "print-bgzf-block-information index-feature-file set-nm-md-uq-tags gather-bam-files add-comments-to-bam"
           - group: oracle-backed
-            index: "43/60"
+            index: "43/59"
             slug: "reference-block-concordance-calculate-average-combined-annotations-print-file-diagnostics-compare-references-check-reference-compatibility"
             suites: "reference-block-concordance calculate-average-combined-annotations print-file-diagnostics compare-references check-reference-compatibility"
           - group: oracle-backed
-            index: "44/60"
+            index: "44/59"
             slug: "condense-depth-evidence-site-depth-to-baf-multi-feature-walker-numt-filter-mt-low-heteroplasmy"
             suites: "condense-depth-evidence site-depth-to-baf multi-feature-walker numt-filter mt-low-heteroplasmy"
           - group: oracle-backed
-            index: "45/60"
+            index: "45/59"
             slug: "merge-mutect2-mc3-downsample-by-duplicate-set-print-sv-evidence-print-read-counts-split-cram"
             suites: "merge-mutect2-mc3 downsample-by-duplicate-set print-sv-evidence print-read-counts split-cram"
           - group: oracle-backed
-            index: "46/60"
+            index: "46/59"
             slug: "collect-f1r2-counts-filter-funcotations-pathseq-build-reference-taxonomy-pathseq-build-kmers-gtf-to-bed"
             suites: "collect-f1r2-counts filter-funcotations pathseq-build-reference-taxonomy pathseq-build-kmers gtf-to-bed"
           - group: oracle-backed
-            index: "47/60"
+            index: "47/59"
             slug: "compose-str-table-file-cram-issue-8768-detector-add-flow-base-quality-gene-expression-evaluation-funcotator-data-source-downloader"
             suites: "compose-str-table-file cram-issue-8768-detector add-flow-base-quality gene-expression-evaluation funcotator-data-source-downloader"
           - group: oracle-backed
-            index: "48/60"
+            index: "48/59"
             slug: "sv-stratify-add-flow-snv-quality-calculate-genotype-posteriors-family-priors-sv-cluster"
             suites: "sv-stratify add-flow-snv-quality calculate-genotype-posteriors family-priors sv-cluster"
           - group: oracle-backed
-            index: "49/60"
+            index: "49/59"
             slug: "grouped-sv-cluster-sv-concordance-sv-annotate-joint-germline-cnv-segmentation-collect-sv-evidence"
             suites: "grouped-sv-cluster sv-concordance sv-annotate joint-germline-cnv-segmentation collect-sv-evidence"
           - group: oracle-backed
-            index: "50/60"
+            index: "50/59"
             slug: "filter-alignment-artifacts-learn-read-orientation-model-brent-optimizer-create-somatic-panel-of-normals-ramped-haplotype-caller"
             suites: "filter-alignment-artifacts learn-read-orientation-model brent-optimizer create-somatic-panel-of-normals ramped-haplotype-caller"
           - group: oracle-backed
-            index: "51/60"
+            index: "51/59"
             slug: "series-stats-depth-of-coverage-vcf-comparator-variant-annotator-reblock-gvcf"
             suites: "series-stats depth-of-coverage vcf-comparator variant-annotator reblock-gvcf"
           - group: oracle-backed
-            index: "52/60"
+            index: "52/59"
             slug: "combine-gvcfs-variant-eval-genotype-gvcfs-structural-variant-discoverer-funcotate-segments"
             suites: "combine-gvcfs variant-eval genotype-gvcfs structural-variant-discoverer funcotate-segments"
           - group: oracle-backed
-            index: "53/60"
+            index: "53/59"
             slug: "extract-variant-annotations-variant-recalibrator-haplotype-based-variant-recaller-flow-feature-mapper-flow-pairhmm-align-reads-to-haplotypes"
             suites: "extract-variant-annotations variant-recalibrator haplotype-based-variant-recaller flow-feature-mapper flow-pairhmm-align-reads-to-haplotypes"
           - group: oracle-backed
-            index: "54/60"
+            index: "54/59"
             slug: "calibrate-dragstr-model-analyze-saturation-mutagenesis-create-read-count-panel-of-normals-ground-truth-reads-builder-ground-truth-scorer"
             suites: "calibrate-dragstr-model analyze-saturation-mutagenesis create-read-count-panel-of-normals ground-truth-reads-builder ground-truth-scorer"
           - group: oracle-backed
-            index: "55/60"
+            index: "55/59"
             slug: "gnarly-genotyper-model-segments-local-assembler-funcotator-main-dispatch"
             suites: "gnarly-genotyper model-segments local-assembler funcotator main-dispatch"
           - group: oracle-backed
-            index: "56/60"
+            index: "56/59"
             slug: "main-catalogue-gatk-config-main-usage-sequence-dictionary-validation-interval-arguments"
             suites: "main-catalogue gatk-config main-usage sequence-dictionary-validation interval-arguments"
           - group: oracle-backed
-            index: "57/60"
+            index: "57/59"
             slug: "filter-resolution-expanded-command-line-main-non-user-main-entry-splitting-index"
             suites: "filter-resolution expanded-command-line main-non-user main-entry splitting-index"
           - group: oracle-backed
-            index: "58/60"
-            slug: "allele-frequency-qc-calculate-contamination-tool-argument-declarations-usage-text-bwa-index-image"
-            suites: "allele-frequency-qc calculate-contamination tool-argument-declarations usage-text bwa-index-image"
+            index: "58/59"
+            slug: "allele-frequency-qc-calculate-contamination-usage-text-bwa-index-image-tool-argument-enums"
+            suites: "allele-frequency-qc calculate-contamination usage-text bwa-index-image tool-argument-enums"
           - group: oracle-backed
-            index: "59/60"
-            slug: "tool-argument-enums-tool-argument-value-classes-plugin-argument-ownership-read-filter-catalogue-mutex-target-names"
-            suites: "tool-argument-enums tool-argument-value-classes plugin-argument-ownership read-filter-catalogue mutex-target-names"
-          - group: oracle-backed
-            index: "60/60"
-            slug: "count-reads-plumbing-read-walker-refusals"
-            suites: "count-reads-plumbing read-walker-refusals"
+            index: "59/59"
+            slug: "tool-argument-value-classes-plugin-argument-ownership-read-filter-catalogue-count-reads-plumbing-read-walker-refusals"
+            suites: "tool-argument-value-classes plugin-argument-ownership read-filter-catalogue count-reads-plumbing read-walker-refusals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "tool-argument-declarations-mutex-target-names"
+            suites: "tool-argument-declarations mutex-target-names"
     steps:
       - uses: actions/checkout@v7
 

--- a/tools/argument-conformance/MutexTargetsDump.java
+++ b/tools/argument-conformance/MutexTargetsDump.java
@@ -23,6 +23,7 @@
  *
  * Output:
  *
+ *     order\t<tool>\t<long name>\t<the target list, space-joined, in the order it holds>
  *     mutex\t<tool>\t<long name>\t<target long name>\t<target field name>\t<annotated|resolved>
  *     sentence\t<tool>\t<long name>\t<the rendered sentence, escaped>
  *
@@ -60,7 +61,15 @@ public class MutexTargetsDump {
             if (definition.getMutexTargetList().isEmpty()) {
                 continue;
             }
-            final List<String> targets = new ArrayList<>(definition.getMutexTargetList());
+            final List<String> ownOrder = new ArrayList<>(definition.getMutexTargetList());
+            // The list in the order it HOLDS, which is the order the refusal joins it in. It is
+            // its own row because the rows below are sorted for stability, and sorting the list
+            // itself is what hid this: `quantize-quals` reads `static-quantized-quals
+            // round-down-quantized`, the order those two declare their own mutex in, and nothing
+            // recovers that from an alphabetical list.
+            rows.add(String.format("order\t%s\t%s\t%s", name, definition.getLongName(),
+                    String.join(" ", ownOrder)));
+            final List<String> targets = new ArrayList<>(ownOrder);
             Collections.sort(targets);
             for (final String targetName : targets) {
                 // The name the usage prints is the TARGET DEFINITION'S FIELD name, which is

--- a/tools/argument-conformance/ToolArgumentDeclarationDump.java
+++ b/tools/argument-conformance/ToolArgumentDeclarationDump.java
@@ -164,8 +164,13 @@ public class ToolArgumentDeclarationDump {
             // collection is its element class and not the collection's own.
             final String type = definition.getUnderlyingFieldClass().getSimpleName();
             final boolean primitive = definition.getUnderlyingField().getType().isPrimitive();
+            // NOT sorted. The message a mutex violation prints joins this list in the order it
+            // holds, and that order is neither alphabetical nor the annotation's: `quantize-quals`
+            // declares no mutex at all, and Barclay fills its list in reverse as it walks the
+            // declarations, so it reads `static-quantized-quals round-down-quantized` -- the order
+            // those two are declared in. Sorting it here made the generated declarations hold the
+            // alphabetical order and the port print a message the reference never writes.
             final List<String> mutex = new ArrayList<>(definition.getMutexTargetList());
-            java.util.Collections.sort(mutex);
             final Object plugin = definition.getDescriptorForControllingPlugin();
             System.out.printf(
                     "def\t%s\t%d\t%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%d|%d|%s|%s|%s|%s|%s|%s%n",

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6573,7 +6573,7 @@
     },
     {
       "id": "tool-argument-declarations",
-      "status": "oracle-backed",
+      "status": "golden-pending",
       "title": "what one tool declares, and therefore which command lines it accepts",
       "harness": "tools/argument-conformance",
       "tools": [
@@ -6593,7 +6593,7 @@
         {
           "dump": "ToolArgumentDeclarationDump",
           "golden": "crates/gatk-tools/tests/data/tool_declarations.txt.gz",
-          "why": "Seven tools' full declaration lists, and eighteen command lines over them: the empty one, the input alone under each spelling, the input twice, an unknown argument, one and two intervals, a variant argument given to a read walker and an input given to a variant walker, a print tool with and without its output and with its output twice, and a tool that is no walker at all."
+          "why": "Golden-pending: the dump no longer sorts the mutex target list, because the order that list holds is the order the refusal joins it in and sorting it made the port print a message the reference never writes (#1069). The golden this replaces was measured with the sort, so it is re-measured on a real x86-64 runner before it is frozen again. Seven tools' full declaration lists, and eighteen command lines over them: the empty one, the input alone under each spelling, the input twice, an unknown argument, one and two intervals, a variant argument given to a read walker and an input given to a variant walker, a print tool with and without its output and with its output twice, and a tool that is no walker at all."
         }
       ]
     },
@@ -6725,7 +6725,7 @@
     },
     {
       "id": "mutex-target-names",
-      "status": "oracle-backed",
+      "status": "golden-pending",
       "title": "the long name and the field name of a mutex target, which are not the same string",
       "harness": "tools/argument-conformance",
       "tools": [],
@@ -6737,7 +6737,7 @@
         {
           "dump": "MutexTargetsDump",
           "golden": "crates/gatk-tools/tests/data/mutex_target_names.txt.gz",
-          "why": "From the pinned container on a real x86-64 runner, published as the golden-pending artefact of the run that added this suite, and identical to the local smoke run. Four mutex arguments, all of them a read filter's, over two of the four tools: the target's long name, the target definition's FIELD name, and the sentence the usage renders from the second."
+          "why": "Golden-pending: the dump no longer sorts the mutex target list, because the order that list holds is the order the refusal joins it in and sorting it made the port print a message the reference never writes (#1069). The golden this replaces was measured with the sort, so it is re-measured on a real x86-64 runner before it is frozen again. From the pinned container on a real x86-64 runner, published as the golden-pending artefact of the run that added this suite, and identical to the local smoke run. Four mutex arguments, all of them a read filter's, over two of the four tools: the target's long name, the target definition's FIELD name, and the sentence the usage renders from the second."
         }
       ]
     },


### PR DESCRIPTION
`ApplyBQSR`'s covering array, run against both sides in CI, produced this pair on thirteen rows:

```
reference  ... in conjunction with argument(s) static-quantized-quals round-down-quantized
port       ... in conjunction with argument(s) round-down-quantized static-quantized-quals
```

`quantize-quals` declares no mutex of its own. `static-quantized-quals` and `round-down-quantized` each declare `mutex = "quantize-quals"`, and Barclay fills the reverse list as it walks the declarations, so the list holds them in the order those two are declared in and the refusal joins it as it is.

Both dumps sorted that list, and `crates/gatk-tools/src/tool_declarations.rs` is generated from one of the two goldens, so the port holds the alphabetical order and prints a message the reference never writes. The sort was for stability and was not needed for it: the order is fixed by the declarations.

- `ToolArgumentDeclarationDump` no longer sorts the `def` row's mutex field;
- `MutexTargetsDump` keeps its sorted rows (they are sorted as whole rows, which the list's order cannot survive) and gains an `order` row carrying the list itself.

Both suites go to `golden-pending`, since the goldens they have were measured with the sort. The second commit freezes what CI measures and regenerates `tool_declarations.rs`, which is what fixes the message.

Towards #1069.