### PR TITLE
A read group missing from the table is exit 3, not 2

### DIFF
--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -1719,8 +1719,15 @@ pub fn apply_bqsr(parser: &Parser) -> Outcome {
         level,
         deflater,
     )
+    // The failure follows the CLASS rather than being assumed: the transformer throws a
+    // `GATKException`, which leaves exit 3 and is printed as a stack trace rather than as
+    // `A USER ERROR has occurred`.
     .map_err(|error| Thrown {
-        failure: Failure::User,
+        failure: if error.is_user() {
+            Failure::User
+        } else {
+            Failure::Other
+        },
         exception: error.java_class(),
         message: Some(error.message()),
     })?;

--- a/crates/gatk-engine/src/bqsr_transformer.rs
+++ b/crates/gatk-engine/src/bqsr_transformer.rs
@@ -114,6 +114,20 @@ pub enum BqsrError {
 }
 
 impl BqsrError {
+    /// The Java class the reference throws.
+    ///
+    /// Both of the transformer's own refusals are `GATKException`s rather than `UserException`s,
+    /// which is what the documentation above already said and what the caller did not read: a
+    /// recalibration table written from a different BAM leaves exit 3, not 2.
+    pub fn java_class(&self) -> &'static str {
+        match self {
+            BqsrError::ReadGroupNotInTable(_) | BqsrError::NoReadGroupDatum(_) => {
+                "org.broadinstitute.hellbender.exceptions.GATKException"
+            }
+            BqsrError::Covariate(error) => error.java_class(),
+        }
+    }
+
     pub fn message(&self) -> String {
         match self {
             // No space after the full stop, which is the reference's concatenation.

--- a/crates/gatk-engine/src/covariates.rs
+++ b/crates/gatk-engine/src/covariates.rs
@@ -126,6 +126,33 @@ pub enum CovariateError {
 }
 
 impl CovariateError {
+    /// The Java class the reference throws, which decides whether the run is a USER error.
+    ///
+    /// Each of these is the class named in the variant's own documentation above, and the reason
+    /// it is here rather than assumed is that the caller's answer decides the EXIT CODE: a
+    /// `UserException` leaves 2 and anything else leaves 3, so classifying a `GATKException` as a
+    /// user error is a divergence a covering-array row reads as a wrong exit rather than a wrong
+    /// message (measured on `ApplyBQSR`'s row 10).
+    pub fn java_class(&self) -> &'static str {
+        match self {
+            CovariateError::ContextSizeTooBig { .. } => {
+                "org.broadinstitute.barclay.argparser.CommandLineException$BadArgumentValue"
+            }
+            CovariateError::ContextSizeNotPositive { .. } => {
+                "org.broadinstitute.barclay.argparser.CommandLineException"
+            }
+            CovariateError::MissingKey(_) => "java.lang.IllegalStateException",
+            CovariateError::NegativeContextKey => {
+                "org.broadinstitute.hellbender.exceptions.GATKException"
+            }
+            CovariateError::CycleTooBig { .. } => {
+                "org.broadinstitute.hellbender.exceptions.UserException"
+            }
+            CovariateError::NoReadGroupInHeader => "java.lang.NullPointerException",
+            CovariateError::Clip(_) => "java.lang.ArrayIndexOutOfBoundsException",
+        }
+    }
+
     /// The exact message, which the golden compares character for character.
     pub fn message(&self) -> String {
         match self {

--- a/crates/gatk-tools/src/apply_bqsr.rs
+++ b/crates/gatk-tools/src/apply_bqsr.rs
@@ -62,10 +62,25 @@ impl ApplyBqsrError {
 
     /// The Java class the reference throws, which the non-user handler prints.
     ///
-    /// One class for all three: the report's own refusals and the transformer's are
-    /// `UserException`s, and a read the reader cannot make sense of is one too.
+    /// NOT one class for all three. The transformer's refusals are `GATKException`s: a
+    /// recalibration table written from a different BAM answers `Read group rg1 not found in the
+    /// recalibration table.` and leaves **exit 3**, where a `UserException` would leave 2 and be
+    /// printed as `A USER ERROR has occurred`. Measured on row 10 of this tool's covering array,
+    /// which is a row the corpus only reached once `--bqsr-recal-file` had a second value.
+    ///
+    /// The report's own refusals and the reader's are user errors, and stay one.
     pub fn java_class(&self) -> &'static str {
-        "org.broadinstitute.hellbender.exceptions.UserException"
+        match self {
+            ApplyBqsrError::Transform(error) => error.java_class(),
+            ApplyBqsrError::Report(_) | ApplyBqsrError::Reads(_) => {
+                "org.broadinstitute.hellbender.exceptions.UserException"
+            }
+        }
+    }
+
+    /// Whether `Main` prints it as a user error, which is what decides the exit code.
+    pub fn is_user(&self) -> bool {
+        self.java_class() == "org.broadinstitute.hellbender.exceptions.UserException"
     }
 }
 


### PR DESCRIPTION
`ApplyBQSR`'s covering array, run against both sides in CI, disagreed on one row of twenty-one:

```
reference  EXIT=3 org.broadinstitute.hellbender.exceptions.GATKException: Read group rg1 not found in the recalibration table....
port       EXIT=2 A USER ERROR has occurred: Read group rg1 not found in the recalibration table....
```

The message was already right; the class was not, and the class decides which handler `Main` uses and therefore the exit code.

`ApplyBqsrError::java_class` returned `UserException` for all three variants. The port's own documentation already recorded the truth: `BqsrError::ReadGroupNotInTable` and `NoReadGroupDatum` are annotated `GATKException`, which is what `BQSRReadTransformer` throws at lines 183 and 192. The classification never read them.

`BqsrError` and `CovariateError` each gain a `java_class` built from the classes their variants document, and the runner's failure follows the class instead of assuming `Failure::User`.

The row exists because #1068 gave `--bqsr-recal-file` a second value: with one value the argument was held, and no row could pair a BAM with a table written from a different one.