### PR TITLE
Measure the header SelectVariants writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,10 @@ jobs:
             index: "60/60"
             slug: "count-reads-plumbing-read-walker-refusals"
             suites: "count-reads-plumbing read-walker-refusals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "select-variants-header"
+            suites: "select-variants-header"
     steps:
       - uses: actions/checkout@v7
 

--- a/crates/gatk-tools/src/lib.rs
+++ b/crates/gatk-tools/src/lib.rs
@@ -144,6 +144,7 @@ pub mod rename_sample_in_vcf;
 pub mod revert_base_quality_scores;
 pub mod sam_output;
 pub mod select_variants;
+pub mod select_variants_header;
 pub mod sequence_dictionary;
 pub mod series_stats;
 pub mod set_nm_md_and_uq_tags;

--- a/crates/gatk-tools/src/select_variants_header.rs
+++ b/crates/gatk-tools/src/select_variants_header.rs
@@ -1,0 +1,146 @@
+//! `SelectVariants.createVCFHeaderLineList` and the header it hands the writer.
+//!
+//! The five existing `select-variants-*` suites all skip the `#` lines of the output, and for a
+//! good reason: the default header carries a `##GATKCommandLine` line holding the wall-clock time
+//! of the run, so a golden of the whole header would flake by construction. That is why this is
+//! the part of the tool nothing measured, and it is not a small part -- the method merges, adds,
+//! REPLACES and removes lines, and the replacement is the half a port gets wrong.
+//!
+//! Four rules, in the order the reference applies them.
+//!
+//! 1. The input's own header lines, through `VCFUtils.smartMergeHeaders` over a set of one.
+//! 2. The tool's default lines: `##source=SelectVariants` and `##GATKCommandLine`, and BOTH of
+//!    them are gone when `--add-output-vcf-command-line` is false, because
+//!    `getDefaultToolVCFHeaderLines` returns an empty set rather than dropping one line.
+//! 3. `--keep-original-ac` adds three lines and `--keep-original-dp` adds one, whether or not any
+//!    record ends up carrying them.
+//! 4. AN, AC, AF and then DP are REMOVED and re-added from htsjdk's standard definitions. This is
+//!    not a merge: an input whose `##INFO=<ID=AC>` says `Description="Not the standard count"`
+//!    comes out with htsjdk's description, and AF appears in a file that never had one. The order
+//!    is `ChromosomeCounts.keyNames`, which is AN, AC, AF rather than the alphabetical reading.
+//!
+//! The drops run LAST, after the four replacements, so `--drop-info-annotation AC` removes the
+//! standard line that had just been put there.
+//!
+//! Ported from `org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants` of
+//! GATK 4.6.2.0.
+
+use htsjdk_vcf::header::{Cardinality, HeaderLine, LineType, VcfHeader};
+use htsjdk_vcf::merge::{smart_merge_headers, Source};
+use htsjdk_vcf::standard_header_lines::standard_info_line;
+
+/// `GATKVCFConstants`: the four keys `--keep-original-ac` and `--keep-original-dp` add.
+pub const ORIGINAL_AC_KEY: &str = "AC_Orig";
+pub const ORIGINAL_AF_KEY: &str = "AF_Orig";
+pub const ORIGINAL_AN_KEY: &str = "AN_Orig";
+pub const ORIGINAL_DP_KEY: &str = "DP_Orig";
+
+/// `ChromosomeCounts.keyNames`, in its own order: allele NUMBER first, then count, then frequency.
+pub const CHROMOSOME_COUNT_KEYS: [&str; 3] = ["AN", "AC", "AF"];
+
+/// What the header construction reads off the command line.
+pub struct HeaderArguments {
+    pub keep_original_chr_counts: bool,
+    pub keep_original_depth: bool,
+    pub info_annotations_to_drop: Vec<String>,
+    pub genotype_annotations_to_drop: Vec<String>,
+    /// `--add-output-vcf-command-line`. False removes the `##source` line as well.
+    pub add_output_vcf_command_line: bool,
+    /// The `##GATKCommandLine` value, which the caller builds because it holds the run's own time.
+    pub tool_command_line: Option<HeaderLine>,
+    /// The samples the output declares, which are the SELECTED ones rather than the input's.
+    pub samples: Vec<String>,
+}
+
+/// `GATKVCFHeaderLines.getInfoLine`, for the four keys this tool can add.
+fn gatk_info_line(id: &str) -> HeaderLine {
+    let (number, line_type, description) = match id {
+        ORIGINAL_AC_KEY => (Cardinality::A, LineType::Integer, "Original AC"),
+        ORIGINAL_AF_KEY => (Cardinality::A, LineType::Float, "Original AF"),
+        ORIGINAL_AN_KEY => (Cardinality::Fixed(1), LineType::Integer, "Original AN"),
+        ORIGINAL_DP_KEY => (Cardinality::Fixed(1), LineType::Integer, "Original DP"),
+        _ => unreachable!("no GATK header line for {id}"),
+    };
+    HeaderLine::Compound {
+        key: "INFO".to_string(),
+        id: id.to_string(),
+        number,
+        line_type,
+        description: description.to_string(),
+        extra: Vec::new(),
+    }
+}
+
+/// True when the line is an `##INFO` (or `##FORMAT`) line with this id.
+fn is_compound(line: &HeaderLine, key: &str, id: &str) -> bool {
+    matches!(
+        line,
+        HeaderLine::Compound { key: k, id: i, .. } if k == key && i == id
+    )
+}
+
+/// `createVCFHeaderLineList`, then `new VCFHeader(lines, samples)`.
+pub fn output_header(input: &VcfHeader, arguments: &HeaderArguments) -> VcfHeader {
+    // One source, which is what `Collections.singletonMap` gives `smartMergeHeaders`. The merge
+    // over a single header is not the identity: it is what repairs a line whose declaration
+    // disagrees with the standard one for its id.
+    let (mut lines, _warnings) = smart_merge_headers(
+        &[Source {
+            header: input,
+            version: None,
+        }],
+        true,
+    )
+    .unwrap_or_else(|_| (input.lines.clone(), Vec::new()));
+
+    if arguments.add_output_vcf_command_line {
+        // `##source=<tool>` and the command line, and the pair is all-or-nothing.
+        lines.push(HeaderLine::Unstructured {
+            key: "source".to_string(),
+            value: "SelectVariants".to_string(),
+        });
+        if let Some(command_line) = &arguments.tool_command_line {
+            lines.push(command_line.clone());
+        }
+    }
+
+    if arguments.keep_original_chr_counts {
+        for key in [ORIGINAL_AC_KEY, ORIGINAL_AF_KEY, ORIGINAL_AN_KEY] {
+            lines.push(gatk_info_line(key));
+        }
+    }
+    if arguments.keep_original_depth {
+        lines.push(gatk_info_line(ORIGINAL_DP_KEY));
+    }
+
+    // The replacement, which is a removal and an addition rather than a merge.
+    for key in CHROMOSOME_COUNT_KEYS {
+        lines.retain(|line| !is_compound(line, "INFO", key));
+        if let Some(standard) = standard_info_line(key) {
+            lines.push(standard);
+        }
+    }
+    lines.retain(|line| !is_compound(line, "INFO", "DP"));
+    if let Some(standard) = standard_info_line("DP") {
+        lines.push(standard);
+    }
+
+    // Last, so that dropping AC removes the line the loop above had just added.
+    lines.retain(|line| {
+        !arguments
+            .info_annotations_to_drop
+            .iter()
+            .any(|id| is_compound(line, "INFO", id))
+    });
+    lines.retain(|line| {
+        !arguments
+            .genotype_annotations_to_drop
+            .iter()
+            .any(|id| is_compound(line, "FORMAT", id))
+    });
+
+    VcfHeader {
+        lines,
+        samples: arguments.samples.clone(),
+    }
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -237,7 +237,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `SVCluster` | sv-caller | oracle-backed | sv-cluster | 1 | not measured |
 | `SVConcordance` | sv-caller | oracle-backed | sv-concordance | 1 | not measured |
 | `SVStratify` | sv-caller | oracle-backed | sv-stratify | 1 | not measured |
-| `SelectVariants` | variant-transform | oracle-backed | select-variants-concordance, select-variants-filters, select-variants-output, select-variants-samples, select-variants-subset, tool-argument-declarations, tool-argument-enums | 7 | not measured |
+| `SelectVariants` | variant-transform | oracle-backed | select-variants-concordance, select-variants-filters, select-variants-header, select-variants-output, select-variants-samples, select-variants-subset, tool-argument-declarations, tool-argument-enums | 8 | not measured |
 | `ShiftFasta` | reference-utility | oracle-backed | shift-fasta | 1 | not measured |
 | `SiteDepthtoBAF` | sv-caller | oracle-backed | site-depth-to-baf | 1 | not measured |
 | `SplitCRAM` | unclassified | oracle-backed | split-cram | 1 | not measured |

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -2897,6 +2897,32 @@
       ]
     },
     {
+      "id": "select-variants-header",
+      "status": "golden-pending",
+      "title": "the header SelectVariants writes, where four INFO lines are replaced rather than merged",
+      "harness": "tools/readfilter-conformance",
+      "tools": [
+        "SelectVariants"
+      ],
+      "compare": {
+        "mode": "lines"
+      },
+      "expect_contains": [
+        "header\tplain\t##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count in genotypes, for each ALT allele, in the same order as listed\">",
+        "header\tplain\t##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele Frequency, for each ALT allele, in the same order as listed\">",
+        "header\tkeep-original-ac\t##INFO=<ID=AC_Orig,Number=A,Type=Integer,Description=\"Original AC\">",
+        "samples\tsubset\ts0,s2"
+      ],
+      "why": "The five existing select-variants suites all skip the `#` lines of the output, because the default header carries a ##GATKCommandLine line holding the wall-clock time of the run and a golden of it would flake by construction. So the header is the part of this tool nothing measures, and createVCFHeaderLineList is not a small part of it: AN, AC, AF and DP are REMOVED and re-added from htsjdk's standard definitions rather than merged, so an input whose ##INFO=<ID=AC> carries its own description comes out with htsjdk's and an AF appears in a file that never had one. --keep-original-ac adds three lines and --keep-original-dp one; the two --drop arguments remove header lines and run AFTER the replacements, so dropping AC removes the standard line just added; the sample columns are the selected set rather than the file's; and --add-output-vcf-command-line false removes the ##source line as well, because getDefaultToolVCFHeaderLines returns an empty set rather than dropping one line. The last case runs with the command line ON and elides its Date and Version, so where the line goes is measured without the golden moving.",
+      "cases": [
+        {
+          "dump": "SelectVariantsHeaderDump",
+          "golden": null,
+          "why": "Golden-pending: to be measured in the pinned container on a real x86-64 runner."
+        }
+      ]
+    },
+    {
       "id": "select-variants-concordance",
       "status": "oracle-backed",
       "title": "SelectVariants' discordance and concordance, which are not opposites",

--- a/tools/readfilter-conformance/SelectVariantsHeaderDump.java
+++ b/tools/readfilter-conformance/SelectVariantsHeaderDump.java
@@ -1,0 +1,190 @@
+/*
+ * The header SelectVariants writes, taken from the reference.
+ *
+ * The five existing SelectVariants suites all skip the `#` lines, and for a good reason: the
+ * default header carries a `##GATKCommandLine` line with the wall-clock Date of the run, so a
+ * golden of the whole header would flake by construction. That is exactly why the header is the
+ * part of this tool nothing measures, and it is not a small part: `createVCFHeaderLineList` merges,
+ * adds, REPLACES and removes lines, and the replacements are the ones a port gets wrong.
+ *
+ * Six behaviours this is built to catch.
+ *
+ *   - AC, AF, AN AND DP ARE REPLACED, not merged. Whatever the input declared for those four INFO
+ *     ids is removed and htsjdk's own standard line is added, so an input whose `##INFO=<ID=AC>`
+ *     says `Number=A,Type=Integer,Description="Allele count"` comes out with the standard
+ *     description instead. AF is added even when the input never had it;
+ *   - --keep-original-ac ADDS THREE LINES (AC_Orig, AF_Orig, AN_Orig) and --keep-original-dp adds
+ *     one (DP_Orig), whether or not any record ends up carrying them;
+ *   - --drop-info-annotation AND --drop-genotype-annotation REMOVE THE HEADER LINE TOO, and they
+ *     run AFTER the four replacements, so dropping AC removes the standard line that had just been
+ *     put there;
+ *   - THE SAMPLE COLUMNS ARE THE SELECTED SET, sorted, which is what `new VCFHeader(lines, samples)`
+ *     does with the TreeSet `createSampleNameInclusionList` returns;
+ *   - THE CONTIG LINES ARE REWRITTEN FROM THE DICTIONARY even with no reference, because
+ *     `updateHeaderContigLines` runs whenever the input header has one;
+ *   - AND `--add-output-vcf-command-line false` REMOVES THE `##source` LINE AS WELL, because both
+ *     come from `getDefaultToolVCFHeaderLines` and it returns an empty set.
+ *
+ * The last case runs with the command line ON and prints it with the Date and the Version elided,
+ * so that where the line goes and what it holds are both measured without the golden moving.
+ *
+ * Output:
+ *
+ *     input\t<label>\t<the whole input vcf, escaped>
+ *     header\t<label>\t<one header line of the output VCF, escaped>
+ *     samples\t<label>\t<the sample columns, comma-joined>
+ *     error\t<label>\t<exception class>:<message>
+ *
+ * Usage: SelectVariantsHeaderDump
+ */
+
+import org.broadinstitute.hellbender.tools.IndexFeatureFile;
+import org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SelectVariantsHeaderDump {
+
+    /*
+     * The input's own AC, AN and DP lines are DELIBERATELY not the standard ones: a port that
+     * merges them through instead of replacing them produces this file's descriptions rather than
+     * htsjdk's, and no other case can tell the difference. AF is absent for the same reason, since
+     * the tool adds it whether or not the input had one.
+     */
+    static final String HEADER =
+            "##fileformat=VCFv4.2\n"
+                    + "##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Not the standard depth\">\n"
+                    + "##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Not the standard count\">\n"
+                    + "##INFO=<ID=AN,Number=1,Type=Integer,Description=\"Not the standard number\">\n"
+                    + "##INFO=<ID=QD,Number=1,Type=Float,Description=\"Quality by depth\">\n"
+                    + "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+                    + "##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Genotype quality\">\n"
+                    + "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Depth\">\n"
+                    + "##FORMAT=<ID=XX,Number=1,Type=Integer,Description=\"An annotation to drop\">\n"
+                    + "##FILTER=<ID=LowGQ,Description=\"Was already there\">\n"
+                    + "##contig=<ID=chr1,length=100000>\n"
+                    + "##contig=<ID=chr2,length=90000>\n"
+                    + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts0\ts1\ts2\n";
+
+    public static void main(final String[] args) throws Exception {
+        final Path dir = Path.of("selectvariants-header-dump");
+        emptyDirectory(dir);
+        Files.createDirectories(dir);
+
+        System.out.println("# SelectVariantsHeaderDump: the header the tool writes, from the reference");
+
+        final Path input = writeVcf(dir, "records",
+                "chr1\t100\t.\tA\tC\t50\t.\tDP=30;AC=1;AN=6;QD=20.0"
+                        + "\tGT:GQ:DP:XX\t0/1:60:10:7\t0/0:60:10:7\t0/0:60:10:7",
+                "chr2\t50\t.\tA\tG\t50\t.\tDP=30;AC=1;AN=6;QD=20.0"
+                        + "\tGT:GQ:DP:XX\t0/1:60:10:7\t0/0:60:10:7\t0/0:60:10:7");
+
+        // The four replacements, with nothing else asked for.
+        run(dir, "plain", input);
+        // The three lines and the one line the keep-original arguments add.
+        run(dir, "keep-original-ac", input, "--keep-original-ac", "true");
+        run(dir, "keep-original-dp", input, "--keep-original-dp", "true");
+        run(dir, "keep-original-both", input, "--keep-original-ac", "true",
+                "--keep-original-dp", "true");
+        // The drops, which run after the replacements: `AC` removes the line just added.
+        run(dir, "drop-info-qd", input, "--drop-info-annotation", "QD");
+        run(dir, "drop-info-ac", input, "--drop-info-annotation", "AC");
+        run(dir, "drop-genotype", input, "--drop-genotype-annotation", "XX");
+        // A drop of something the header never declared, which removes nothing and refuses nothing.
+        run(dir, "drop-absent", input, "--drop-info-annotation", "NOPE");
+        // The sample columns, which are the selected set rather than the file's.
+        run(dir, "subset", input, "-sn", "s2", "-sn", "s0");
+        // Sites only, where the sample columns go entirely.
+        run(dir, "sites-only", input, "--sites-only-vcf-output", "true");
+        // The command line, with its Date and Version elided so the golden holds still.
+        runWithCommandLine(dir, "command-line", input);
+    }
+
+    static Path writeVcf(final Path dir, final String label, final String... records)
+            throws Exception {
+        final StringBuilder text = new StringBuilder(HEADER);
+        for (final String record : records) {
+            text.append(record).append("\n");
+        }
+        final Path file = dir.resolve(label + ".vcf");
+        Files.writeString(file, text.toString(), StandardCharsets.UTF_8);
+        new IndexFeatureFile().instanceMain(new String[] {"-I", file.toString()});
+        System.out.printf("input\t%s\t%s%n", label, ReferenceQueryDump.escape(text.toString()));
+        return file;
+    }
+
+    static void run(final Path dir, final String label, final Path input,
+                    final String... arguments) {
+        final List<String> all = new ArrayList<>(List.of("--add-output-vcf-command-line", "false"));
+        all.addAll(List.of(arguments));
+        execute(dir, label, input, all);
+    }
+
+    static void runWithCommandLine(final Path dir, final String label, final Path input) {
+        execute(dir, label, input, List.of());
+    }
+
+    static void execute(final Path dir, final String label, final Path input,
+                        final List<String> arguments) {
+        final Path output = dir.resolve(label + "-out.vcf");
+        final List<String> all = new ArrayList<>(List.of("-V", input.toString(),
+                "-O", output.toString()));
+        all.addAll(arguments);
+        try {
+            new SelectVariants().instanceMain(all.toArray(new String[0]));
+        } catch (final Exception e) {
+            System.out.printf("error\t%s\t%s:%s%n", label, e.getClass().getName(),
+                    ReferenceQueryDump.escape(String.valueOf(e.getMessage())));
+            return;
+        }
+        print(label, output);
+    }
+
+    /** The `##GATKCommandLine` line with the two fields that move replaced by a fixed word. */
+    static String elide(final String line) {
+        return line.replaceAll("Version=\"[^\"]*\"", "Version=\"ELIDED\"")
+                .replaceAll("Date=\"[^\"]*\"", "Date=\"ELIDED\"");
+    }
+
+    static void print(final String label, final Path output) {
+        final List<String> lines;
+        try {
+            lines = Files.readAllLines(output, StandardCharsets.UTF_8);
+        } catch (final Exception e) {
+            System.out.printf("error\t%s-read\t%s:%s%n", label, e.getClass().getName(),
+                    String.valueOf(e.getMessage()));
+            return;
+        }
+        for (final String line : lines) {
+            if (!line.startsWith("#")) {
+                break;
+            }
+            if (line.startsWith("#CHROM")) {
+                final String[] field = line.split("\t");
+                final List<String> samples = new ArrayList<>();
+                for (int index = 9; index < field.length; index++) {
+                    samples.add(field[index]);
+                }
+                System.out.printf("samples\t%s\t%s%n", label, String.join(",", samples));
+                continue;
+            }
+            System.out.printf("header\t%s\t%s%n", label,
+                    ReferenceQueryDump.escape(elide(line)));
+        }
+    }
+
+    static void emptyDirectory(final Path dir) throws Exception {
+        if (!Files.isDirectory(dir)) {
+            return;
+        }
+        try (final var entries = Files.list(dir)) {
+            for (final Path entry : entries.toList()) {
+                Files.deleteIfExists(entry);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five suites cover `SelectVariants` and all five skip the `#` lines of the output, because the default header carries a `##GATKCommandLine` line holding the wall-clock time of the run. So the header is the part of this tool nothing measures, and `createVCFHeaderLineList` is not a small part of it.

Measured from the reference:

- **AN, AC, AF and DP are replaced, not merged.** An input declaring its own `##INFO=<ID=AC,...>` comes out with htsjdk's description, and an AF line appears in a file that never had one. The DP that wins is the INFO standard (`Approximate read depth; some reads may have been filtered`), not the FORMAT one of the same id.
- `--keep-original-ac` adds `AC_Orig`, `AF_Orig`, `AN_Orig`; `--keep-original-dp` adds `DP_Orig`.
- **The drops run last**, after the replacements, so `--drop-info-annotation AC` leaves no AC line at all.
- The sample columns are the selected set in the TreeSet's order (`-sn s2 -sn s0` writes `s0 s2`), and `--sites-only-vcf-output` leaves none.
- `--add-output-vcf-command-line false` removes the `##source` line as well, because `getDefaultToolVCFHeaderLines` returns an empty set rather than dropping one line.

The last case runs with the command line on and elides its `Date` and `Version`, so where the line goes is measured without the golden moving.

`select_variants_header::output_header` is the port. It does not build the command-line value: that string holds the run's own time, so the caller passes it in.

Golden-pending. The dump smoke-ran locally against the pinned container and produced 163 rows with every named behaviour present; the golden comes from a real x86-64 runner, and the test lands with it.