### PR TITLE
Build SelectVariants' runner, and measure where it stops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "htsjdk-bam",
  "htsjdk-bgzf",
  "htsjdk-tribble",
+ "htsjdk-vcf",
 ]
 
 [[package]]

--- a/crates/gatk-cli/Cargo.toml
+++ b/crates/gatk-cli/Cargo.toml
@@ -24,6 +24,9 @@ htsjdk-bgzf.workspace = true
 # The index a VCF WRITER builds on the fly, which is not the one IndexFeatureFile builds from the
 # same file: the dictionary is properties and the file's own stats are left at zero.
 htsjdk-tribble.workspace = true
+# The variant model the ported statics do not carry: `SelectVariants` decides on a reduced record
+# and writes the file's own, so both are in scope here.
+htsjdk-vcf.workspace = true
 
 [dev-dependencies]
 gatk-corpus = { path = "../gatk-corpus" }

--- a/crates/gatk-cli/src/lib.rs
+++ b/crates/gatk-cli/src/lib.rs
@@ -23,6 +23,7 @@
 pub mod command_line;
 pub mod definitions;
 pub mod runners;
+pub mod variant_bridge;
 
 use gatk_tools::main_entry::{self, Failure, Route, Stream, Thrown};
 
@@ -278,6 +279,7 @@ pub fn runner(name: &str) -> Option<Runner> {
         "ApplyBQSR" => Some(run_apply_bqsr),
         "IndexFeatureFile" => Some(run_index_feature_file),
         "PrintBGZFBlockInformation" => Some(run_print_bgzf_block_information),
+        "SelectVariants" => Some(run_select_variants),
         _ => None,
     }
 }
@@ -285,6 +287,10 @@ pub fn runner(name: &str) -> Option<Runner> {
 /// The runners, each of which needs the parsed command line rather than the raw one.
 fn run_apply_bqsr(args: &[String]) -> Result<Option<String>, Thrown> {
     runners::apply_bqsr(&parsed("ApplyBQSR", args)?)
+}
+
+fn run_select_variants(args: &[String]) -> Result<Option<String>, Thrown> {
+    runners::select_variants(&parsed("SelectVariants", args)?)
 }
 
 fn run_gather_vcfs_cloud(args: &[String]) -> Result<Option<String>, Thrown> {

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -730,18 +730,25 @@ fn has_feature_index(path: &str) -> bool {
     std::path::Path::new(&index_feature_file::default_output(path)).is_file()
 }
 
-/// `CountVariants.doWork`, with the input read, the intervals resolved and the count written.
+/// Everything `GATKTool.onStartup` does for a VARIANT walker, up to and including the intervals.
 ///
-/// Four things the `count-variants` golden pins and this reproduces: the count reaches no stream
-/// without `-O`, whatever the class documentation says; a record is selected by its whole SPAN,
-/// `END` or the length of `REF`, so an interval reaches a record whose position it does not hold;
-/// `-L` against an input with no index is refused BEFORE any record is read; and the refusal for
-/// an unwritable `-O` carries the path and nothing else.
-pub fn count_variants(parser: &Parser) -> Outcome {
-    // A variant walker applies no read filter and still VALIDATES the ones a command line names:
-    // the descriptor belongs to the command line rather than to the traversal, so `--read-filter`
-    // and its three companions are refused here exactly as they are on a read walker.
-    let _ = resolve_read_filters(parser, "CountVariants")?;
+/// It is shared rather than copied because the ORDER is the part that is measured: a port that
+/// asks the reader before it validates a dictionary answers a later question first, and a
+/// covering-array row shows that as a wrong message rather than a wrong number. The sequence is
+/// the reference's own -- the read filters while the command line is parsed, then the driving
+/// variants, then the reads, then the master dictionary, then the reference, then the pairwise
+/// validation, and only then `-L`.
+struct VariantStart {
+    /// The `--variant` path as it was given, which several refusals quote.
+    input: String,
+    /// The driving variants as text, decompressed if the file was block compressed.
+    text: String,
+    codec: gatk_tools::feature_codec::Codec,
+    intervals: Option<Vec<gatk_engine::interval::SimpleInterval>>,
+}
+
+fn variant_walker_startup(parser: &Parser, tool: &str) -> Result<VariantStart, Thrown> {
+    let _ = resolve_read_filters(parser, tool)?;
     // `--variant` is a SCALAR on this tool, where a read walker's `--input` is a collection: the
     // declaration says `collection: false`, and reading it as a list finds nothing at all.
     let input = argument(parser, "variant").ok_or_else(|| {
@@ -873,6 +880,31 @@ pub fn count_variants(parser: &Parser) -> Outcome {
         header.clone()
     };
     let intervals = interval_arguments(parser, &best)?.map(|parameters| parameters.intervals);
+
+    Ok(VariantStart {
+        input,
+        text,
+        codec,
+        intervals,
+    })
+}
+/// `CountVariants.doWork`, with the input read, the intervals resolved and the count written.
+///
+/// Four things the `count-variants` golden pins and this reproduces: the count reaches no stream
+/// without `-O`, whatever the class documentation says; a record is selected by its whole SPAN,
+/// `END` or the length of `REF`, so an interval reaches a record whose position it does not hold;
+/// `-L` against an input with no index is refused BEFORE any record is read; and the refusal for
+/// an unwritable `-O` carries the path and nothing else.
+pub fn count_variants(parser: &Parser) -> Outcome {
+    // A variant walker applies no read filter and still VALIDATES the ones a command line names:
+    // the descriptor belongs to the command line rather than to the traversal, so `--read-filter`
+    // and its three companions are refused here exactly as they are on a read walker.
+    let VariantStart {
+        input,
+        text,
+        codec,
+        intervals,
+    } = variant_walker_startup(parser, "CountVariants")?;
 
     let features: Vec<Locus> = gatk_tools::feature_codec::features(&text, codec)
         .into_iter()
@@ -1751,4 +1783,494 @@ fn number_or(parser: &Parser, long_name: &str, default: i32) -> i32 {
     scalar(parser, long_name)
         .and_then(|text| text.parse().ok())
         .unwrap_or(default)
+}
+
+/// `SelectVariants.doWork`: the records the arguments select, written as a VCF.
+///
+/// The tool is a variant walker like `CountVariants`, so the whole startup is shared -- and shared
+/// rather than copied because the order of the refusals is what a covering-array row measures.
+/// What follows the startup is the pipeline the five `select-variants-*` suites measure, in the
+/// reference's own order: the queue is drained as far as the record about to be read, the record
+/// is filtered, subset, filtered again, no-called and dropped from, and joins the queue rather
+/// than the file.
+///
+/// # What this refuses rather than approximates
+///
+/// Six argument groups reach behaviour no static in this repository reproduces: a pedigree and
+/// its Mendelian violations, the two random fractions, the GenomicsDB-only decoding, the
+/// concordance tracks, `--variant-output-filtering` and `--fully-decode`. Each is refused when it
+/// is SET, which is a port limitation with the tool's name on it rather than a silent difference:
+/// a run that ignored `--select-random-fraction 0.5` would answer a question it was not asked.
+pub fn select_variants(parser: &Parser) -> Outcome {
+    let VariantStart {
+        input,
+        text,
+        codec: _,
+        intervals,
+    } = variant_walker_startup(parser, "SelectVariants")?;
+
+    select_variants_limits(parser)?;
+
+    let output = argument(parser, "output").ok_or_else(|| {
+        Thrown::command_line("Argument output was missing: Argument 'output' is required")
+    })?;
+
+    let file = htsjdk_vcf::reader::read_vcf(&text).map_err(|failure| Thrown {
+        failure: Failure::User,
+        exception: "htsjdk.tribble.TribbleException",
+        message: Some(failure.error.message()),
+    })?;
+
+    // `createSampleNameInclusionList(vcfHeaders)`, over the driving variants' own samples.
+    let sample_arguments = gatk_tools::select_variants::SampleArguments {
+        sample_names: arguments(parser, "sample-name"),
+        sample_expressions: arguments(parser, "sample-expressions"),
+        exclude_sample_names: arguments(parser, "exclude-sample-name"),
+        exclude_sample_expressions: arguments(parser, "exclude-sample-expressions"),
+        allow_nonoverlapping_command_line_samples: flag(
+            parser,
+            "allow-nonoverlapping-command-line-samples",
+        ),
+    };
+    let selection = gatk_tools::select_variants::create_sample_name_inclusion_list(
+        &file.header.samples,
+        &sample_arguments,
+    )
+    .map_err(|refusal| Thrown {
+        failure: Failure::User,
+        exception: refusal.java_class(),
+        message: Some(refusal.message()),
+    })?;
+
+    let subset_arguments = gatk_tools::select_variants::SubsetArguments {
+        remove_unused_alternates: flag(parser, "remove-unused-alternates"),
+        preserve_alleles: flag(parser, "preserve-alleles"),
+        keep_original_chr_counts: flag(parser, "keep-original-ac"),
+        keep_original_depth: flag(parser, "keep-original-dp"),
+    };
+    let filter_arguments = select_variants_filters(parser)?;
+    let output_arguments = gatk_tools::select_variants::OutputArguments {
+        set_filtered_genotypes_to_no_call: flag(parser, "set-filtered-gt-to-nocall"),
+        info_annotations_to_drop: arguments(parser, "drop-info-annotation"),
+        genotype_annotations_to_drop: arguments(parser, "drop-genotype-annotation"),
+    };
+
+    // `--sites-only-vcf-output` empties the sample columns, and it does so on the HEADER as well
+    // as on every record, which is why it is read before the header is built.
+    let sites_only = flag(parser, "sites-only-vcf-output");
+    let header = gatk_tools::select_variants_header::output_header(
+        &file.header,
+        &gatk_tools::select_variants_header::HeaderArguments {
+            keep_original_chr_counts: subset_arguments.keep_original_chr_counts,
+            keep_original_depth: subset_arguments.keep_original_depth,
+            info_annotations_to_drop: output_arguments.info_annotations_to_drop.clone(),
+            genotype_annotations_to_drop: output_arguments.genotype_annotations_to_drop.clone(),
+            add_output_vcf_command_line: flag(parser, "add-output-vcf-command-line"),
+            tool_command_line: command_line_header_line(parser),
+            samples: if sites_only {
+                Vec::new()
+            } else {
+                selection.samples.clone()
+            },
+        },
+    );
+
+    // The traversal, which is the intervals' if there are any. A feature file with no index is
+    // refused here rather than earlier, exactly as `CountVariants`' is.
+    let located: Vec<LocatedRecord> = file
+        .records
+        .iter()
+        .enumerate()
+        .map(|(index, record)| LocatedRecord {
+            index,
+            contig: record.contig.clone(),
+            start: record.start as i32,
+            stop: record.stop as i32,
+        })
+        .collect();
+    if gatk_engine::variant_source::intervals_for_traversal(intervals.as_deref()).is_some()
+        && !has_feature_index(&input)
+    {
+        return Err(Thrown {
+            failure: Failure::User,
+            exception: "org.broadinstitute.hellbender.exceptions.UserException",
+            message: Some(format!(
+                "Input {input} must support random access to enable traversal by intervals. \
+                 If it's a file, please index it using the bundled tool IndexFeatureFile"
+            )),
+        });
+    }
+
+    let mut pending: gatk_tools::select_variants::PendingWriter<
+        htsjdk_vcf::variant::VariantContext,
+    > = gatk_tools::select_variants::PendingWriter::new();
+    let mut written: Vec<htsjdk_vcf::variant::VariantContext> = Vec::new();
+    for located in gatk_engine::variant_source::traverse(&located, intervals.as_deref()) {
+        let original = &file.records[located.index];
+        // `apply` drains BEFORE it looks at the record, which is what lets a record trimmed onto a
+        // later start be written first.
+        for (_, vc) in pending.drain_before(&original.contig, original.start as i32) {
+            written.push(vc);
+        }
+
+        let bridged = crate::variant_bridge::to_engine(original);
+        if !gatk_tools::select_variants::keeps_before_subset(
+            &bridged.record,
+            &bridged.filter_record,
+            &filter_arguments,
+            &selection,
+        )
+        .map_err(select_error)?
+        {
+            continue;
+        }
+
+        let subset = gatk_tools::select_variants::subset_record(
+            &bridged.record,
+            &selection,
+            &subset_arguments,
+        )
+        .map_err(|error| Thrown {
+            failure: Failure::User,
+            exception: "org.broadinstitute.hellbender.exceptions.GATKException",
+            message: Some(error.message()),
+        })?;
+        // The second round of JEXL sees the record the subset produced, not the one that was read.
+        let after = crate::variant_bridge::to_engine(&crate::variant_bridge::from_engine(
+            original, &subset,
+        ));
+        if !gatk_tools::select_variants::keeps_after_subset(
+            &subset,
+            &after.filter_record,
+            &filter_arguments,
+        )
+        .map_err(select_error)?
+        {
+            continue;
+        }
+
+        let mut record = subset;
+        if output_arguments.set_filtered_genotypes_to_no_call {
+            gatk_tools::select_variants::set_filtered_genotypes_to_no_call(&mut record);
+        }
+        gatk_tools::select_variants::drop_annotations(&mut record, &output_arguments);
+        // The file's own record is built HERE and carried through the queue: the queue reorders,
+        // and nothing downstream could pair a reordered record with the one it was decoded from.
+        let vc = crate::variant_bridge::from_engine(original, &record);
+        pending.add(record, vc);
+    }
+    for (_, vc) in pending.drain() {
+        written.push(vc);
+    }
+
+    if sites_only {
+        for record in &mut written {
+            record.genotypes.clear();
+        }
+    }
+
+    let text = htsjdk_vcf::vcf_file::write_vcf(&header, &written).map_err(|error| Thrown {
+        failure: Failure::User,
+        exception: "org.broadinstitute.hellbender.exceptions.UserException",
+        message: Some(format!("{error:?}")),
+    })?;
+    write_variant_output(parser, &output, &text)?;
+    Ok(None)
+}
+
+/// A decoded record's position, which is all the traversal needs to select it.
+struct LocatedRecord {
+    index: usize,
+    contig: String,
+    start: i32,
+    stop: i32,
+}
+
+impl gatk_engine::variant_source::Located for LocatedRecord {
+    fn contig(&self) -> &str {
+        &self.contig
+    }
+    fn start(&self) -> i32 {
+        self.start
+    }
+    fn stop(&self) -> i32 {
+        self.stop
+    }
+}
+
+/// A `SelectError` as the reference throws it.
+fn select_error(error: gatk_tools::select_variants::SelectError) -> Thrown {
+    Thrown {
+        failure: Failure::User,
+        exception: error.java_class(),
+        message: Some(error.message()),
+    }
+}
+
+/// The arguments that decide which records survive, read off the command line.
+fn select_variants_filters(
+    parser: &Parser,
+) -> Result<gatk_tools::select_variants::FilterArguments, Thrown> {
+    use gatk_tools::select_variants::{AlleleRestriction, VariantType};
+
+    fn types(parser: &Parser, name: &str) -> Result<Vec<VariantType>, Thrown> {
+        arguments(parser, name)
+            .iter()
+            .map(|value| match value.as_str() {
+                "NO_VARIATION" => Ok(VariantType::NoVariation),
+                "SNP" => Ok(VariantType::Snp),
+                "MNP" => Ok(VariantType::Mnp),
+                "INDEL" => Ok(VariantType::Indel),
+                "SYMBOLIC" => Ok(VariantType::Symbolic),
+                "MIXED" => Ok(VariantType::Mixed),
+                other => Err(Thrown::command_line(format!(
+                    "'{other}' is not a valid value for {name}."
+                ))),
+            })
+            .collect()
+    }
+
+    let restriction = match argument(parser, "restrict-alleles-to").as_deref() {
+        Some("BIALLELIC") => AlleleRestriction::Biallelic,
+        Some("MULTIALLELIC") => AlleleRestriction::Multiallelic,
+        _ => AlleleRestriction::All,
+    };
+    Ok(gatk_tools::select_variants::FilterArguments {
+        types_to_include: types(parser, "select-type-to-include")?,
+        types_to_exclude: types(parser, "select-type-to-exclude")?,
+        allele_restriction: restriction,
+        max_indel_size: number_or(parser, "max-indel-size", i32::MAX),
+        min_indel_size: number_or(parser, "min-indel-size", 0),
+        keep_ids: arguments(parser, "keep-ids"),
+        exclude_ids: arguments(parser, "exclude-ids"),
+        exclude_filtered: flag(parser, "exclude-filtered"),
+        exclude_non_variants: flag(parser, "exclude-non-variants"),
+        max_filtered_genotypes: number_or(parser, "max-filtered-genotypes", i32::MAX),
+        min_filtered_genotypes: number_or(parser, "min-filtered-genotypes", 0),
+        max_fraction_filtered_genotypes: fraction(parser, "max-fraction-filtered-genotypes", 1.0),
+        min_fraction_filtered_genotypes: fraction(parser, "min-fraction-filtered-genotypes", 0.0),
+        max_nocall_number: number_or(parser, "max-nocall-number", i32::MAX),
+        max_nocall_fraction: fraction(parser, "max-nocall-fraction", 1.0),
+        select_expressions: arguments(parser, "select"),
+        select_genotype_expressions: arguments(parser, "select-genotype-expressions"),
+        invert_select: flag(parser, "invertSelect"),
+        apply_jexl_filters_first: flag(parser, "apply-jexl-filters-first"),
+    })
+}
+
+/// A `double` argument, or the declared default when it was not given.
+fn fraction(parser: &Parser, long_name: &str, default: f64) -> f64 {
+    scalar(parser, long_name)
+        .and_then(|text| text.parse().ok())
+        .unwrap_or(default)
+}
+
+/// The six argument groups `SelectVariants` has and this port does not.
+///
+/// Each is refused when it is SET rather than ignored: a run that quietly dropped
+/// `--select-random-fraction 0.5` would answer a question it was not asked, and a refusal that
+/// names the port is the honest form of a gap (`gatk_rs::PortLimitation`).
+fn select_variants_limits(parser: &Parser) -> Result<(), Thrown> {
+    let mut refused: Vec<&str> = Vec::new();
+    if argument(parser, "pedigree").is_some() {
+        refused.push("--pedigree");
+    }
+    for flagged in [
+        "mendelian-violation",
+        "invert-mendelian-violation",
+        "call-genotypes",
+    ] {
+        if flag(parser, flagged) {
+            refused.push(match flagged {
+                "mendelian-violation" => "--mendelian-violation",
+                "invert-mendelian-violation" => "--invert-mendelian-violation",
+                _ => "--call-genotypes",
+            });
+        }
+    }
+    if fraction(parser, "select-random-fraction", 1.0) != 1.0 {
+        refused.push("--select-random-fraction");
+    }
+    if fraction(parser, "remove-fraction-genotypes", 0.0) != 0.0 {
+        refused.push("--remove-fraction-genotypes");
+    }
+    if argument(parser, "concordance").is_some() {
+        refused.push("--concordance");
+    }
+    if argument(parser, "discordance").is_some() {
+        refused.push("--discordance");
+    }
+    if argument(parser, "variant-output-filtering").is_some() {
+        refused.push("--variant-output-filtering");
+    }
+    if refused.is_empty() {
+        return Ok(());
+    }
+    Err(Thrown::non_user(
+        PORT_LIMITATION,
+        format!(
+            "SelectVariants in this port does not implement {}: a pedigree's Mendelian \
+             violations, the two random fractions, the concordance tracks, the genotype caller \
+             and the output filtering mode each reach behaviour no measured static reproduces, \
+             and answering without them would be a different answer rather than a refusal",
+            refused.join(", ")
+        ),
+    ))
+}
+
+/// `##GATKCommandLine=<ID=...,CommandLine="...",Version=...,Date=...>`, or nothing.
+///
+/// The four fields are in the reference's own order, and the value of the third is the toolkit
+/// version this port claims. The fourth is the run's own wall-clock time, which is why the header
+/// construction takes this as an input rather than building it: a golden of a file carrying it
+/// would move on every run, and the `select-variants-header` suite elides it for that reason.
+fn command_line_header_line(parser: &Parser) -> Option<htsjdk_vcf::header::HeaderLine> {
+    if !flag(parser, "add-output-vcf-command-line") {
+        return None;
+    }
+    Some(htsjdk_vcf::header::HeaderLine::Structured {
+        key: "GATKCommandLine".to_string(),
+        fields: vec![
+            ("ID".to_string(), "SelectVariants".to_string()),
+            (
+                "CommandLine".to_string(),
+                crate::command_line::expanded("SelectVariants", parser),
+            ),
+            ("Version".to_string(), crate::TOOLKIT_VERSION.to_string()),
+            ("Date".to_string(), display_date_time()),
+        ],
+    })
+}
+
+/// `Utils.getDateTimeForDisplay(ZonedDateTime.now())`, which is
+/// `DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG)` under the US locale the reference
+/// pins: `September 3, 2026 at 1:38:54 AM UTC`, measured from the pinned container.
+///
+/// The ZONE here is UTC where the reference uses the machine's own, and the difference is
+/// deliberate rather than overlooked: the field holds the instant the run happened, so no two runs
+/// agree on it and no golden can compare it. The pinned container runs UTC, which is where every
+/// measurement of this port is made. Reproducing a local zone's abbreviation would need a tz
+/// database for a field nothing checks.
+fn display_date_time() -> String {
+    const MONTHS: [&str; 12] = [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ];
+    let seconds = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|since| since.as_secs() as i64)
+        .unwrap_or(0);
+    let days = seconds.div_euclid(86_400);
+    let time_of_day = seconds.rem_euclid(86_400);
+    // `days` since 1970-01-01 to a civil date, by Howard Hinnant's `civil_from_days`.
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let shifted_month = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * shifted_month + 2) / 5 + 1;
+    let month = if shifted_month < 10 {
+        shifted_month + 3
+    } else {
+        shifted_month - 9
+    };
+    let year = if month <= 2 { year + 1 } else { year };
+
+    let hour24 = time_of_day / 3600;
+    let minute = (time_of_day % 3600) / 60;
+    let second = time_of_day % 60;
+    // A twelve-hour clock, where midnight is 12 AM and noon is 12 PM.
+    let hour = match hour24 % 12 {
+        0 => 12,
+        other => other,
+    };
+    let meridiem = if hour24 < 12 { "AM" } else { "PM" };
+    format!(
+        "{} {}, {} at {}:{:02}:{:02} {} UTC",
+        MONTHS[(month - 1) as usize],
+        day,
+        year,
+        hour,
+        minute,
+        second,
+        meridiem
+    )
+}
+
+/// The VCF a variant-writing tool leaves behind: the text, block compressed where the name says so,
+/// with the index the arguments ask for beside it.
+fn write_variant_output(parser: &Parser, output: &str, text: &str) -> Result<(), Thrown> {
+    let block_compressed = output.ends_with(".gz") || output.ends_with(".bgz");
+    let bytes = if block_compressed {
+        let (level, deflater) = output_compression(parser);
+        let mut writer = htsjdk_bgzf::BgzfWriter::with_deflater(Vec::new(), level, deflater);
+        std::io::Write::write_all(&mut writer, text.as_bytes())
+            .map_err(|error| Thrown::non_user(PORT_FAILURE, format!("{error}")))?;
+        writer
+            .into_inner()
+            .map_err(|error| Thrown::non_user(PORT_FAILURE, format!("{error}")))?
+    } else {
+        text.as_bytes().to_vec()
+    };
+    std::fs::write(output, &bytes).map_err(|error| {
+        Thrown::non_user(PORT_FAILURE, format!("could not write {output}: {error}"))
+    })?;
+
+    if !flag(parser, "create-output-variant-index") {
+        return Ok(());
+    }
+    let dictionary: Vec<(String, i32)> = text
+        .lines()
+        .take_while(|line| line.starts_with('#'))
+        .filter_map(|line| {
+            let body = line.strip_prefix("##contig=<")?.trim_end_matches('>');
+            let name = body.split(',').find_map(|f| f.strip_prefix("ID="))?;
+            let length = body
+                .split(',')
+                .find_map(|f| f.strip_prefix("length="))
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(0);
+            Some((name.to_string(), length))
+        })
+        .collect();
+    let mut source = index_feature_file::Source::new(output);
+    source.timestamp = modified_millis(output);
+    let index = match index_feature_file::index_kind(output) {
+        index_feature_file::IndexKind::Tabix => {
+            let (level, deflater) = output_compression(parser);
+            gatk_tools::index_feature_file::build_tabix(&bytes, &source, output, deflater, level)
+                .map_err(|refusal| Thrown {
+                    failure: Failure::User,
+                    exception: refusal.java_class(),
+                    message: Some(refusal.message()),
+                })?
+        }
+        _ => on_the_fly_index(
+            text,
+            &dictionary,
+            output,
+            bytes.len() as i64,
+            source.timestamp,
+        ),
+    };
+    let companion = index_feature_file::default_output(output);
+    std::fs::write(&companion, index).map_err(|error| {
+        Thrown::non_user(
+            PORT_FAILURE,
+            format!("could not write {companion}: {error}"),
+        )
+    })
 }

--- a/crates/gatk-cli/src/variant_bridge.rs
+++ b/crates/gatk-cli/src/variant_bridge.rs
@@ -1,0 +1,288 @@
+//! Between htsjdk's `VariantContext` and the reduced record the ported statics read.
+//!
+//! # Why there are two models at all
+//!
+//! `htsjdk_vcf::variant::VariantContext` is the file: an id, a QUAL, applied-or-not filters, typed
+//! attributes and genotypes whose alleles are alleles. `gatk_engine::variant_context_utils::Variant`
+//! is what the ported GATK statics were written against, and it is deliberately smaller -- "as much
+//! of a `VariantContext` as these functions read and write", which is the contig, the span, the
+//! alleles, the genotypes and the attributes as strings. Neither is wrong. A tool that only decides
+//! whether to keep a record needs the small one; a tool that WRITES the record back needs the file.
+//!
+//! `SelectVariants` is the first ported tool that needs both, so this is where they meet.
+//!
+//! # The rule that makes the trip lossless
+//!
+//! Going down is a rendering: every attribute becomes the string the encoder would have written.
+//! Going back up is NOT the inverse rendering, because it cannot be: a decoded INFO flag is
+//! `Value::Bool(true)` and prints as `KEY`, while the string it renders to is empty and would print
+//! as `KEY=`. So the trip back is a DIFF against the record it came from. A key whose rendered
+//! string is unchanged keeps the original `Value` -- flag, list and all -- and only a key the
+//! pipeline actually rewrote becomes a `Value::Str`. The three the pipeline rewrites are AC, AN and
+//! AF, which `calculateChromosomeCounts` sets as text in the reference as well.
+//!
+//! Genotype alleles make the same trip through indices, because that is what
+//! `gatk_engine::subset_alleles` works in: a call is a position in the record's allele list and a
+//! no-call is `None`. The list they index is the record's list AFTER the subset, which is why the
+//! write-back reads the alleles it is given rather than the ones the original carried.
+
+use std::collections::HashMap;
+
+use gatk_engine::subset_alleles::Genotype as EngineGenotype;
+use gatk_engine::variant_context_utils::{Allele as EngineAllele, Variant};
+use gatk_tools::select_variants::{FilterRecord, Record};
+use htsjdk_vcf::allele::Allele as VcfAllele;
+use htsjdk_vcf::variant::{Genotype as VcfGenotype, Value, VariantContext};
+
+/// One record in both models, with the file's own copy kept for the write-back's diff.
+pub struct Bridged {
+    /// The record as it was decoded. Nothing writes to it; it is the baseline the diff is against.
+    pub original: VariantContext,
+    pub record: Record,
+    pub filter_record: FilterRecord,
+}
+
+/// What `Value.format()` would write, which is what the string model holds.
+///
+/// `None` is the one thing a string model cannot represent, and only a `false` flag produces it;
+/// such a field is dropped by the encoder, so the empty string here is a value no key reaches.
+fn rendered(value: &Value) -> String {
+    value.format().unwrap_or_default()
+}
+
+/// The bases the reduced model measures: the DISPLAY string, so that `*` stays one base and a
+/// symbolic allele keeps its angle brackets rather than becoming empty.
+fn engine_allele(allele: &VcfAllele) -> EngineAllele {
+    EngineAllele {
+        bases: allele.display_string().into_bytes(),
+        is_reference: allele.is_reference(),
+    }
+}
+
+/// The index of a genotype's allele in the record's list, which is how the reference stores a call.
+///
+/// A no-call is `None`. An allele the record does not declare is `None` as well rather than an
+/// error: htsjdk's own `GenotypesContext` allows it, and the reference reads such a call as no
+/// call when it counts chromosomes.
+fn allele_index(alleles: &[VcfAllele], allele: &VcfAllele) -> Option<usize> {
+    if allele.is_no_call() {
+        return None;
+    }
+    alleles.iter().position(|candidate| candidate == allele)
+}
+
+fn engine_genotype(genotype: &VcfGenotype, alleles: &[VcfAllele]) -> EngineGenotype {
+    let mut attributes: Vec<(String, String)> = Vec::new();
+    // `FT` is a field of its own in htsjdk and an attribute in the reduced model, and it is the
+    // attribute `setFilteredGenotypeToNocall` reads, so it goes first.
+    if let Some(filters) = &genotype.filters {
+        attributes.push(("FT".to_string(), filters.clone()));
+    }
+    for (key, value) in &genotype.extended {
+        attributes.push((key.clone(), rendered(value)));
+    }
+    EngineGenotype {
+        alleles: genotype
+            .alleles
+            .iter()
+            .map(|allele| allele_index(alleles, allele))
+            .collect(),
+        pl: genotype.pl.clone(),
+        gq: genotype.gq,
+        ad: genotype.ad.clone(),
+        dp: genotype.dp,
+        attributes,
+    }
+}
+
+/// The record as the ported statics read it, with the file's copy kept beside it.
+pub fn to_engine(vc: &VariantContext) -> Bridged {
+    let genotypes: Vec<EngineGenotype> = vc
+        .genotypes
+        .iter()
+        .map(|genotype| engine_genotype(genotype, &vc.alleles))
+        .collect();
+    let variant = Variant {
+        contig: vc.contig.clone(),
+        start: vc.start as i32,
+        stop: vc.stop as i32,
+        alleles: vc.alleles.iter().map(engine_allele).collect(),
+        genotypes,
+        attributes: vc
+            .attributes
+            .iter()
+            .map(|(key, value)| (key.clone(), rendered(value)))
+            .collect(),
+    };
+    // `VariantContextUtils.match`'s view of the record: what a JEXL expression can name, which is
+    // the id, the filters, the INFO map and one map per genotype.
+    let filter_record = FilterRecord {
+        id: vc.id.clone(),
+        filters: vc.filters.clone().unwrap_or_default(),
+        info: vc
+            .attributes
+            .iter()
+            .map(|(key, value)| (key.clone(), rendered(value)))
+            .collect::<HashMap<String, String>>(),
+        genotype_fields: vc
+            .genotypes
+            .iter()
+            .map(|genotype| {
+                let mut fields: HashMap<String, String> = genotype
+                    .extended
+                    .iter()
+                    .map(|(key, value)| (key.clone(), rendered(value)))
+                    .collect();
+                if let Some(filters) = &genotype.filters {
+                    fields.insert("FT".to_string(), filters.clone());
+                }
+                if let Some(gq) = genotype.gq {
+                    fields.insert("GQ".to_string(), gq.to_string());
+                }
+                if let Some(dp) = genotype.dp {
+                    fields.insert("DP".to_string(), dp.to_string());
+                }
+                fields
+            })
+            .collect(),
+    };
+    Bridged {
+        original: vc.clone(),
+        record: Record {
+            variant,
+            samples: vc
+                .genotypes
+                .iter()
+                .map(|genotype| genotype.sample_name.clone())
+                .collect(),
+        },
+        filter_record,
+    }
+}
+
+/// An engine allele back as the file's, by identity where the record already had it.
+///
+/// Identity rather than reconstruction, because `Allele::create` is not a total inverse of
+/// `display_string`: a symbolic allele's brackets and the star allele go through it, and htsjdk's
+/// own equality counts the reference flag. An allele the subset produced that the original did not
+/// carry cannot be looked up, and that one is built.
+fn vcf_allele(original: &[VcfAllele], allele: &EngineAllele) -> VcfAllele {
+    let text = String::from_utf8_lossy(&allele.bases).to_string();
+    original
+        .iter()
+        .find(|candidate| {
+            candidate.display_string() == text && candidate.is_reference() == allele.is_reference
+        })
+        .cloned()
+        .unwrap_or_else(|| {
+            VcfAllele::from_str(&text, allele.is_reference).unwrap_or_else(|_| VcfAllele::no_call())
+        })
+}
+
+/// The attributes of the written record: the original's `Value` wherever the string is unchanged,
+/// and a `Value::Str` wherever the pipeline rewrote it.
+///
+/// Order is the engine's, which is the original's order with anything added at the end, because
+/// that is where `set_attribute` puts a key the record did not have. The encoder sorts, so the
+/// order does not reach the file; it is kept so that a divergence can be read.
+fn written_attributes(
+    original: &[(String, Value)],
+    engine: &[(String, String)],
+) -> Vec<(String, Value)> {
+    engine
+        .iter()
+        .map(|(key, text)| {
+            let held = original
+                .iter()
+                .find(|(name, _)| name == key)
+                .filter(|(_, value)| rendered(value) == *text);
+            match held {
+                Some((_, value)) => (key.clone(), value.clone()),
+                None => (key.clone(), Value::Str(text.clone())),
+            }
+        })
+        .collect()
+}
+
+fn written_genotype(
+    original: Option<&VcfGenotype>,
+    sample_name: &str,
+    genotype: &EngineGenotype,
+    alleles: &[VcfAllele],
+) -> VcfGenotype {
+    let filters = genotype
+        .attributes
+        .iter()
+        .find(|(key, _)| key == "FT")
+        .map(|(_, value)| value.clone());
+    let extended: Vec<(String, String)> = genotype
+        .attributes
+        .iter()
+        .filter(|(key, _)| key != "FT")
+        .cloned()
+        .collect();
+    VcfGenotype {
+        sample_name: sample_name.to_string(),
+        alleles: genotype
+            .alleles
+            .iter()
+            .map(|call| match call {
+                Some(index) => alleles
+                    .get(*index)
+                    .cloned()
+                    .unwrap_or_else(VcfAllele::no_call),
+                None => VcfAllele::no_call(),
+            })
+            .collect(),
+        phased: original.is_some_and(|genotype| genotype.phased),
+        gq: genotype.gq,
+        dp: genotype.dp,
+        ad: genotype.ad.clone(),
+        pl: genotype.pl.clone(),
+        filters,
+        extended: written_attributes(
+            original
+                .map(|genotype| genotype.extended.as_slice())
+                .unwrap_or(&[]),
+            &extended,
+        ),
+    }
+}
+
+/// The record to write: the one that was decoded, with what the pipeline changed applied to it.
+///
+/// The id, the QUAL and the applied-or-not distinction of the filters are carried across
+/// untouched, because nothing in the pipeline can reach them: `SelectVariants` selects records and
+/// rewrites alleles, and a record it keeps is the record the file had.
+pub fn from_engine(original: &VariantContext, record: &Record) -> VariantContext {
+    let alleles: Vec<VcfAllele> = record
+        .variant
+        .alleles
+        .iter()
+        .map(|allele| vcf_allele(&original.alleles, allele))
+        .collect();
+    let genotypes = record
+        .variant
+        .genotypes
+        .iter()
+        .zip(record.samples.iter())
+        .map(|(genotype, sample_name)| {
+            let held = original
+                .genotypes
+                .iter()
+                .find(|candidate| candidate.sample_name == *sample_name);
+            written_genotype(held, sample_name, genotype, &alleles)
+        })
+        .collect();
+    VariantContext {
+        contig: record.variant.contig.clone(),
+        start: record.variant.start as i64,
+        stop: record.variant.stop as i64,
+        id: original.id.clone(),
+        alleles,
+        log10_p_error: original.log10_p_error,
+        filters: original.filters.clone(),
+        attributes: written_attributes(&original.attributes, &record.variant.attributes),
+        genotypes,
+    }
+}

--- a/crates/gatk-tools/src/select_variants.rs
+++ b/crates/gatk-tools/src/select_variants.rs
@@ -968,26 +968,31 @@ pub fn drop_annotations(record: &mut Record, arguments: &OutputArguments) {
 /// changes, then adds the record it just finished. `onTraversalSuccess` drains the rest. The queue
 /// exists because trimming moves a record RIGHT, so a file written in the order it was read would
 /// not be sorted; it is the tool repairing an order it broke itself.
+///
+/// `T` is whatever the caller wants back beside the record. A tool that only measures the ORDER
+/// passes `()`; a runner that has to write the file passes the record the file was decoded from,
+/// because the queue reorders and nothing else can pair the two afterwards. The ordering itself
+/// reads only the record, so the payload cannot change the answer.
 #[derive(Debug, Default)]
-pub struct PendingWriter {
-    pending: Vec<Record>,
+pub struct PendingWriter<T = ()> {
+    pending: Vec<(Record, T)>,
 }
 
-impl PendingWriter {
-    pub fn new() -> PendingWriter {
+impl<T> PendingWriter<T> {
+    pub fn new() -> PendingWriter<T> {
         PendingWriter {
             pending: Vec::new(),
         }
     }
 
     /// What is written before `record` is read, in order.
-    pub fn drain_before(&mut self, contig: &str, start: i32) -> Vec<Record> {
+    pub fn drain_before(&mut self, contig: &str, start: i32) -> Vec<(Record, T)> {
         let mut written = Vec::new();
         // `PriorityQueue.peek` is the smallest start; ties keep insertion order here, which is the
         // order the reference's heap gives for equal keys of a two-element comparison.
         while let Some(head) = self.head() {
-            let same_contig = self.pending[head].variant.contig == contig;
-            if same_contig && self.pending[head].variant.start > start {
+            let same_contig = self.pending[head].0.variant.contig == contig;
+            if same_contig && self.pending[head].0.variant.start > start {
                 break;
             }
             written.push(self.pending.remove(head));
@@ -996,12 +1001,12 @@ impl PendingWriter {
     }
 
     /// The record joins the queue rather than the file.
-    pub fn add(&mut self, record: Record) {
-        self.pending.push(record);
+    pub fn add(&mut self, record: Record, payload: T) {
+        self.pending.push((record, payload));
     }
 
     /// `onTraversalSuccess`: whatever is left, in start order.
-    pub fn drain(&mut self) -> Vec<Record> {
+    pub fn drain(&mut self) -> Vec<(Record, T)> {
         let mut written = Vec::new();
         while let Some(head) = self.head() {
             written.push(self.pending.remove(head));
@@ -1013,7 +1018,7 @@ impl PendingWriter {
         self.pending
             .iter()
             .enumerate()
-            .min_by_key(|(index, record)| (record.variant.start, *index))
+            .min_by_key(|(index, (record, _))| (record.variant.start, *index))
             .map(|(index, _)| index)
     }
 }

--- a/crates/gatk-tools/tests/select_variants_output.rs
+++ b/crates/gatk-tools/tests/select_variants_output.rs
@@ -220,18 +220,25 @@ fn written(records: &[Record], header_samples: &[String], run: &str) -> Vec<Reco
     let (sample_arguments, subset_arguments, output_arguments) = setup(run);
     let selection =
         create_sample_name_inclusion_list(header_samples, &sample_arguments).expect("a selection");
-    let mut writer = PendingWriter::new();
-    let mut out = Vec::new();
+    // The queue carries a payload for a caller that has to write the file; this suite measures the
+    // ORDER, so its payload is the unit and the pairs are unwrapped on the way out.
+    let mut writer: PendingWriter<()> = PendingWriter::new();
+    let mut out: Vec<Record> = Vec::new();
     for record in records {
-        out.extend(writer.drain_before(&record.variant.contig, record.variant.start));
+        out.extend(
+            writer
+                .drain_before(&record.variant.contig, record.variant.start)
+                .into_iter()
+                .map(|(record, ())| record),
+        );
         let mut result = subset_record(record, &selection, &subset_arguments).expect("a subset");
         if output_arguments.set_filtered_genotypes_to_no_call {
             set_filtered_genotypes_to_no_call(&mut result);
         }
         drop_annotations(&mut result, &output_arguments);
-        writer.add(result);
+        writer.add(result, ());
     }
-    out.extend(writer.drain());
+    out.extend(writer.drain().into_iter().map(|(record, ())| record));
     out
 }
 


### PR DESCRIPTION
Draft, and deliberately so: the runner reproduces the reference byte for byte on the path that rebuilds genotypes, and cannot on the other one until IPNP-BIPN/htsjdk-rs#222 lands. Stacked on #1073, which measures the header it writes.

Measured both ways against the container, same input:

```
input                     GT:GQ:DP:XX
reference, whole cohort   GT:GQ:DP:XX   <- the FILE's order
reference, -sn s0 -sn s1  GT:DP:GQ:XX   <- recomputed and sorted
this port, either way     GT:DP:GQ:XX
```

htsjdk writes a record whose genotypes nobody decoded from the file's own bytes; `read_vcf` decodes eagerly and drops that substring. The site fields are re-encoded on both paths (INFO is sorted either way), so it is a genotype-column rule, and no change here can repair it.

What is here: `variant_bridge` (the trip back is a diff against the decoded record, so a flag stays a flag), the traversal in the reference's order over the ported statics, a shared variant-walker startup so the refusal ORDER is not copied twice, a payload on `PendingWriter` so a reordered record can be paired with its original, `PortLimitation` refusals for the six argument groups no measured static reproduces, and `##GATKCommandLine` with the date format measured from the container.

Towards #1074.