### PR TITLE
Refuse an enabled-and-disabled filter where the reference refuses it

### DIFF
--- a/crates/gatk-barclay/src/lib.rs
+++ b/crates/gatk-barclay/src/lib.rs
@@ -1251,6 +1251,15 @@ pub struct Parser {
     plugin_resolution: Option<PluginResolution>,
     /// The plugins the tool handed the descriptor as defaults, which count as selected.
     default_plugins: Vec<String>,
+    /// `pluginDescriptor.validateAndResolvePlugins()`, which is the descriptor's OWN validation
+    /// and not the parser's.
+    ///
+    /// It lives here rather than in the caller because of WHEN it runs: `validateArgumentValues`
+    /// calls it before it walks the definitions, so a command line that both names a filter twice
+    /// and breaks a mutex reports the filter. A port that ran it after parsing reported the mutex
+    /// (#1070).
+    #[allow(clippy::type_complexity)]
+    plugin_validation: Option<Box<dyn Fn(&Parser) -> Result<(), Error>>>,
     /// `argumentsFilesLoadedAlready`.
     ///
     /// Parser state rather than per-call state, because the recursion is the same parser calling
@@ -1269,6 +1278,7 @@ impl Parser {
             append_to_collections: false,
             plugin_resolution: None,
             default_plugins: Vec::new(),
+            plugin_validation: None,
             arguments_files_loaded_already: Vec::new(),
         }
     }
@@ -1277,6 +1287,15 @@ impl Parser {
     /// before the required check.
     pub fn with_plugin_resolution(mut self, resolution: PluginResolution) -> Self {
         self.plugin_resolution = Some(resolution);
+        self
+    }
+
+    /// The descriptor's own validation, which runs where the reference runs it.
+    pub fn with_plugin_validation(
+        mut self,
+        validate: impl Fn(&Parser) -> Result<(), Error> + 'static,
+    ) -> Self {
+        self.plugin_validation = Some(Box::new(validate));
         self
     }
 
@@ -1663,7 +1682,14 @@ impl Parser {
     /// `validateArgumentValues()`: every definition, in declaration order, so the first missing
     /// required argument reported is the first one declared.
     fn validate_argument_values(&self) -> Result<(), Error> {
-        for definition in self.validate_plugin_argument_values()? {
+        let definitions = self.validate_plugin_argument_values()?;
+        // The descriptor's own validation, BEFORE the per-definition walk: this is where the
+        // reference decides that a read filter is both enabled and disabled, and a command line
+        // that also breaks a mutex reports the filter rather than the mutex.
+        if let Some(validate) = &self.plugin_validation {
+            validate(self)?;
+        }
+        for definition in definitions {
             // The partners that were actually given, by long name, in the annotation's order.
             let provided: Vec<String> = definition
                 .annotation

--- a/crates/gatk-cli/src/lib.rs
+++ b/crates/gatk-cli/src/lib.rs
@@ -345,12 +345,20 @@ fn parser_for(
     list: &'static [gatk_tools::tool_declarations::Declaration],
 ) -> gatk_barclay::Parser {
     let parser = gatk_barclay::Parser::new(definitions::definitions(list));
-    match gatk_tools::plugin_ownership::default_filters(tool) {
+    let parser = match gatk_tools::plugin_ownership::default_filters(tool) {
         None => parser,
         Some(defaults) => {
             parser.with_default_plugins(defaults.iter().map(|name| (*name).to_string()).collect())
         }
-    }
+    };
+    // `GATKReadFilterPluginDescriptor.validateAndResolvePlugins()`, which the parser runs before
+    // it walks the definitions. The resolution itself is the same one the runner asks for; what
+    // this places is WHEN it refuses, and the difference is visible on a command line that breaks
+    // two rules at once (#1070).
+    let owned = tool.to_string();
+    parser.with_plugin_validation(move |parser| {
+        runners::resolve_read_filters_in(parser, &owned).map(|_| ())
+    })
 }
 
 /// The port's own refusal, which the reference has no equivalent of.

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -253,6 +253,23 @@ fn resolve_read_filters(
     parser: &Parser,
     tool: &str,
 ) -> Result<Vec<gatk_tools::filter_resolution::ResolvedFilter>, Thrown> {
+    resolve_read_filters_in(parser, tool).map_err(|error| Thrown {
+        // Every one of them is a `CommandLineException`, which is status ONE.
+        failure: Failure::CommandLine,
+        exception: error.class,
+        message: Some(error.message),
+    })
+}
+
+/// The same resolution as the parser's own, which is where it FIRST runs.
+///
+/// The descriptor validates while the command line is parsed, so by the time a runner asks, the
+/// answer is either already a refusal or cannot become one. It is asked twice rather than cached
+/// because the resolution is a pure function of four arguments and the tool's defaults.
+pub(crate) fn resolve_read_filters_in(
+    parser: &Parser,
+    tool: &str,
+) -> Result<Vec<gatk_tools::filter_resolution::ResolvedFilter>, gatk_barclay::Error> {
     // The descriptor owns FOUR arguments, and reading two of them was a port that ignored
     // `--disable-read-filter` and `--inverted-read-filter` entirely. `filter-resolution` measured
     // what all four decide, including the order and the six refusals.
@@ -264,11 +281,9 @@ fn resolve_read_filters(
         &arguments(parser, "inverted-read-filter"),
         flag(parser, "disable-tool-default-read-filters"),
     )
-    .map_err(|error| Thrown {
-        // Every one of them is a `CommandLineException`, which is status ONE.
-        failure: Failure::CommandLine,
-        exception: error.java_class(),
-        message: Some(error.message()),
+    .map_err(|error| gatk_barclay::Error {
+        class: error.java_class(),
+        message: error.message(),
     })
 }
 


### PR DESCRIPTION
A row of `ApplyBQSR`'s covering array broke two rules at once — `--quantize-quals` beside its mutex partner, and `MappedReadFilter` named by both `--read-filter` and `--disable-read-filter` — and the two sides reported different ones:

```
reference  A USER ERROR has occurred: The read filter(s): MappedReadFilter are both enabled and disabled
port       Argument 'quantize-quals' cannot be used in conjunction with argument(s) ...
```

Both refusals were already ported; what was wrong is where one of them lives. `validateArgumentValues()` runs `pluginDescriptor.validateAndResolvePlugins()` before it walks the definitions, and GATK's read-filter descriptor is what raises the enabled-and-disabled conflict, so it precedes every mutex check. The port raised it from `resolve_read_filters` in the runner, after parsing had finished.

`Parser` gains the hook the reference has: a descriptor validation between the plugin trim and the per-definition walk. `parser_for` installs the same resolution the runner asks for, so the refusal becomes a parse-time one.

Measured on the row that found it: the port now answers the reference's message and leaves 1.

Closes #1070.