### PR TITLE
Freeze CountVariants' new number

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -160,7 +160,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
 | `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, filter-resolution, interval-arguments, read-walker-refusals, tool-argument-declarations, tool-argument-enums, usage-text | 9 | t=2, 21/21 rows (100%) |
-| `CountVariants` | variant-walker | oracle-backed | count-variants, interval-arguments, sequence-dictionary-validation, tool-argument-declarations, tool-argument-enums | 5 | not measured |
+| `CountVariants` | variant-walker | oracle-backed | count-variants, interval-arguments, sequence-dictionary-validation, tool-argument-declarations, tool-argument-enums | 5 | t=2, 23/23 rows (100%) |
 | `CreateHadoopBamSplittingIndex` | unclassified | oracle-backed | splitting-index | 1 | t=2, 11/11 rows (100%) |
 | `CreateReadCountPanelOfNormals` | cnv-segmentation | oracle-backed | create-read-count-panel-of-normals | 1 | not measured |
 | `CreateSomaticPanelOfNormals` | variant-transform | oracle-backed | brent-optimizer, create-somatic-panel-of-normals | 2 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -42,6 +42,15 @@
       "t": 2,
       "share": 1.0
     },
+    "CountVariants": {
+      "rows": 23,
+      "accepted": 13,
+      "rejected": 10,
+      "distinct_outputs": 4,
+      "matched": 23,
+      "t": 2,
+      "share": 1.0
+    },
     "CreateHadoopBamSplittingIndex": {
       "rows": 11,
       "accepted": 8,


### PR DESCRIPTION
Run 33708897777 on `main`. All eight tools at share 1.000; `CountVariants` reproduced all 23 rows, 13 of them traversals it could not reach while half its array paired a `--read-index` with a feature file.