### PR TITLE
Declare CountBases and FlagStat, the archetype's other two

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,16 +418,20 @@ jobs:
             suites: "interval-arguments filter-resolution expanded-command-line main-non-user main-entry"
           - group: oracle-backed
             index: "58/60"
-            slug: "splitting-index-allele-frequency-qc-calculate-contamination-tool-argument-declarations-usage-text"
-            suites: "splitting-index allele-frequency-qc calculate-contamination tool-argument-declarations usage-text"
+            slug: "splitting-index-allele-frequency-qc-calculate-contamination-usage-text-bwa-index-image"
+            suites: "splitting-index allele-frequency-qc calculate-contamination usage-text bwa-index-image"
           - group: oracle-backed
             index: "59/60"
-            slug: "bwa-index-image-tool-argument-enums-tool-argument-value-classes-plugin-argument-ownership-read-filter-catalogue"
-            suites: "bwa-index-image tool-argument-enums tool-argument-value-classes plugin-argument-ownership read-filter-catalogue"
+            slug: "tool-argument-enums-tool-argument-value-classes-plugin-argument-ownership-read-filter-catalogue-mutex-target-names"
+            suites: "tool-argument-enums tool-argument-value-classes plugin-argument-ownership read-filter-catalogue mutex-target-names"
           - group: oracle-backed
             index: "60/60"
-            slug: "mutex-target-names-count-reads-plumbing-read-walker-refusals"
-            suites: "mutex-target-names count-reads-plumbing read-walker-refusals"
+            slug: "count-reads-plumbing-read-walker-refusals"
+            suites: "count-reads-plumbing read-walker-refusals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "tool-argument-declarations"
+            suites: "tool-argument-declarations"
     steps:
       - uses: actions/checkout@v7
 

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -520,16 +520,25 @@ pub fn number(parser: &Parser, long_name: &str) -> i32 {
         .unwrap_or(0)
 }
 
-/// `CountReads.doWork`, with the input read and the output written.
+/// Everything `GATKTool.onStartup` does for a READ walker, up to the record the traversal reads.
 ///
-/// Three things the `count-reads-plumbing` golden pins and this reproduces: the tool RETURNS the
-/// count, so `handleResult` prints a number; `-O` receives that number and nothing else, with no
-/// trailing newline, because the reference writes it with `print`; and `-O` does not suppress the
-/// return, so the file is written AND the value comes back.
-pub fn count_reads(parser: &Parser) -> Outcome {
-    // The plugin descriptor is validated while the command line is PARSED, so its refusals come
-    // before the input is even opened.
-    let resolved_filters = resolve_read_filters(parser, "CountReads")?;
+/// Shared rather than copied, because the ORDER is what a covering-array row over any of these
+/// tools measures: `loadMasterSequenceDictionary`, `initializeReference`, `initializeReads`,
+/// `initializeIntervals`, `validateSequenceDictionaries`, the traversal bounds, and only then the
+/// record parse. A port that asked the reader first answered a later question first (#69), and
+/// three tools of one archetype copying that order three times is three chances to get it wrong.
+///
+/// The filter is NOT built here. `read_filter` borrows the header, and a struct that owned both
+/// would be self-referential; the caller builds it in one line from what this returns.
+struct ReadWalkerStart {
+    source: ReadsDataSource,
+    header: SamHeader,
+    intervals: Vec<gatk_engine::interval::SimpleInterval>,
+    filters: Vec<gatk_tools::filter_resolution::ResolvedFilter>,
+}
+
+fn read_walker_startup(parser: &Parser, tool: &str) -> Result<ReadWalkerStart, Thrown> {
+    let resolved_filters = resolve_read_filters(parser, tool)?;
     // `--input` is a COLLECTION on a read walker, not a scalar: the reference takes more than one
     // BAM and merges their headers. This port reads one, which is what every case of the golden
     // hands it, and refuses the rest rather than silently counting the first.
@@ -687,8 +696,30 @@ pub fn count_reads(parser: &Parser) -> Outcome {
         return Err(Thrown::non_user(refusal.exception(), refusal.message()));
     }
     let source = source.expect("a source, since the parse refusal was not taken");
+    Ok(ReadWalkerStart {
+        source,
+        header,
+        intervals,
+        filters: resolved_filters,
+    })
+}
+/// `CountReads.doWork`, with the input read and the output written.
+///
+/// Three things the `count-reads-plumbing` golden pins and this reproduces: the tool RETURNS the
+/// count, so `handleResult` prints a number; `-O` receives that number and nothing else, with no
+/// trailing newline, because the reference writes it with `print`; and `-O` does not suppress the
+/// return, so the file is written AND the value comes back.
+pub fn count_reads(parser: &Parser) -> Outcome {
+    // The plugin descriptor is validated while the command line is PARSED, so its refusals come
+    // before the input is even opened.
+    let ReadWalkerStart {
+        source,
+        header,
+        intervals,
+        filters,
+    } = read_walker_startup(parser, "CountReads")?;
 
-    let filter = read_filter(parser, &resolved_filters, &header)?;
+    let filter = read_filter(parser, &filters, &header)?;
     let count = gatk_tools::count_reads::count_reads(&source, &intervals, &filter)
         .map_err(|error| Thrown::user(format!("{error:?}")))?;
 
@@ -1773,4 +1804,70 @@ fn number_or(parser: &Parser, long_name: &str, default: i32) -> i32 {
     scalar(parser, long_name)
         .and_then(|text| text.parse().ok())
         .unwrap_or(default)
+}
+
+/// `CountBases.doWork`: the same traversal `CountReads` runs, summing lengths instead of records.
+///
+/// The whole startup is shared, which is the point of doing an archetype rather than a tool: these
+/// two declare the same seventy arguments as `CountReads` and differ in one line of `apply` and in
+/// what is printed.
+pub fn count_bases(parser: &Parser) -> Outcome {
+    let ReadWalkerStart {
+        source,
+        header,
+        intervals,
+        filters,
+    } = read_walker_startup(parser, "CountBases")?;
+
+    let filter = read_filter(parser, &filters, &header)?;
+    let count = gatk_tools::count_reads::count_bases(&source, &intervals, &filter)
+        .map_err(|error| Thrown::user(format!("{error:?}")))?;
+
+    if let Some(output) = argument(parser, "output") {
+        // `print`, not `println`: the file is the number's digits and nothing else.
+        std::fs::write(&output, gatk_tools::count_reads::output(count))
+            .map_err(|error| Thrown::non_user(PORT_FAILURE, format!("{output}: {error}")))?;
+    }
+    Ok(Some(count.to_string()))
+}
+
+/// `FlagStat.doWork`: thirteen counters and their percentages, over the same traversal.
+///
+/// The counters need the record's contig AND its mate's, because two of them ask whether the mate
+/// is on a different one, so the traversal carries the header's names rather than the indices.
+pub fn flag_stat(parser: &Parser) -> Outcome {
+    let ReadWalkerStart {
+        source,
+        header,
+        intervals,
+        filters,
+    } = read_walker_startup(parser, "FlagStat")?;
+
+    let filter = read_filter(parser, &filters, &header)?;
+    let records = gatk_tools::read_walker::traverse(&source, &intervals, &filter)
+        .map_err(|error| Thrown::user(format!("{error:?}")))?;
+    let mut status = gatk_tools::counting_walkers::FlagStatus::default();
+    for record in &records {
+        status.add(
+            record,
+            contig_name(&header, record.reference_index),
+            contig_name(&header, record.mate_reference_index),
+        );
+    }
+    let text = status.to_text();
+
+    if let Some(output) = argument(parser, "output") {
+        std::fs::write(&output, &text)
+            .map_err(|error| Thrown::non_user(PORT_FAILURE, format!("{output}: {error}")))?;
+    }
+    // `onTraversalSuccess` returns the report itself, which `handleResult` prints.
+    Ok(Some(text))
+}
+
+/// The contig a reference index names, or nothing where the index is `-1`.
+fn contig_name(header: &SamHeader, index: i32) -> Option<&str> {
+    usize::try_from(index)
+        .ok()
+        .and_then(|index| header.sequences.get(index))
+        .map(|sequence| sequence.name.as_str())
 }

--- a/tools/argument-conformance/ToolArgumentDeclarationDump.java
+++ b/tools/argument-conformance/ToolArgumentDeclarationDump.java
@@ -97,6 +97,14 @@ public class ToolArgumentDeclarationDump {
         // `CheckTerminatorBlock` and `BuildBamIndex` would have been two more and are not here:
         // they are PICARD's tools, which GATK dispatches to, so their declarations come from
         // Picard's own parser and belong in picard-rs's measurement rather than this one.
+        // The two read walkers that share `CountReads`' plumbing exactly: reads in, a number or a
+        // report out. They are here because an archetype is the unit of this milestone -- a tool
+        // of one archetype shares its argument shape AND its file plumbing with the others, so the
+        // second and third cost a fraction of the first.
+        declarations("CountBases",
+                new org.broadinstitute.hellbender.tools.CountBases());
+        declarations("FlagStat",
+                new org.broadinstitute.hellbender.tools.FlagStat());
         declarations("PrintBGZFBlockInformation",
                 new org.broadinstitute.hellbender.tools.PrintBGZFBlockInformation());
         declarations("CreateHadoopBamSplittingIndex",

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6600,7 +6600,7 @@
     },
     {
       "id": "tool-argument-declarations",
-      "status": "oracle-backed",
+      "status": "golden-pending",
       "title": "what one tool declares, and therefore which command lines it accepts",
       "harness": "tools/argument-conformance",
       "tools": [
@@ -6620,7 +6620,7 @@
         {
           "dump": "ToolArgumentDeclarationDump",
           "golden": "crates/gatk-tools/tests/data/tool_declarations.txt.gz",
-          "why": "Re-measured without the sort, in the pinned container on a real x86-64 runner, as the candidate artefact of run 33704325792; the mutex target list now carries the order it holds, which is the order the refusal joins it in (#1069). Seven tools' full declaration lists, and eighteen command lines over them: the empty one, the input alone under each spelling, the input twice, an unknown argument, one and two intervals, a variant argument given to a read walker and an input given to a variant walker, a print tool with and without its output and with its output twice, and a tool that is no walker at all."
+          "why": "Golden-pending: `CountBases` and `FlagStat` join the declared tools, so the golden is re-measured on a real x86-64 runner before it is frozen again. Re-measured without the sort, in the pinned container on a real x86-64 runner, as the candidate artefact of run 33704325792; the mutex target list now carries the order it holds, which is the order the refusal joins it in (#1069). Seven tools' full declaration lists, and eighteen command lines over them: the empty one, the input alone under each spelling, the input twice, an unknown argument, one and two intervals, a variant argument given to a read walker and an input given to a variant walker, a print tool with and without its output and with its output twice, and a tool that is no walker at all."
         }
       ]
     },


### PR DESCRIPTION
Milestone C's ordering is one tool end to end, then its array, then the rest by archetype. `CountReads` was the first read walker; these are the second and third, and they declare the same seventy arguments:

```
count  CountReads  instance=38 tool=70
count  CountBases  instance=38 tool=70
count  FlagStat    instance=38 tool=70
```

The logic is already oracle-backed in `counting_walkers`, so what they need is the declaration and the runner rather than a port. Golden-pending; the runners and their arrays follow the freeze.

Part of #819, #822.