### PR TITLE
Freeze the ten-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -156,7 +156,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `Concordance` | variant-walker | oracle-backed | concordance-annotated-vcfs, concordance-filter-analysis, concordance-summary | 3 | not measured |
 | `CondenseDepthEvidence` | unclassified | oracle-backed | condense-depth-evidence | 1 | not measured |
 | `ConvertHeaderlessHadoopBamShardToBam` | record-transform | oracle-backed | convert-headerless-shard | 1 | not measured |
-| `CountBases` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | not measured |
+| `CountBases` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | t=2, 21/21 rows (100%) |
 | `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
 | `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, filter-resolution, interval-arguments, read-walker-refusals, tool-argument-declarations, tool-argument-enums, usage-text | 9 | t=2, 21/21 rows (100%) |
@@ -179,7 +179,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `FilterMutectCalls` | variant-transform | oracle-backed | filter-mutect-calls | 1 | not measured |
 | `FilterVariantTranches` | variant-transform | oracle-backed | filter-variant-tranches | 1 | not measured |
 | `FixMisencodedBaseQualityReads` | record-transform | oracle-backed | fix-misencoded | 1 | not measured |
-| `FlagStat` | reporting-walker | oracle-backed | counting-walkers | 1 | not measured |
+| `FlagStat` | reporting-walker | oracle-backed | counting-walkers | 1 | t=2, 21/21 rows (100%) |
 | `FlowFeatureMapper` | flow-based | oracle-backed | flow-feature-mapper | 1 | not measured |
 | `FlowPairHMMAlignReadsToHaplotypes` | flow-based | oracle-backed | flow-pairhmm-align-reads-to-haplotypes | 1 | not measured |
 | `FuncotateSegments` | variant-walker | oracle-backed | funcotate-segments | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -86,6 +86,24 @@
       "matched": 21,
       "t": 2,
       "share": 1.0
+    },
+    "CountBases": {
+      "rows": 21,
+      "accepted": 9,
+      "rejected": 12,
+      "distinct_outputs": 3,
+      "matched": 21,
+      "t": 2,
+      "share": 1.0
+    },
+    "FlagStat": {
+      "rows": 21,
+      "accepted": 9,
+      "rejected": 12,
+      "distinct_outputs": 3,
+      "matched": 21,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
Run 33715715884 on `main`. Both new tools reproduced their whole array on the first run:

| tool | rows | accepted | distinct | share |
|---|---|---|---|---|
| IndexFeatureFile | 8 | 5 | 5 | 1.000 |
| PrintBGZFBlockInformation | 6 | 4 | 2 | 1.000 |
| CountReads | 21 | 9 | 3 | 1.000 |
| CountVariants | 23 | 13 | 4 | 1.000 |
| CreateHadoopBamSplittingIndex | 11 | 8 | 7 | 1.000 |
| PrintReads | 21 | 9 | 9 | 1.000 |
| GatherVcfsCloud | 11 | 5 | 2 | 1.000 |
| ApplyBQSR | 21 | 9 | 9 | 1.000 |
| CountBases | 21 | 9 | 3 | 1.000 |
| FlagStat | 21 | 9 | 3 | 1.000 |

That the second and third read walker matched with no correction is the archetype's claim in a number: the startup they share is the part that was measured, and what is theirs alone was already oracle-backed in `counting_walkers`.

Part of #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)