### PR TITLE
Declare a reference walker and an interval utility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,16 +418,20 @@ jobs:
             suites: "interval-arguments filter-resolution expanded-command-line main-non-user main-entry"
           - group: oracle-backed
             index: "58/60"
-            slug: "splitting-index-allele-frequency-qc-calculate-contamination-tool-argument-declarations-usage-text"
-            suites: "splitting-index allele-frequency-qc calculate-contamination tool-argument-declarations usage-text"
+            slug: "splitting-index-allele-frequency-qc-calculate-contamination-usage-text-bwa-index-image"
+            suites: "splitting-index allele-frequency-qc calculate-contamination usage-text bwa-index-image"
           - group: oracle-backed
             index: "59/60"
-            slug: "bwa-index-image-tool-argument-enums-tool-argument-value-classes-plugin-argument-ownership-read-filter-catalogue"
-            suites: "bwa-index-image tool-argument-enums tool-argument-value-classes plugin-argument-ownership read-filter-catalogue"
+            slug: "tool-argument-enums-tool-argument-value-classes-plugin-argument-ownership-read-filter-catalogue-mutex-target-names"
+            suites: "tool-argument-enums tool-argument-value-classes plugin-argument-ownership read-filter-catalogue mutex-target-names"
           - group: oracle-backed
             index: "60/60"
-            slug: "mutex-target-names-count-reads-plumbing-read-walker-refusals"
-            suites: "mutex-target-names count-reads-plumbing read-walker-refusals"
+            slug: "count-reads-plumbing-read-walker-refusals"
+            suites: "count-reads-plumbing read-walker-refusals"
+          - group: golden-pending
+            index: "1/1"
+            slug: "tool-argument-declarations"
+            suites: "tool-argument-declarations"
     steps:
       - uses: actions/checkout@v7
 

--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -1871,3 +1871,45 @@ fn contig_name(header: &SamHeader, index: i32) -> Option<&str> {
         .and_then(|index| header.sequences.get(index))
         .map(|sequence| sequence.name.as_str())
 }
+
+/// `CountBasesInReference.doWork`: every base of the traversal, counted by its byte.
+///
+/// A `ReferenceWalker` is the first archetype here whose traversal is the FASTA rather than a file
+/// of records, so almost none of the read walker's startup applies: there are no reads to open, no
+/// index to find and no dictionaries to compare. What is left is the reference itself and the
+/// intervals over it, and the intervals are the tool's own -- `reference_walker::traverse` resolves
+/// them against the FASTA's dictionary, which is the only dictionary a run of this tool has.
+pub fn count_bases_in_reference(parser: &Parser) -> Outcome {
+    let _ = resolve_read_filters(parser, "CountBasesInReference")?;
+    let reference = argument(parser, "reference").ok_or_else(|| {
+        Thrown::command_line("Argument reference was missing: Argument 'reference' is required")
+    })?;
+    let mut source =
+        gatk_engine::reference::ReferenceFileSource::open(std::path::Path::new(&reference))
+            .map_err(|error| Thrown::user(format!("{error:?}")))?;
+
+    let arguments = gatk_engine::interval_args::IntervalArguments {
+        include: arguments(parser, "intervals"),
+        exclude: arguments(parser, "exclude-intervals"),
+        padding: number(parser, "interval-padding"),
+        exclusion_padding: number(parser, "interval-exclusion-padding"),
+        set_rule: match scalar(parser, "interval-set-rule").as_deref() {
+            Some("INTERSECTION") => gatk_engine::interval_args::SetRule::Intersection,
+            _ => gatk_engine::interval_args::SetRule::Union,
+        },
+        merging_rule: match scalar(parser, "interval-merging-rule").as_deref() {
+            Some("OVERLAPPING_ONLY") => MergingRule::OverlappingOnly,
+            _ => MergingRule::All,
+        },
+    };
+    let counts = gatk_tools::count_bases_in_reference::run(&mut source, &arguments)
+        .map_err(|error| Thrown::user(format!("{error:?}")))?;
+    let report = counts.report();
+
+    if let Some(output) = argument(parser, "output") {
+        // `print`, not `println`: the rows already carry their own newlines.
+        std::fs::write(&output, &report)
+            .map_err(|error| Thrown::non_user(PORT_FAILURE, format!("{output}: {error}")))?;
+    }
+    Ok(Some(report))
+}

--- a/tools/argument-conformance/ToolArgumentDeclarationDump.java
+++ b/tools/argument-conformance/ToolArgumentDeclarationDump.java
@@ -105,6 +105,13 @@ public class ToolArgumentDeclarationDump {
                 new org.broadinstitute.hellbender.tools.CountBases());
         declarations("FlagStat",
                 new org.broadinstitute.hellbender.tools.FlagStat());
+        // Two archetypes neither the read walkers nor the variant walkers reach: a REFERENCE
+        // walker, whose traversal is the FASTA rather than a file of records, and an interval
+        // utility, which is a `GATKTool` with no traversal at all and writes a DIRECTORY of files.
+        declarations("CountBasesInReference",
+                new org.broadinstitute.hellbender.tools.walkers.fasta.CountBasesInReference());
+        declarations("SplitIntervals",
+                new org.broadinstitute.hellbender.tools.walkers.SplitIntervals());
         declarations("PrintBGZFBlockInformation",
                 new org.broadinstitute.hellbender.tools.PrintBGZFBlockInformation());
         declarations("CreateHadoopBamSplittingIndex",

--- a/tools/conformance/manifest.json
+++ b/tools/conformance/manifest.json
@@ -6600,7 +6600,7 @@
     },
     {
       "id": "tool-argument-declarations",
-      "status": "oracle-backed",
+      "status": "golden-pending",
       "title": "what one tool declares, and therefore which command lines it accepts",
       "harness": "tools/argument-conformance",
       "tools": [
@@ -6620,7 +6620,7 @@
         {
           "dump": "ToolArgumentDeclarationDump",
           "golden": "crates/gatk-tools/tests/data/tool_declarations.txt.gz",
-          "why": "Re-measured with `CountBases` and `FlagStat` among the declared tools, in the pinned container on a real x86-64 runner, as the candidate artefact of run 33713985893; identical to the local smoke run. Re-measured without the sort, in the pinned container on a real x86-64 runner, as the candidate artefact of run 33704325792; the mutex target list now carries the order it holds, which is the order the refusal joins it in (#1069). Seven tools' full declaration lists, and eighteen command lines over them: the empty one, the input alone under each spelling, the input twice, an unknown argument, one and two intervals, a variant argument given to a read walker and an input given to a variant walker, a print tool with and without its output and with its output twice, and a tool that is no walker at all."
+          "why": "Golden-pending: `CountBasesInReference` and `SplitIntervals` join the declared tools, so the golden is re-measured on a real x86-64 runner. Re-measured with `CountBases` and `FlagStat` among the declared tools, in the pinned container on a real x86-64 runner, as the candidate artefact of run 33713985893; identical to the local smoke run. Re-measured without the sort, in the pinned container on a real x86-64 runner, as the candidate artefact of run 33704325792; the mutex target list now carries the order it holds, which is the order the refusal joins it in (#1069). Seven tools' full declaration lists, and eighteen command lines over them: the empty one, the input alone under each spelling, the input twice, an unknown argument, one and two intervals, a variant argument given to a read walker and an input given to a variant walker, a print tool with and without its output and with its output twice, and a tool that is no walker at all."
         }
       ]
     },


### PR DESCRIPTION
Two archetypes neither the read walkers nor the variant walkers reach:

```
count  CountBasesInReference  instance=38 tool=70
count  SplitIntervals         instance=45 tool=77
```

`CountBasesInReference` is a `ReferenceWalker` — its traversal is the FASTA rather than a file of records — and it inherits exactly the seventy arguments a read walker declares, so the standard collections are the tool's inheritance and not its archetype's. `SplitIntervals` is a `GATKTool` with no traversal at all and seven arguments of its own, and it writes a directory of files rather than one.

Both have oracle-backed logic already, so what these declarations unlock is the runner.

Golden-pending; the smoke run in the pinned container produced both tools' rows and left every existing one unchanged.

Part of #819, #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)