### PR TITLE
Freeze the eleven-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -157,7 +157,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CondenseDepthEvidence` | unclassified | oracle-backed | condense-depth-evidence | 1 | not measured |
 | `ConvertHeaderlessHadoopBamShardToBam` | record-transform | oracle-backed | convert-headerless-shard | 1 | not measured |
 | `CountBases` | locus-walker | oracle-backed | count-reads-and-bases, counting-walkers | 2 | t=2, 21/21 rows (100%) |
-| `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | not measured |
+| `CountBasesInReference` | reference-utility | oracle-backed | reference-walker | 1 | t=2, 19/19 rows (100%) |
 | `CountFalsePositives` | variant-walker | oracle-backed | count-false-positives | 1 | not measured |
 | `CountReads` | locus-walker | oracle-backed | count-reads-and-bases, count-reads-plumbing, counting-walkers, filter-resolution, interval-arguments, read-walker-refusals, tool-argument-declarations, tool-argument-enums, usage-text | 9 | t=2, 21/21 rows (100%) |
 | `CountVariants` | variant-walker | oracle-backed | count-variants, interval-arguments, sequence-dictionary-validation, tool-argument-declarations, tool-argument-enums | 5 | t=2, 23/23 rows (100%) |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -104,6 +104,15 @@
       "matched": 21,
       "t": 2,
       "share": 1.0
+    },
+    "CountBasesInReference": {
+      "rows": 19,
+      "accepted": 8,
+      "rejected": 11,
+      "distinct_outputs": 4,
+      "matched": 19,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
Run 33720672494 on `main`. `CountBasesInReference` reproduces all nineteen rows once the dictionary precedence is right.

| tool | rows | accepted | distinct | share |
|---|---|---|---|---|
| IndexFeatureFile | 8 | 5 | 5 | 1.000 |
| PrintBGZFBlockInformation | 6 | 4 | 2 | 1.000 |
| CountReads | 21 | 9 | 3 | 1.000 |
| CountVariants | 23 | 13 | 4 | 1.000 |
| CreateHadoopBamSplittingIndex | 11 | 8 | 7 | 1.000 |
| PrintReads | 21 | 9 | 9 | 1.000 |
| GatherVcfsCloud | 11 | 5 | 2 | 1.000 |
| ApplyBQSR | 21 | 9 | 9 | 1.000 |
| CountBases | 21 | 9 | 3 | 1.000 |
| FlagStat | 21 | 9 | 3 | 1.000 |
| CountBasesInReference | 19 | 8 | 4 | 1.000 |

Eleven tools, 193 rows, every one reproduced.

Part of #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)