### PR TITLE
Freeze the twelve-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -241,7 +241,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ShiftFasta` | reference-utility | oracle-backed | shift-fasta | 1 | not measured |
 | `SiteDepthtoBAF` | sv-caller | oracle-backed | site-depth-to-baf | 1 | not measured |
 | `SplitCRAM` | unclassified | oracle-backed | split-cram | 1 | not measured |
-| `SplitIntervals` | interval-utility | oracle-backed | split-intervals | 1 | not measured |
+| `SplitIntervals` | interval-utility | oracle-backed | split-intervals | 1 | t=2, 25/25 rows (100%) |
 | `SplitNCigarReads` | record-transform | oracle-backed | split-n-cigar-reads | 1 | not measured |
 | `SplitReads` | record-transform | oracle-backed | split-reads | 1 | not measured |
 | `StructuralVariantDiscoverer` | unclassified | oracle-backed | structural-variant-discoverer | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -113,6 +113,15 @@
       "matched": 19,
       "t": 2,
       "share": 1.0
+    },
+    "SplitIntervals": {
+      "rows": 25,
+      "accepted": 13,
+      "rejected": 12,
+      "distinct_outputs": 8,
+      "matched": 25,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
Run 33738227740 on `main`. `SplitIntervals` reproduces all twenty-five rows once the sort order follows both rules — the scatter mode stamps it, and `--dont-mix-contigs` takes it away.

| tool | rows | accepted | distinct | share |
|---|---|---|---|---|
| IndexFeatureFile | 8 | 5 | 5 | 1.000 |
| PrintBGZFBlockInformation | 6 | 4 | 2 | 1.000 |
| CountReads | 21 | 9 | 3 | 1.000 |
| CountVariants | 23 | 13 | 4 | 1.000 |
| CreateHadoopBamSplittingIndex | 11 | 8 | 7 | 1.000 |
| PrintReads | 21 | 9 | 9 | 1.000 |
| GatherVcfsCloud | 11 | 5 | 2 | 1.000 |
| ApplyBQSR | 21 | 9 | 9 | 1.000 |
| CountBases | 21 | 9 | 3 | 1.000 |
| FlagStat | 21 | 9 | 3 | 1.000 |
| CountBasesInReference | 19 | 8 | 4 | 1.000 |
| SplitIntervals | 25 | 13 | 8 | 1.000 |

Twelve tools, 208 rows, every one reproduced.

Part of #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)