### PR TITLE
Freeze the fourteen-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -217,9 +217,9 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `NuMTFilterTool` | unclassified | oracle-backed | numt-filter | 1 | not measured |
 | `PathSeqBuildKmers` | metagenomics | oracle-backed | pathseq-build-kmers | 1 | not measured |
 | `PathSeqBuildReferenceTaxonomy` | metagenomics | oracle-backed | pathseq-build-reference-taxonomy | 1 | not measured |
-| `Pileup` | locus-walker | oracle-backed | pileup-tool | 1 | not measured |
+| `Pileup` | locus-walker | oracle-backed | pileup-tool | 1 | t=2, 21/21 rows (100%) |
 | `PostProcessReadsForRSEM` | record-transform | oracle-backed | post-process-reads-for-rsem | 1 | not measured |
-| `PreprocessIntervals` | interval-utility | oracle-backed | preprocess-intervals | 1 | not measured |
+| `PreprocessIntervals` | interval-utility | oracle-backed | preprocess-intervals | 1 | t=2, 20/20 rows (100%) |
 | `PrintBGZFBlockInformation` | unclassified | oracle-backed | print-bgzf-block-information | 1 | t=2, 6/6 rows (100%) |
 | `PrintDistantMates` | record-transform | oracle-backed | print-distant-mates | 1 | not measured |
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -122,6 +122,24 @@
       "matched": 25,
       "t": 2,
       "share": 1.0
+    },
+    "Pileup": {
+      "rows": 21,
+      "accepted": 10,
+      "rejected": 11,
+      "distinct_outputs": 3,
+      "matched": 21,
+      "t": 2,
+      "share": 1.0
+    },
+    "PreprocessIntervals": {
+      "rows": 20,
+      "accepted": 10,
+      "rejected": 10,
+      "distinct_outputs": 4,
+      "matched": 20,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
Run 33749995442 on `main`. Both new tools reproduce their whole array once the three defects CI found are fixed.

| tool | rows | accepted | distinct | share |
|---|---|---|---|---|
| IndexFeatureFile | 8 | 5 | 5 | 1.000 |
| PrintBGZFBlockInformation | 6 | 4 | 2 | 1.000 |
| CountReads | 21 | 9 | 3 | 1.000 |
| CountVariants | 23 | 13 | 4 | 1.000 |
| CreateHadoopBamSplittingIndex | 11 | 8 | 7 | 1.000 |
| PrintReads | 21 | 9 | 9 | 1.000 |
| GatherVcfsCloud | 11 | 5 | 2 | 1.000 |
| ApplyBQSR | 21 | 9 | 9 | 1.000 |
| CountBases | 21 | 9 | 3 | 1.000 |
| FlagStat | 21 | 9 | 3 | 1.000 |
| CountBasesInReference | 19 | 8 | 4 | 1.000 |
| SplitIntervals | 25 | 13 | 8 | 1.000 |
| Pileup | 21 | 10 | 3 | 1.000 |
| PreprocessIntervals | 20 | 10 | 4 | 1.000 |

**Fourteen tools, 249 rows, every one reproduced.** Five archetypes have a runner and a measured array: read walker, variant walker, reference walker, locus walker and interval utility.

Part of #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)