### PR TITLE
Freeze the sixteen-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -194,7 +194,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GenotypeGVCFs` | assembly-caller | oracle-backed | genotype-gvcfs | 1 | not measured |
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |
 | `GetPileupSummaries` | locus-walker | oracle-backed | get-pileup-summaries | 1 | not measured |
-| `GetSampleName` | reporting-walker | oracle-backed | get-sample-name | 1 | not measured |
+| `GetSampleName` | reporting-walker | oracle-backed | get-sample-name | 1 | t=2, 21/21 rows (100%) |
 | `GnarlyGenotyper` | assembly-caller | oracle-backed | gnarly-genotyper | 1 | not measured |
 | `GroundTruthReadsBuilder` | flow-based | oracle-backed | ground-truth-reads-builder | 1 | not measured |
 | `GroundTruthScorer` | flow-based | oracle-backed | ground-truth-scorer, series-stats | 2 | not measured |
@@ -221,7 +221,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `PostProcessReadsForRSEM` | record-transform | oracle-backed | post-process-reads-for-rsem | 1 | not measured |
 | `PreprocessIntervals` | interval-utility | oracle-backed | preprocess-intervals | 1 | t=2, 20/20 rows (100%) |
 | `PrintBGZFBlockInformation` | unclassified | oracle-backed | print-bgzf-block-information | 1 | t=2, 6/6 rows (100%) |
-| `PrintDistantMates` | record-transform | oracle-backed | print-distant-mates | 1 | not measured |
+| `PrintDistantMates` | record-transform | oracle-backed | print-distant-mates | 1 | t=2, 19/19 rows (100%) |
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |
 | `PrintReadCounts` | sv-caller | oracle-backed | print-read-counts | 1 | not measured |
 | `PrintReads` | record-transform | oracle-backed | expanded-command-line, printreads, tool-argument-declarations, tool-argument-enums | 4 | t=2, 21/21 rows (100%) |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -140,6 +140,24 @@
       "matched": 20,
       "t": 2,
       "share": 1.0
+    },
+    "GetSampleName": {
+      "rows": 21,
+      "accepted": 9,
+      "rejected": 12,
+      "distinct_outputs": 2,
+      "matched": 21,
+      "t": 2,
+      "share": 1.0
+    },
+    "PrintDistantMates": {
+      "rows": 19,
+      "accepted": 10,
+      "rejected": 9,
+      "distinct_outputs": 10,
+      "matched": 19,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
Run 33839337290 on `main`. **Sixteen tools, 289 rows, every one reproduced.**

| tool | rows | accepted | distinct | share |
|---|---|---|---|---|
| IndexFeatureFile | 8 | 5 | 5 | 1.000 |
| PrintBGZFBlockInformation | 6 | 4 | 2 | 1.000 |
| CountReads | 21 | 9 | 3 | 1.000 |
| CountVariants | 23 | 13 | 4 | 1.000 |
| CreateHadoopBamSplittingIndex | 11 | 8 | 7 | 1.000 |
| PrintReads | 21 | 9 | 9 | 1.000 |
| GatherVcfsCloud | 11 | 5 | 2 | 1.000 |
| ApplyBQSR | 21 | 9 | 9 | 1.000 |
| CountBases | 21 | 9 | 3 | 1.000 |
| FlagStat | 21 | 9 | 3 | 1.000 |
| CountBasesInReference | 19 | 8 | 4 | 1.000 |
| SplitIntervals | 25 | 13 | 8 | 1.000 |
| Pileup | 21 | 10 | 3 | 1.000 |
| PreprocessIntervals | 20 | 10 | 4 | 1.000 |
| GetSampleName | 21 | 9 | 2 | 1.000 |
| PrintDistantMates | 19 | 10 | 10 | 1.000 |

`PrintDistantMates` observes ten distinct outputs over ten accepted rows — the widest here, and the reason it found five defects.

Part of #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)