### PR TITLE
Freeze the eighteen-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -150,7 +150,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CombineGVCFs` | assembly-caller | oracle-backed | combine-gvcfs | 1 | not measured |
 | `CombineSegmentBreakpoints` | unclassified | oracle-backed | combine-segment-breakpoints | 1 | not measured |
 | `CompareBaseQualities` | reporting-walker | oracle-backed | compare-base-qualities | 1 | not measured |
-| `CompareIntervalLists` | unclassified | oracle-backed | compare-interval-lists | 1 | not measured |
+| `CompareIntervalLists` | unclassified | oracle-backed | compare-interval-lists | 1 | t=2, 7/7 rows (100%), **1 distinct output** |
 | `CompareReferences` | reference-utility | oracle-backed | compare-references | 1 | not measured |
 | `ComposeSTRTableFile` | reference-utility | oracle-backed | compose-str-table-file | 1 | not measured |
 | `Concordance` | variant-walker | oracle-backed | concordance-annotated-vcfs, concordance-filter-analysis, concordance-summary | 3 | not measured |
@@ -178,7 +178,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `FilterIntervals` | cnv-segmentation | oracle-backed | filter-intervals | 1 | not measured |
 | `FilterMutectCalls` | variant-transform | oracle-backed | filter-mutect-calls | 1 | not measured |
 | `FilterVariantTranches` | variant-transform | oracle-backed | filter-variant-tranches | 1 | not measured |
-| `FixMisencodedBaseQualityReads` | record-transform | oracle-backed | fix-misencoded | 1 | not measured |
+| `FixMisencodedBaseQualityReads` | record-transform | oracle-backed | fix-misencoded | 1 | t=2, 21/21 rows (100%) |
 | `FlagStat` | reporting-walker | oracle-backed | counting-walkers | 1 | t=2, 21/21 rows (100%) |
 | `FlowFeatureMapper` | flow-based | oracle-backed | flow-feature-mapper | 1 | not measured |
 | `FlowPairHMMAlignReadsToHaplotypes` | flow-based | oracle-backed | flow-pairhmm-align-reads-to-haplotypes | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -158,6 +158,24 @@
       "matched": 19,
       "t": 2,
       "share": 1.0
+    },
+    "CompareIntervalLists": {
+      "rows": 7,
+      "accepted": 3,
+      "rejected": 4,
+      "distinct_outputs": 1,
+      "matched": 7,
+      "t": 2,
+      "share": 1.0
+    },
+    "FixMisencodedBaseQualityReads": {
+      "rows": 21,
+      "accepted": 9,
+      "rejected": 12,
+      "distinct_outputs": 9,
+      "matched": 21,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
Eighteen tools, **317 rows, 152 accepted, every one reproduced**. The two newest joined at 1.000 on their first measured run.

`CompareIntervalLists` reads one distinct output because it writes no file — its verdict is a line on standard output, and two of its three verdicts are exceptions the corpus does record.

Part of #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)