### PR TITLE
AnnotateIntervals writes the dictionary it resolved with

### DIFF
--- a/crates/gatk-cli/src/runners.rs
+++ b/crates/gatk-cli/src/runners.rs
@@ -2546,12 +2546,14 @@ pub fn annotate_intervals(parser: &Parser) -> Outcome {
         gatk_engine::reference::ReferenceFileSource::open(std::path::Path::new(&reference))
             .map_err(|error| Thrown::user(format!("{error:?}")))?;
 
-    // The same two dictionaries `PreprocessIntervals` uses: the master resolves the intervals and
-    // the reference's own `.dict` is written into the `@SQ` lines.
+    // ONE dictionary here, unlike `PreprocessIntervals`: `getBestAvailableSequenceDictionary`
+    // answers both questions, so a `--sequence-dictionary` resolves the intervals AND is written
+    // into the `@SQ` lines. Writing the reference's own put an `M5` in ten rows where the
+    // reference writes none, which is the master's dictionary showing through.
     let from_dict = reference_dictionary(parser)?;
     let own = gatk_tools::reference_walker::dictionary(&source);
-    let written = from_dict.clone().unwrap_or(own.clone());
     let best = master_dictionary(parser)?.or(from_dict).unwrap_or(own);
+    let written = best.clone();
     let intervals = match interval_arguments(parser, &best)? {
         Some(parameters) => parameters.intervals,
         None => best


### PR DESCRIPTION
CI measured 9 of 19, and all ten rows that differed carry a `--sequence-dictionary`:

```
reference  @SQ  SN:chr1  LN:100000
port       @SQ  SN:chr1  LN:100000  M5:2e46001c07f539e7af723bd52446f3f7
```

`getBestAvailableSequenceDictionary` answers **both** of this tool's questions — the intervals resolve against it and `SimpleLocatableMetadata` is built from it — so a master `--sequence-dictionary` is what the `@SQ` lines carry. That is one dictionary where `PreprocessIntervals` uses two, and the previous commit copied that tool's pair without checking this one asks the same question twice.

Without a master the output is unchanged and still byte-identical.

Part of #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)