### PR TITLE
Freeze the nineteen-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -125,7 +125,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `AlleleFrequencyQC` | unclassified | oracle-backed | allele-frequency-qc | 1 | not measured |
 | `AnalyzeCovariates` | reporting-walker | oracle-backed | analyze-covariates | 1 | not measured |
 | `AnalyzeSaturationMutagenesis` | locus-walker | oracle-backed | analyze-saturation-mutagenesis | 1 | not measured |
-| `AnnotateIntervals` | cnv-segmentation | oracle-backed | annotate-intervals | 1 | not measured |
+| `AnnotateIntervals` | cnv-segmentation | oracle-backed | annotate-intervals | 1 | t=2, 19/19 rows (100%) |
 | `AnnotateVcfWithBamDepth` | variant-walker | oracle-backed | annotate-vcf-with-bam-depth | 1 | not measured |
 | `AnnotateVcfWithExpectedAlleleFraction` | variant-walker | oracle-backed | annotate-vcf-with-expected-allele-fraction | 1 | not measured |
 | `ApplyBQSR` | record-transform | oracle-backed | apply-bqsr, tool-argument-declarations, tool-argument-enums | 3 | t=2, 21/21 rows (100%) |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -176,6 +176,15 @@
       "matched": 21,
       "t": 2,
       "share": 1.0
+    },
+    "AnnotateIntervals": {
+      "rows": 19,
+      "accepted": 10,
+      "rejected": 9,
+      "distinct_outputs": 4,
+      "matched": 19,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
`AnnotateIntervals` joins the frozen set, measured on a real x86-64 runner in the pinned container from main's run for #1100.

```
tool=PreprocessIntervals t=2 rows=20 rejected=10 distinct_outputs=4 matched=20 share=1.000
tool=AnnotateIntervals   t=2 rows=19 rejected=9  distinct_outputs=4 matched=19 share=1.000
```

Nineteen tools, 336 rows, 162 of them accepted, every one reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)