### PR TITLE
Freeze the twenty-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -140,7 +140,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `CalibrateDragstrModel` | assembly-caller | oracle-backed | calibrate-dragstr-model | 1 | not measured |
 | `CallCopyRatioSegments` | cnv-segmentation | oracle-backed | call-copy-ratio-segments | 1 | not measured |
 | `CallableLoci` | locus-walker | oracle-backed | callable-loci | 1 | not measured |
-| `CheckPileup` | reporting-walker | oracle-backed | check-pileup | 1 | not measured |
+| `CheckPileup` | reporting-walker | oracle-backed | check-pileup | 1 | t=2, 20/20 rows (100%) |
 | `CheckReferenceCompatibility` | reference-utility | oracle-backed | check-reference-compatibility | 1 | not measured |
 | `ClipReads` | record-transform | oracle-backed | clip-reads | 1 | not measured |
 | `CollectAllelicCounts` | locus-walker | oracle-backed | collect-allelic-counts | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -185,6 +185,15 @@
       "matched": 19,
       "t": 2,
       "share": 1.0
+    },
+    "CheckPileup": {
+      "rows": 20,
+      "accepted": 10,
+      "rejected": 10,
+      "distinct_outputs": 5,
+      "matched": 20,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
`CheckPileup` joins the frozen set, measured on a real x86-64 runner in the pinned container from main's run for #1103.

```
tool=Pileup      t=2 rows=21 rejected=11 distinct_outputs=3 matched=21 share=1.000
tool=CheckPileup t=2 rows=20 rejected=10 distinct_outputs=5 matched=20 share=1.000
```

Five distinct outputs is the most of any tool in the set: a run that validates, a run whose report names the loci the truth file does not cover, and a run refused for a base that disagrees are three different answers rather than three spellings of one.

Twenty tools, 356 rows, 172 of them accepted, every one reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)