### PR TITLE
Freeze the twenty-two-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -145,7 +145,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ClipReads` | record-transform | oracle-backed | clip-reads | 1 | not measured |
 | `CollectAllelicCounts` | locus-walker | oracle-backed | collect-allelic-counts | 1 | not measured |
 | `CollectF1R2Counts` | unclassified | oracle-backed | collect-f1r2-counts | 1 | not measured |
-| `CollectReadCounts` | locus-walker | oracle-backed | collect-read-counts | 1 | not measured |
+| `CollectReadCounts` | locus-walker | oracle-backed | collect-read-counts | 1 | t=2, 17/17 rows (100%) |
 | `CollectSVEvidence` | sv-caller | oracle-backed | collect-sv-evidence | 1 | not measured |
 | `CombineGVCFs` | assembly-caller | oracle-backed | combine-gvcfs | 1 | not measured |
 | `CombineSegmentBreakpoints` | unclassified | oracle-backed | combine-segment-breakpoints | 1 | not measured |
@@ -172,7 +172,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `ExampleMultiFeatureWalker` | unclassified | oracle-backed | multi-feature-walker | 1 | not measured |
 | `ExtractVariantAnnotations` | variant-transform | oracle-backed | extract-variant-annotations | 1 | not measured |
 | `FastaAlternateReferenceMaker` | reference-utility | oracle-backed | fasta-alternate-reference-maker | 1 | not measured |
-| `FastaReferenceMaker` | reference-utility | oracle-backed | fasta-reference-maker | 1 | not measured |
+| `FastaReferenceMaker` | reference-utility | oracle-backed | fasta-reference-maker | 1 | t=2, 21/21 rows (100%) |
 | `FilterAlignmentArtifacts` | variant-transform | oracle-backed | filter-alignment-artifacts | 1 | not measured |
 | `FilterFuncotations` | variant-walker | oracle-backed | filter-funcotations | 1 | not measured |
 | `FilterIntervals` | cnv-segmentation | oracle-backed | filter-intervals | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -194,6 +194,24 @@
       "matched": 20,
       "t": 2,
       "share": 1.0
+    },
+    "FastaReferenceMaker": {
+      "rows": 21,
+      "accepted": 9,
+      "rejected": 12,
+      "distinct_outputs": 6,
+      "matched": 21,
+      "t": 2,
+      "share": 1.0
+    },
+    "CollectReadCounts": {
+      "rows": 17,
+      "accepted": 9,
+      "rejected": 8,
+      "distinct_outputs": 4,
+      "matched": 17,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
Both new tools measured on a real x86-64 runner in the pinned container from main's run for #1108.

```
tool=FastaReferenceMaker t=2 rows=21 rejected=12 distinct_outputs=6 matched=21 share=1.000
tool=CollectReadCounts   t=2 rows=17 rejected=8  distinct_outputs=4 matched=17 share=1.000
```

Six distinct outputs is the most of any tool measured so far: `FastaReferenceMaker`'s rows differ in which intervals are asked for, how wide the lines are wrapped, and whether the run is refused with the writer's three files already open.

Twenty-two tools, 394 rows, 190 of them accepted, every one reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)