### PR TITLE
Freeze the twenty-four-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -193,7 +193,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `GeneExpressionEvaluation` | locus-walker | oracle-backed | gene-expression-evaluation | 1 | not measured |
 | `GenotypeGVCFs` | assembly-caller | oracle-backed | genotype-gvcfs | 1 | not measured |
 | `GetNormalArtifactData` | locus-walker | oracle-backed | normal-artifact-data | 1 | not measured |
-| `GetPileupSummaries` | locus-walker | oracle-backed | get-pileup-summaries | 1 | not measured |
+| `GetPileupSummaries` | locus-walker | oracle-backed | get-pileup-summaries | 1 | t=2, 19/19 rows (100%) |
 | `GetSampleName` | reporting-walker | oracle-backed | get-sample-name | 1 | t=2, 21/21 rows (100%) |
 | `GnarlyGenotyper` | assembly-caller | oracle-backed | gnarly-genotyper | 1 | not measured |
 | `GroundTruthReadsBuilder` | flow-based | oracle-backed | ground-truth-reads-builder | 1 | not measured |
@@ -247,7 +247,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `StructuralVariantDiscoverer` | unclassified | oracle-backed | structural-variant-discoverer | 1 | not measured |
 | `TagGermlineEvents` | unclassified | oracle-backed | tag-germline-events | 1 | not measured |
 | `TransferReadTags` | record-transform | oracle-backed | transfer-read-tags | 1 | not measured |
-| `UnmarkDuplicates` | record-transform | oracle-backed | record-transform | 1 | not measured |
+| `UnmarkDuplicates` | record-transform | oracle-backed | record-transform | 1 | t=2, 19/19 rows (100%) |
 | `UpdateVCFSequenceDictionary` | variant-transform | oracle-backed | update-vcf-sequence-dictionary | 1 | not measured |
 | `VCFComparator` | unclassified | oracle-backed | vcf-comparator | 1 | not measured |
 | `ValidateBasicSomaticShortMutations` | variant-walker | oracle-backed | validate-basic-somatic-short-mutations | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -212,6 +212,24 @@
       "matched": 17,
       "t": 2,
       "share": 1.0
+    },
+    "GetPileupSummaries": {
+      "rows": 19,
+      "accepted": 7,
+      "rejected": 12,
+      "distinct_outputs": 3,
+      "matched": 19,
+      "t": 2,
+      "share": 1.0
+    },
+    "UnmarkDuplicates": {
+      "rows": 19,
+      "accepted": 10,
+      "rejected": 9,
+      "distinct_outputs": 10,
+      "matched": 19,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
Both new tools measured on a real x86-64 runner in the pinned container from main's run for #1112.

```
tool=GetPileupSummaries t=2 rows=19 rejected=12 distinct_outputs=3  matched=19 share=1.000
tool=UnmarkDuplicates   t=2 rows=19 rejected=9  distinct_outputs=10 matched=19 share=1.000
```

They took three CI rounds rather than one, and each round found a real defect: a path handed to a reader that takes text, a `SAMFormatException` answered as a user error, and a `Bad input: ` prefix printed twice. None was visible locally, because the sweep had been run against a deleted corpus — nineteen mutual refusals read as nineteen agreements. That hole is closed.

Twenty-four tools, 432 rows, 207 of them accepted, every one reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)