### PR TITLE
Freeze the twenty-six-tool measurement

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -134,7 +134,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `BwaMemIndexImageCreator` | reference-utility | oracle-backed | bwa-index-image | 1 | not measured |
 | `CRAMIssue8768Detector` | unclassified | oracle-backed | cram-issue-8768-detector | 1 | not measured |
 | `CalculateAverageCombinedAnnotations` | unclassified | oracle-backed | calculate-average-combined-annotations | 1 | not measured |
-| `CalculateContamination` | reporting-walker | oracle-backed | calculate-contamination | 1 | not measured |
+| `CalculateContamination` | reporting-walker | oracle-backed | calculate-contamination | 1 | t=2, 8/8 rows (100%) |
 | `CalculateGenotypePosteriors` | variant-walker | oracle-backed | calculate-genotype-posteriors, family-priors | 2 | not measured |
 | `CalculateMixingFractions` | variant-walker | oracle-backed | calculate-mixing-fractions | 1 | not measured |
 | `CalibrateDragstrModel` | assembly-caller | oracle-backed | calibrate-dragstr-model | 1 | not measured |
@@ -225,7 +225,7 @@ Reference: gatk 4.6.2.0 (`76edc75c2650`), picard 3.4.0 (`6c3f23bc2e0d`), htsjdk 
 | `PrintFileDiagnostics` | unclassified | oracle-backed | print-file-diagnostics | 1 | not measured |
 | `PrintReadCounts` | sv-caller | oracle-backed | print-read-counts | 1 | not measured |
 | `PrintReads` | record-transform | oracle-backed | expanded-command-line, printreads, tool-argument-declarations, tool-argument-enums | 4 | t=2, 21/21 rows (100%) |
-| `PrintReadsHeader` | record-transform | oracle-backed | print-reads-header | 1 | not measured |
+| `PrintReadsHeader` | record-transform | oracle-backed | print-reads-header | 1 | t=2, 19/19 rows (100%) |
 | `PrintSVEvidence` | unclassified | oracle-backed | print-sv-evidence | 1 | not measured |
 | `RampedHaplotypeCaller` | assembly-caller | oracle-backed | ramped-haplotype-caller | 1 | not measured |
 | `ReadAnonymizer` | unclassified | oracle-backed | read-anonymizer | 1 | not measured |

--- a/tools/coverage/measured.json
+++ b/tools/coverage/measured.json
@@ -230,6 +230,24 @@
       "matched": 19,
       "t": 2,
       "share": 1.0
+    },
+    "CalculateContamination": {
+      "rows": 8,
+      "accepted": 8,
+      "rejected": 0,
+      "distinct_outputs": 6,
+      "matched": 8,
+      "t": 2,
+      "share": 1.0
+    },
+    "PrintReadsHeader": {
+      "rows": 19,
+      "accepted": 11,
+      "rejected": 8,
+      "distinct_outputs": 3,
+      "matched": 19,
+      "t": 2,
+      "share": 1.0
     }
   }
 }


### PR DESCRIPTION
Both tools measured on a real x86-64 runner in the pinned container from main's run for #1116.

```
tool=CalculateContamination t=2 rows=8  rejected=0 distinct_outputs=6 matched=8  share=1.000
tool=PrintReadsHeader       t=2 rows=19 rejected=8 distinct_outputs=3 matched=19 share=1.000
```

`CalculateContamination` is the first tool here whose array carries no refusal at all: a tool that declares no reads, no reference and no intervals has nothing to refuse a row for, so all eight rows reach the model and produce six distinct outputs. That is the argument for measuring the small tools too, not only the walkers.

Twenty-six tools, 459 rows, 226 of them accepted, every one reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)