### PR TITLE
An empty fixture list says a tool must not be given an argument

### DIFF
--- a/tools/coverage/README.md
+++ b/tools/coverage/README.md
@@ -58,6 +58,26 @@ taking a `File` can want a BED and an interval list. It replaces the list rather
 because the reason to declare one is that the shared value is wrong here, not that it is
 incomplete.
 
+An **empty** list in `per_tool` says something stronger: this tool must not be given this argument
+at all.
+
+```json
+{
+  "per_tool": {
+    "MarkDuplicatesWithMateCigar": { "--ASSUME_SORTED": [] }
+  }
+}
+```
+
+It exists because a row carries every argument the domain holds, and some tools refuse an argument
+because of what another argument says. `MarkDuplicatesWithMateCigar` refuses `ASSUME_SORTED`
+whenever `ASSUME_SORT_ORDER` is given, and Barclay refuses both together before the tool runs, so
+an array holding the pair has every one of its rows rejected for the same reason -- nineteen rows
+measuring the argument parser. `FilterSamReads` is the same shape with eight filters and eight
+mutually exclusive arguments. The empty list drops the argument from the rows and records why in
+the exclusion list, which is the same bargain `exclude` makes for `--help` and `--version`: a
+narrower claim, stated rather than implied.
+
 ## One value is not a domain
 
 An argument with a single fixture value is *held* at it: every row carries it, no row varies it,

--- a/tools/coverage/domains.py
+++ b/tools/coverage/domains.py
@@ -113,6 +113,15 @@ def domain_of(arg, fixtures, numeric_policy="strict", excluded_by_hand=None):
     if excluded_by_hand and name in excluded_by_hand:
         return [], f"excluded by the repository: {excluded_by_hand[name]}"
     if name in fixtures:
+        # An EMPTY list is a declaration, not an oversight: it says this repository must not give
+        # this tool this argument at all. Picard has tools whose arguments are mutually exclusive
+        # by another argument's value -- `FilterSamReads` refuses a `READ_LIST_FILE` unless
+        # `FILTER` names a read-list filter, `MarkDuplicatesWithMateCigar` refuses `ASSUME_SORTED`
+        # beside `ASSUME_SORT_ORDER` -- and a row carries every argument the domain holds, so one
+        # such argument refuses every row of the array. Declaring the empty list drops it from the
+        # rows and records why, which is the same bargain the exclusions below make.
+        if not fixtures[name]:
+            return [], "excluded by the repository: no value is declared for this tool"
         return [(f"fixture[{i}]", v) for i, v in enumerate(fixtures[name])], None
 
     if arg.get("deprecated"):


### PR DESCRIPTION
A covering-array row carries every argument the domain holds, and some tools refuse an argument because of what **another** argument says.

`MarkDuplicatesWithMateCigar` refuses `ASSUME_SORTED` whenever `ASSUME_SORT_ORDER` is given, and Barclay refuses the pair before the tool runs:

```text
MarkDuplicatesWithMateCigar: rows=19 accepted by the reference=0 rejected=19 distinct rejections=1
  rejection: EXIT=1 Argument 'ASSUME_SORTED' cannot be used in conjunction with argument(s) ASSUME_SORT_ORDER
```

Nineteen rows measuring the argument parser. `FilterSamReads` is the same shape and worse -- eight filters with eight mutually exclusive arguments -- so declaring two of them refuses all twenty-five rows in thirteen different ways, and declaring neither refuses the six filters that need one.

An **empty** list in `per_tool` now says "no value is declared for this tool": the argument is dropped from every row and the reason is recorded in the exclusion list, exactly as `exclude` does for `--help` and `--version`. It was previously an `IndexError` in `build`.

```json
{
  "per_tool": {
    "MarkDuplicatesWithMateCigar": { "--ASSUME_SORTED": [] }
  }
}
```

The change is inert for every array that declares no empty list: regenerating one with and without the patch produces the same bytes, and `HaplotypeCaller` still verifies at t=2 (22,821 tuples, none missing).

This is harness plumbing for picard-rs, which is where both blocked tools live (IPNP-BIPN/picard-rs#113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)