### PR TITLE
Read a documented enum's members from the usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,7 +678,7 @@ jobs:
         # document is stale, and a stale number in a sizing document is how a plan drifts.
         run: |
           python3 tools/coverage/covering.py --all --t 2 | tee /tmp/all.txt
-          grep -q "oracle runs=19437" /tmp/all.txt || {
+          grep -q "oracle runs=19454" /tmp/all.txt || {
             echo "pairwise sizing changed; update docs/what-pairwise-coverage-costs.md"
             exit 1
           }

--- a/docs/what-pairwise-coverage-costs.md
+++ b/docs/what-pairwise-coverage-costs.md
@@ -12,8 +12,13 @@ Every tool in the inventory, t=2, arrays verified tuple by tuple:
 
 | value policy | oracle runs | arguments in the arrays | excluded |
 |---|---:|---:|---:|
-| `strict` | **19,437** | 6,312 of 13,130 (48%) | 6,818 |
-| `perturb` | **21,918** | 8,674 of 13,130 (66%) | 4,456 |
+| `strict` | **19,454** | 6,320 of 13,130 (48%) | 6,810 |
+| `perturb` | **21,923** | 8,682 of 13,130 (66%) | 4,448 |
+
+Both totals moved by a few rows when the inventory learned to read a documented enum's members
+(#1120): eight arguments that had no domain at all now have one, so eight arguments left the
+excluded column and the arrays that hold them grew. Nothing else about the sizing changed, and the
+median did not move.
 
 Median tool: **19 rows**. The distribution is very long-tailed: `VCFComparator` alone needs 3,102,
 because `--read-filter` has 56 members and `--annotation` has 55, and pairwise over two domains

--- a/tools/conformance/ci.template.yml
+++ b/tools/conformance/ci.template.yml
@@ -371,7 +371,7 @@ jobs:
         # document is stale, and a stale number in a sizing document is how a plan drifts.
         run: |
           python3 tools/coverage/covering.py --all --t 2 | tee /tmp/all.txt
-          grep -q "oracle runs=19437" /tmp/all.txt || {
+          grep -q "oracle runs=19454" /tmp/all.txt || {
             echo "pairwise sizing changed; update docs/what-pairwise-coverage-costs.md"
             exit 1
           }

--- a/tools/inventory/extract_undocumented.py
+++ b/tools/inventory/extract_undocumented.py
@@ -27,6 +27,23 @@ ANSI = re.compile(r"\x1b\[[0-9;]*m")
 ARG_LINE = re.compile(r"^--(?P<name>[A-Za-z0-9_.\-]+)(?:,(?P<short>-[A-Za-z0-9_\-]+))?\s+<(?P<type>[^>]+)>\s*(?P<rest>.*)$")
 DEFAULT_VALUE = re.compile(r"Default value:\s*(?P<v>.+?)\.(?:\s|$)")
 POSSIBLE_VALUES = re.compile(r"Possible values:\s*\{(?P<v>[^}]*)\}")
+# A `ClpEnum`'s members, which Barclay prints ONE PER LINE with their documentation instead of the
+# brace-delimited list a plain enum gets:
+#
+#     --MODE <Mode>   Which reads ... Default value: ALL. ALL (Check all reads.)
+#                     PRIMARY_ONLY (Check primary alignments.)
+#
+# Eight arguments are rendered this way and came back with no members at all, so the covering
+# arrays held them at their default and observed one code path (#1120). The name is upper case with
+# underscores, which is what tells a member from a word of the documentation it is followed by.
+DOCUMENTED_MEMBER = re.compile(r"(?<![A-Za-z0-9_])(?P<name>[A-Z][A-Z0-9_]*)\s+\(")
+# What follows the default and is NOT a member. The mutex sentence names its targets in the same
+# shape a documented member is printed in -- `SECOND_INPUT (SI)` -- and reading those as members put
+# `--MATRIX_OUTPUT: ["SECOND_INPUT"]` in the inventory, which is not an enum at all. The collection
+# sentence is here for the same reason: boilerplate after the default rather than a value.
+NOT_MEMBERS = re.compile(
+    r"Cannot be used in conjunction with|This argument may be specified|"
+    r"The --\S+ argument|Required\.")
 LIST_ENTRY = re.compile(r"^ {4}([A-Za-z][A-Za-z0-9]*)\s")
 
 
@@ -70,6 +87,20 @@ def parse_help(text):
         members = None
         if pv:
             members = [x.strip() for x in pv.group("v").split(",") if x.strip()]
+        elif dv is not None:
+            # A documented enum prints its members after the default rather than in a list. Only
+            # the text AFTER `Default value: X.` is read, and only up to the first boilerplate
+            # sentence, so neither an upper-case word of the description nor a mutex target can be
+            # mistaken for a member. A repeated name is kept once, in the rendering's order.
+            tail = blob[dv.end():]
+            boilerplate = NOT_MEMBERS.search(tail)
+            if boilerplate:
+                tail = tail[: boilerplate.start()]
+            found = []
+            for name in DOCUMENTED_MEMBER.findall(tail):
+                if name not in found:
+                    found.append(name)
+            members = found or None
         current["default"] = default
         current["enum_members"] = members
         args.append(current)
@@ -138,14 +169,69 @@ def resolve_class(by_simple_name, name):
     return package, fqn, ("picard" if fqn.startswith("picard.") else "gatk")
 
 
+def refresh_undocumented(a, inv):
+    """Re-read the usage of every tool the inventory already holds as undocumented.
+
+    The merge in [`main`] is a ONE-WAY step: it looks for tools the inventory is missing and marks
+    everything it was handed as documented, so running it twice recovers nothing and mislabels the
+    43 it recovered the first time. A fix to `parse_help` therefore had no way to reach the
+    inventory, which is how eight arguments kept `enum_members: null` long after the rendering they
+    are printed in was understood (#1120).
+
+    This is the other direction: the tools are the ones already recorded with `documented: false`,
+    their arguments are read again from the same `--help` the first pass read, and nothing else in
+    the file is touched. Idempotent by construction, so a run's diff is exactly what the parser has
+    learned since the last one.
+    """
+    undocumented = [t for t in inv["tools"] if not t.get("documented", True)]
+    print(f"refreshing {len(undocumented)} undocumented tools")
+    changed = 0
+    for index, tool in enumerate(undocumented, 1):
+        parsed = parse_help(run(a.jar, [], [tool["name"], "--help"]))
+        if not parsed:
+            print(f"  [{index}/{len(undocumented)}] {tool['name']}: NO ARGUMENTS PARSED, kept")
+            continue
+        if parsed != tool["arguments"]:
+            changed += 1
+            gained = sum(
+                1
+                for argument in parsed
+                if argument.get("enum_members")
+                and not next(
+                    (
+                        existing.get("enum_members")
+                        for existing in tool["arguments"]
+                        if existing["name"] == argument["name"]
+                    ),
+                    None,
+                )
+            )
+            print(f"  [{index}/{len(undocumented)}] {tool['name']}: changed, "
+                  f"{gained} argument(s) gained members")
+            tool["arguments"] = parsed
+    inv["counts"]["arguments"] = sum(len(t["arguments"]) for t in inv["tools"])
+    out = a.out or a.inventory
+    out.write_text(json.dumps(inv, indent=2))
+    print(f"refreshed: {changed} tool(s) changed, arguments={inv['counts']['arguments']} -> {out}")
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("jar", type=pathlib.Path)
     ap.add_argument("inventory", type=pathlib.Path)
     ap.add_argument("-o", "--out", type=pathlib.Path)
+    ap.add_argument(
+        "--refresh",
+        action="store_true",
+        help="re-read the usage of the tools already recorded as undocumented, and replace their "
+             "arguments, rather than looking for tools the inventory is missing",
+    )
     a = ap.parse_args()
 
     inv = json.loads(a.inventory.read_text())
+    if a.refresh:
+        refresh_undocumented(a, inv)
+        return
     documented = {t["name"]: t for t in inv["tools"]}
     cli = cli_tool_names(a.jar)
 

--- a/tools/inventory/generated/inventory.json
+++ b/tools/inventory/generated/inventory.json
@@ -145416,7 +145416,13 @@
           "max": null,
           "deprecated": false,
           "default": null,
-          "enum_members": null
+          "enum_members": [
+            "STARTS_IN",
+            "ENDS_IN",
+            "OVERLAPS",
+            "CONTAINED",
+            "ANYWHERE"
+          ]
         }
       ]
     },
@@ -146376,7 +146382,13 @@
           "max": null,
           "deprecated": false,
           "default": null,
-          "enum_members": null
+          "enum_members": [
+            "STARTS_IN",
+            "ENDS_IN",
+            "OVERLAPS",
+            "CONTAINED",
+            "ANYWHERE"
+          ]
         },
         {
           "name": "--ambig-filter-bases",
@@ -146849,7 +146861,12 @@
           "max": null,
           "deprecated": false,
           "default": "ALL",
-          "enum_members": null
+          "enum_members": [
+            "ALL",
+            "PRIMARY_ONLY",
+            "PRIMARY_MAPPED_ONLY",
+            "PRIMARY_PROPER_PAIR_ONLY"
+          ]
         },
         {
           "name": "--OUTPUT",
@@ -152806,7 +152823,10 @@
           "max": null,
           "deprecated": false,
           "default": "CHECK_SAME_SAMPLE",
-          "enum_members": null
+          "enum_members": [
+            "CHECK_SAME_SAMPLE",
+            "CHECK_ALL_OTHERS"
+          ]
         },
         {
           "name": "--CROSSCHECK_SAMPLES",
@@ -157669,7 +157689,13 @@
           "max": null,
           "deprecated": false,
           "default": null,
-          "enum_members": null
+          "enum_members": [
+            "STARTS_IN",
+            "ENDS_IN",
+            "OVERLAPS",
+            "CONTAINED",
+            "ANYWHERE"
+          ]
         },
         {
           "name": "--ambig-filter-bases",
@@ -162588,7 +162614,13 @@
           "max": null,
           "deprecated": false,
           "default": null,
-          "enum_members": null
+          "enum_members": [
+            "STARTS_IN",
+            "ENDS_IN",
+            "OVERLAPS",
+            "CONTAINED",
+            "ANYWHERE"
+          ]
         },
         {
           "name": "--ambig-filter-bases",
@@ -169991,7 +170023,13 @@
           "max": null,
           "deprecated": false,
           "default": null,
-          "enum_members": null
+          "enum_members": [
+            "STARTS_IN",
+            "ENDS_IN",
+            "OVERLAPS",
+            "CONTAINED",
+            "ANYWHERE"
+          ]
         },
         {
           "name": "--dirichlet-keep-prior-in-count",
@@ -171355,7 +171393,13 @@
           "max": null,
           "deprecated": false,
           "default": null,
-          "enum_members": null
+          "enum_members": [
+            "STARTS_IN",
+            "ENDS_IN",
+            "OVERLAPS",
+            "CONTAINED",
+            "ANYWHERE"
+          ]
         },
         {
           "name": "--dirichlet-keep-prior-in-count",


### PR DESCRIPTION
Closes #1120.

Seven arguments of two nested enums named `Mode` carried `enum_members: null`, so `domains.py` excluded them as an unmodelled type and every covering array held them at their default. The cause is the **rendering**, not the enum: a `ClpEnum`, whose members carry documentation, is not printed as a `Possible values: {...}` list at all.

```
--MODE <Mode>   Which reads ... Default value: ALL. ALL (Check all reads.)
                PRIMARY_ONLY (Check primary alignments.)
                PRIMARY_MAPPED_ONLY (Check mapped alignments.)
```

The members are now read from the text after the default when there is no list, up to the first boilerplate sentence. That cut matters: the mutex sentence names its targets in the same shape a documented member is printed in, and reading it as members put `--MATRIX_OUTPUT: ["SECOND_INPUT"]` in the inventory.

The fix also needed a way into the artefact. `extract_undocumented.py` only looked for tools the inventory was missing and marked everything it was handed as documented, so a parser fix could never reach the file. `--refresh` re-reads the usage of the tools already recorded as undocumented and replaces their arguments, touching nothing else; it is idempotent, so a run's diff is exactly what the parser has learned.

**The diff is exactly that.** Eight arguments gain members; every other field of every tool and argument is byte-identical, and the counts (311 tools, 13130 arguments, 43 undocumented) do not move. The eighth is `CrosscheckReadGroupFingerprints --CROSSCHECK_MODE`, a real `ClpEnum` the issue had not spotted. `CheckDuplicateMarking`'s array goes from ten modelled arguments to eleven, and `--MODE` is the one argument of that tool that decides anything — picard-rs can drop the `per_tool` workaround it carries for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)